### PR TITLE
PVR additions + bug fixes

### DIFF
--- a/16x9/DialogFullScreenInfo.xml
+++ b/16x9/DialogFullScreenInfo.xml
@@ -25,21 +25,34 @@
 				</control>
 
 				<!-- Title -->
-				<control type="label">
+				<control type="fadelabel">
 					<left>20</left>
 					<top>14</top>
-					<width>1280</width>
+					<width>1300</width>
 					<height>30</height>
 					<font>Font33</font>
 					<textcolor>$VAR[TextColor1]</textcolor>
 					<label>$VAR[VideoPlayerTitle]</label>
+					<visible>!VideoPlayer.Content(LiveTV)</visible>
+				</control>
+				
+				<!-- Live TV Title -->
+				<control type="fadelabel">
+					<left>20</left>
+					<top>14</top>
+					<width>1020</width>
+					<height>30</height>
+					<font>Font33</font>
+					<textcolor>$VAR[TextColor1]</textcolor>
+					<label>$VAR[VideoPlayerTitle]</label>
+					<visible>VideoPlayer.Content(LiveTV)</visible>
 				</control>
 
 				<!-- Live TV Start/End Time -->
-				<control type="label">
-					<left>20</left>
+				<control type="fadelabel">
+					<right>300</right>
 					<top>14</top>
-					<width>1280</width>
+					<width>280</width>
 					<height>30</height>
 					<font>Font33</font>
 					<align>right</align>
@@ -139,6 +152,38 @@
 
 			<control type="group">
 				<visible>!Window.IsActive(seekbar) + !Window.IsActive(videoosd)</visible>
+				<animation type="Visible">
+					<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+					<effect type="fade" start="0" end="100" time="200"/>
+				</animation>
+				
+				<!-- PVR channel number input -->
+				<control type="group">
+					<left>0</left>
+					<top>0</top>
+					<width>1920</width>
+					<height>1080</height>
+					<visible>!String.IsEmpty(PVR.ChannelNumberInput)</visible>
+					<control type="image">
+						<centerleft>50%</centerleft>
+						<centertop>50%</centertop>
+						<width>140</width>
+						<height>140</height>
+						<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+					</control>
+					<control type="label">
+						<label>$INFO[PVR.ChannelNumberInput]</label>
+						<centerleft>50%</centerleft>
+						<centertop>50%</centertop>
+						<align>center</align>
+						<font>Font72</font>
+						<width>140</width>
+						<height>140</height>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<aligny>center</aligny>
+					</control>
+				</control>
+				
 				<!-- Player forwarding/rewinding -->
 				<control type="group">
 					<left>150</left>
@@ -213,6 +258,35 @@
 					</control>
 
 				</control>
+				
+				<!-- Timeshift status -->
+				<control type="group">
+					<visible>Pvr.IsTimeShift</visible>
+					<left>430</left>
+					<top>870</top>
+					<width>920</width>
+					<height>60</height>
+					<animation type="Visible">
+						<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+						<effect type="fade" start="0" end="100" time="200"/>
+					</animation>
+					
+					<control type="image">
+						<width>920</width>
+						<height>60</height>
+						<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+					</control>
+					
+					<control type="label">
+						<left>20</left>
+						<width>880</width>
+						<height>60</height>
+						<font>Font27</font>
+						<align>center</align>
+						<textcolor>$VAR[TextColor2]</textcolor>
+						<label>$LOCALIZE[31112] $INFO[PVR.TimeshiftCur(hh:mm xx)] (-$INFO[PVR.TimeshiftOffset])</label>
+					</control>
+				</control>
 
 				<!-- Progress -->
 				<control type="group">
@@ -236,6 +310,18 @@
 						<font>Font27</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
 						<label>$INFO[Player.Time]$INFO[Player.Duration, / ,]</label>
+						<visible>!Pvr.IsPlayingTv</visible>
+					</control>
+					
+					<!--  PVR current position/Time remaining -->
+					<control type="label">
+						<left>20</left>
+						<width>260</width>
+						<height>60</height>
+						<font>Font27</font>
+						<textcolor>$VAR[TextColor2]</textcolor>
+						<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration, / ,]</label>
+						<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 					</control>
 
 					<!--  Progress bar -->
@@ -250,6 +336,22 @@
 						<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
 						<righttexture></righttexture>
 						<overlaytexture></overlaytexture>
+						<visible>!Pvr.IsPlayingTv</visible>
+					</control>
+					
+					<!--  PVR progress bar -->
+					<control type="progress">
+						<left>280</left>
+						<top>20</top>
+						<width>920</width>
+						<height>20</height>
+						<info>PVR.EpgEventProgress</info>
+						<texturebg border="2" colordiffuse="$VAR[DialogColor2]">osd/OSDProgressBack.png</texturebg>
+						<lefttexture></lefttexture>
+						<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
+						<righttexture></righttexture>
+						<overlaytexture></overlaytexture>
+						<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 					</control>
 
 					<!--  Cache bar -->
@@ -275,7 +377,19 @@
 						<font>Font27</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
 						<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
-						<visible>Integer.IsGreater(Player.Duration,0)</visible>
+						<visible>Integer.IsGreater(Player.Duration,0) + !Pvr.IsPlayingTv</visible>
+					</control>
+					
+					<!-- PVR current Time/End Time -->
+					<control type="label">
+						<left>1001</left>
+						<width>600</width>
+						<height>60</height>
+						<align>right</align>
+						<font>Font27</font>
+						<textcolor>$VAR[TextColor2]</textcolor>
+						<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081] ,]</label>
+						<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 					</control>
 
 				</control>

--- a/16x9/DialogSeekBar.xml
+++ b/16x9/DialogSeekBar.xml
@@ -2,168 +2,273 @@
 <window>
 	<!-- seekbar -->
 	<defaultcontrol always="true">901</defaultcontrol>
-	<visible>[VideoPlayer.IsFullscreen | Window.IsVisible(visualisation)] + [Player.Seeking | Player.DisplayAfterSeek + String.IsEqual(Skin.String(HideOSD),Always) | Player.Paused + String.IsEqual(Skin.String(HideOSD),Always) | Player.DisplayAfterSeek + !System.IdleTime(5) + String.IsEqual(Skin.String(HideOSD),5s) | Player.Paused + !System.IdleTime(5) + String.IsEqual(Skin.String(HideOSD),5s) | Player.DisplayAfterSeek + !System.IdleTime(10) + String.IsEqual(Skin.String(HideOSD),10s) | Player.Paused + !System.IdleTime(10) + String.IsEqual(Skin.String(HideOSD),10s)	| Player.DisplayAfterSeek + !System.IdleTime(20) + String.IsEqual(Skin.String(HideOSD),20s) | Player.Paused + !System.IdleTime(20) + String.IsEqual(Skin.String(HideOSD),20s) | Player.DisplayAfterSeek + !System.IdleTime(30) + String.IsEqual(Skin.String(HideOSD),30s) | Player.Paused + !System.IdleTime(30) + String.IsEqual(Skin.String(HideOSD),30s) | Player.DisplayAfterSeek + !System.IdleTime(60) + String.IsEqual(Skin.String(HideOSD),1 min) | Player.Paused + !System.IdleTime(60) + String.IsEqual(Skin.String(HideOSD),1 min) | Player.DisplayAfterSeek + !System.IdleTime(120) + String.IsEqual(Skin.String(HideOSD),2 min) | Player.Paused + !System.IdleTime(120) + String.IsEqual(Skin.String(HideOSD),2 min) | Player.DisplayAfterSeek + !System.IdleTime(180) + String.IsEqual(Skin.String(HideOSD),3 min) | Player.Paused + !System.IdleTime(180) + String.IsEqual(Skin.String(HideOSD),3 min) | Player.DisplayAfterSeek + !System.IdleTime(300) + String.IsEqual(Skin.String(HideOSD),5 min) | Player.Paused + !System.IdleTime(300) + String.IsEqual(Skin.String(HideOSD),5 min) | Player.Forwarding | Player.Rewinding | Player.IsTempo] + !Window.IsVisible(VideoOSD) + !Window.IsVisible(subtitlesearch) + !Window.IsVisible(MusicOSD) + ![Window.IsActive(gameviewmode) | Window.IsActive(gamevideofilter)]</visible>
-	<animation type="WindowOpen" condition="![Window.IsVisible(visualisation) + Player.ShowInfo]">
-		<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
-		<effect type="fade" start="0" end="100" time="200"/>
-	</animation>
+		<visible>[Player.Seeking | Player.DisplayAfterSeek + String.IsEqual(Skin.String(HideOSD),Always) | Player.Paused + String.IsEqual(Skin.String(HideOSD),Always) | Player.DisplayAfterSeek + !System.IdleTime(5) + String.IsEqual(Skin.String(HideOSD),5s) | Player.Paused + !System.IdleTime(5) + String.IsEqual(Skin.String(HideOSD),5s) | Player.DisplayAfterSeek + !System.IdleTime(10) + String.IsEqual(Skin.String(HideOSD),10s) | Player.Paused + !System.IdleTime(10) + String.IsEqual(Skin.String(HideOSD),10s)	| Player.DisplayAfterSeek + !System.IdleTime(20) + String.IsEqual(Skin.String(HideOSD),20s) | Player.Paused + !System.IdleTime(20) + String.IsEqual(Skin.String(HideOSD),20s) | Player.DisplayAfterSeek + !System.IdleTime(30) + String.IsEqual(Skin.String(HideOSD),30s) | Player.Paused + !System.IdleTime(30) + String.IsEqual(Skin.String(HideOSD),30s) | Player.DisplayAfterSeek + !System.IdleTime(60) + String.IsEqual(Skin.String(HideOSD),1 min) | Player.Paused + !System.IdleTime(60) + String.IsEqual(Skin.String(HideOSD),1 min) | Player.DisplayAfterSeek + !System.IdleTime(120) + String.IsEqual(Skin.String(HideOSD),2 min) | Player.Paused + !System.IdleTime(120) + String.IsEqual(Skin.String(HideOSD),2 min) | Player.DisplayAfterSeek + !System.IdleTime(180) + String.IsEqual(Skin.String(HideOSD),3 min) | Player.Paused + !System.IdleTime(180) + String.IsEqual(Skin.String(HideOSD),3 min) | Player.DisplayAfterSeek + !System.IdleTime(300) + String.IsEqual(Skin.String(HideOSD),5 min) | Player.Paused + !System.IdleTime(300) + String.IsEqual(Skin.String(HideOSD),5 min) | Player.Forwarding | Player.Rewinding | Player.IsTempo] + !Window.IsVisible(VideoOSD) + !Window.IsVisible(subtitlesearch) + !Window.IsVisible(MusicOSD) + ![Window.IsActive(gameviewmode) | Window.IsActive(gamevideofilter)] | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
+		<visible>VideoPlayer.IsFullscreen | Window.IsVisible(visualisation)</visible>
+		<zorder>0</zorder>
 
 	<controls>
 
-		<!-- Player forwarding/rewinding -->
+		<!-- PVR channel number input -->
 		<control type="group">
-			<left>150</left>
-			<top>870</top>
-			<width>140</width>
-			<height>60</height>
-			<visible>player.forwarding + !Player.HasGame | player.rewinding + !Player.HasGame | player.paused | player.istempo + !Player.HasGame</visible>
-
-			<animation effect="slide" end="0,75" time="0" condition="player.istempo">Conditional</animation>
-
-			<!-- Background -->
+			<left>0</left>
+			<top>0</top>
+			<width>1920</width>
+			<height>1080</height>
+			<visible>!String.IsEmpty(PVR.ChannelNumberInput)</visible>
 			<control type="image">
+				<centerleft>50%</centerleft>
+				<centertop>50%</centertop>
 				<width>140</width>
-				<height>60</height>
+				<height>140</height>
 				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
 			</control>
-
-			<!-- Status -->
 			<control type="label">
-				<width>140</width>
-				<height>60</height>
-				<font>Font36</font>
+				<label>$INFO[PVR.ChannelNumberInput]</label>
+				<centerleft>50%</centerleft>
+				<centertop>50%</centertop>
 				<align>center</align>
-				<label>$VAR[PlayerStatus]</label>
-				<textcolor>$VAR[TextColor2]</textcolor>
+				<font>Font72</font>
+				<width>140</width>
+				<height>140</height>
+				<textcolor>$VAR[TextColor1]</textcolor>
+				<aligny>center</aligny>
 			</control>
-
-			<!-- Pause -->
-			<control type="image">
-				<left>40</left>
-				<width>60</width>
-				<height>60</height>
-				<texture colordiffuse="$VAR[DialogColor1]">osd/OSDPauseNF.png</texture>
-				<visible>player.paused</visible>
-			</control>
-
 		</control>
-
-		<!-- Player skipping -->
+	
 		<control type="group">
-			<right>150</right>
-			<top>870</top>
-			<width>140</width>
-			<height>60</height>
-			<visible>[[Player.DisplayAfterSeek + Integer.IsGreater(Player.ChapterCount,0)] | Integer.IsGreater(MusicPlayer.PlaylistLength,0) | !String.IsEmpty(Player.SeekStepSize)] + !Player.HasGame</visible>
-			<visible>String.IsEmpty(Player.SeekNumeric)</visible>
-
-			<!-- Background -->
-			<control type="image">
+			<animation type="WindowOpen">
+				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+				<effect type="fade" start="0" end="100" time="200"/>
+			</animation>
+			<!-- Player forwarding/rewinding -->
+			<control type="group">
+				<left>150</left>
+				<top>870</top>
 				<width>140</width>
 				<height>60</height>
-				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				<visible>player.forwarding + !Player.HasGame | player.rewinding + !Player.HasGame | player.paused | player.istempo + !Player.HasGame</visible>
+				<animation type="Visible">
+					<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+					<effect type="fade" start="0" end="100" time="200"/>
+				</animation>
+
+				<!-- Background -->
+				<control type="image">
+					<width>140</width>
+					<height>60</height>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				</control>
+
+				<!-- Status -->
+				<control type="label">
+					<width>140</width>
+					<height>60</height>
+					<font>Font36</font>
+					<align>center</align>
+					<label>$VAR[PlayerStatus]</label>
+					<textcolor>$VAR[TextColor2]</textcolor>
+				</control>
+
+				<!-- Pause -->
+				<control type="image">
+					<left>40</left>
+					<width>60</width>
+					<height>60</height>
+					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDPauseNF.png</texture>
+					<visible>player.paused</visible>
+				</control>
+
 			</control>
 
-			<!-- Status -->
-			<control type="label">
+			<!-- Player skipping -->
+			<control type="group">
+				<right>150</right>
+				<top>870</top>
 				<width>140</width>
 				<height>60</height>
-				<font>Font27</font>
-				<align>center</align>
-				<label>[B]$INFO[Player.Chapter,(,/]$INFO[Player.ChapterCount,,)][/B][B]$INFO[MusicPlayer.PlaylistPosition,(,/]$INFO[MusicPlayer.PlaylistLength,,)][/B]</label>
-				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!Window.IsVisible(visualisation) + String.IsEmpty(Player.SeekStepSize)</visible>
+				<visible>[[Player.DisplayAfterSeek + Integer.IsGreater(Player.ChapterCount,0)] | Integer.IsGreater(MusicPlayer.PlaylistLength,0) | !String.IsEmpty(Player.SeekStepSize)] + !Player.HasGame</visible>
+				<visible>String.IsEmpty(Player.SeekNumeric)</visible>
+
+				<!-- Background -->
+				<control type="image">
+					<width>140</width>
+					<height>60</height>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				</control>
+
+				<!-- Status -->
+				<control type="label">
+					<width>140</width>
+					<height>60</height>
+					<font>Font27</font>
+					<align>center</align>
+					<label>[B]$INFO[Player.Chapter,(,/]$INFO[Player.ChapterCount,,)][/B][B]$INFO[MusicPlayer.PlaylistPosition,(,/]$INFO[MusicPlayer.PlaylistLength,,)][/B]</label>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<visible>!Window.IsVisible(visualisation) + String.IsEmpty(Player.SeekStepSize)</visible>
+				</control>
+
+				<!-- Status -->
+				<control type="label">
+					<width>140</width>
+					<height>60</height>
+					<font>Font27</font>
+					<align>center</align>
+					<label>[B]$INFO[MusicPlayer.PlaylistPosition,(,/]$INFO[MusicPlayer.PlaylistLength,,)][/B]</label>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<visible>Window.IsVisible(visualisation) + String.IsEmpty(Player.SeekStepSize)</visible>
+				</control>
+
+				<!-- Status -->
+				<control type="label">
+					<width>140</width>
+					<height>60</height>
+					<font>Font27</font>
+					<align>center</align>
+					<visible>!String.IsEmpty(Player.SeekStepSize)</visible>
+					<label>$INFO[Player.SeekStepSize]</label>
+					<textcolor>$VAR[TextColor2]</textcolor>
+				</control>
+
 			</control>
 
-			<!-- Status -->
-			<control type="label">
-				<width>140</width>
+			<!-- Timeshift status -->
+			<control type="group">
+				<visible>Pvr.IsTimeShift</visible>
+				<left>430</left>
+				<top>870</top>
+				<width>920</width>
 				<height>60</height>
-				<font>Font27</font>
-				<align>center</align>
-				<label>[B]$INFO[MusicPlayer.PlaylistPosition,(,/]$INFO[MusicPlayer.PlaylistLength,,)][/B]</label>
-				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>Window.IsVisible(visualisation) + String.IsEmpty(Player.SeekStepSize)</visible>
+				<animation type="Visible">
+					<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+					<effect type="fade" start="0" end="100" time="200"/>
+				</animation>
+				
+				<control type="image">
+					<width>920</width>
+					<height>60</height>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				</control>
+				
+				<control type="label">
+					<left>20</left>
+					<width>880</width>
+					<height>60</height>
+					<font>Font27</font>
+					<align>center</align>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$LOCALIZE[31112] $INFO[PVR.TimeshiftCur(hh:mm xx)] (-$INFO[PVR.TimeshiftOffset])</label>
+				</control>
 			</control>
-
-			<!-- Status -->
-			<control type="label">
-				<width>140</width>
-				<height>60</height>
-				<font>Font27</font>
-				<align>center</align>
-				<visible>!String.IsEmpty(Player.SeekStepSize)</visible>
-				<label>$INFO[Player.SeekStepSize]</label>
-				<textcolor>$VAR[TextColor2]</textcolor>
-			</control>
-
-		</control>
-
-		<!-- Progress -->
-		<control type="group">
-			<left>150</left>
-			<top>945</top>
-			<width>1620</width>
-			<height>60</height>
-			<visible>[String.IsEmpty(Player.SeekNumeric) + !Player.IsTempo] + !Player.HasGame</visible>
-
-			<!-- Background -->
-			<control type="image">
+			
+			<!-- Progress -->
+			<control type="group">
+				<left>150</left>
+				<top>945</top>
 				<width>1620</width>
 				<height>60</height>
-				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
-			</control>
+				<visible>[String.IsEmpty(Player.SeekNumeric) + !Player.IsTempo] + !Player.HasGame</visible>
+				<animation type="Visible">
+					<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+					<effect type="fade" start="0" end="100" time="200"/>
+				</animation>
 
-			<!--  Current position/Time remaining -->
-			<control type="label">
-				<left>20</left>
-				<width>260</width>
-				<height>60</height>
-				<font>Font27</font>
-				<textcolor>$VAR[TextColor2]</textcolor>
-				<label>$INFO[Player.Time]$INFO[Player.Duration, / ,]</label>
-			</control>
+				<!-- Background -->
+				<control type="image">
+					<width>1620</width>
+					<height>60</height>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				</control>
 
-			<!--  Progress bar -->
-			<control type="progress" id="1">
-				<left>280</left>
-				<top>20</top>
-				<width>920</width>
-				<height>20</height>
-				<info>Player.Progress</info>
-				<texturebg border="2" colordiffuse="$VAR[DialogColor2]">osd/OSDProgressBack.png</texturebg>
-				<lefttexture></lefttexture>
-				<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
-				<righttexture></righttexture>
-				<overlaytexture></overlaytexture>
-			</control>
+				<!--  Current position/Time remaining -->
+				<control type="label">
+					<left>20</left>
+					<width>260</width>
+					<height>60</height>
+					<font>Font27</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$INFO[Player.Time]$INFO[Player.Duration, / ,]</label>
+					<visible>!Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!--  PVR current position/Time remaining -->
+				<control type="label">
+					<left>20</left>
+					<width>260</width>
+					<height>60</height>
+					<font>Font27</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration, / ,]</label>
+					<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
+				</control>
 
-			<!--  Cache bar -->
-			<control type="progress" id="1">
-				<left>280</left>
-				<top>20</top>
-				<width>920</width>
-				<height>20</height>
-				<info>Player.ProgressCache</info>
-				<texturebg colordiffuse="$VAR[DialogColor2]" border="2">osd/OSDProgressBack.png</texturebg>
-				<lefttexture></lefttexture>
-				<midtexture colordiffuse="OSDCache" border="2">osd/OSDProgressBar.png</midtexture>
-				<righttexture></righttexture>
-				<overlaytexture></overlaytexture>
-			</control>
+				<!--  Progress bar -->
+				<control type="progress" id="1">
+					<left>280</left>
+					<top>20</top>
+					<width>920</width>
+					<height>20</height>
+					<info>Player.Progress</info>
+					<texturebg border="2" colordiffuse="$VAR[DialogColor2]">osd/OSDProgressBack.png</texturebg>
+					<lefttexture></lefttexture>
+					<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
+					<righttexture></righttexture>
+					<overlaytexture></overlaytexture>
+					<visible>!Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!--  PVR progress bar -->
+				<control type="progress">
+					<left>280</left>
+					<top>20</top>
+					<width>920</width>
+					<height>20</height>
+					<info>PVR.EpgEventProgress</info>
+					<texturebg border="2" colordiffuse="$VAR[DialogColor2]">osd/OSDProgressBack.png</texturebg>
+					<lefttexture></lefttexture>
+					<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
+					<righttexture></righttexture>
+					<overlaytexture></overlaytexture>
+					<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
+				</control>
 
-			<!-- Current Time/End Time -->
-			<control type="label">
-				<left>1001</left>
-				<width>600</width>
-				<height>60</height>
-				<align>right</align>
-				<font>Font27</font>
-				<textcolor>$VAR[TextColor2]</textcolor>
-				<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
-				<visible>Integer.IsGreater(Player.Duration,0)</visible>
-			</control>
+				<!--  Cache bar -->
+				<control type="progress" id="1">
+					<left>280</left>
+					<top>20</top>
+					<width>920</width>
+					<height>20</height>
+					<info>Player.ProgressCache</info>
+					<texturebg colordiffuse="$VAR[DialogColor2]" border="2">osd/OSDProgressBack.png</texturebg>
+					<lefttexture></lefttexture>
+					<midtexture colordiffuse="OSDCache" border="2">osd/OSDProgressBar.png</midtexture>
+					<righttexture></righttexture>
+					<overlaytexture></overlaytexture>
+				</control>
 
+				<!-- Current Time/End Time -->
+				<control type="label">
+					<left>1001</left>
+					<width>600</width>
+					<height>60</height>
+					<align>right</align>
+					<font>Font27</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
+					<visible>Integer.IsGreater(Player.Duration,0) + !Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!-- PVR current Time/End Time -->
+				<control type="label">
+					<left>1001</left>
+					<width>600</width>
+					<height>60</height>
+					<align>right</align>
+					<font>Font27</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081] ,]</label>
+					<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
+				</control>
+			</control>
 		</control>
 
 	</controls>

--- a/16x9/SkinSettings.xml
+++ b/16x9/SkinSettings.xml
@@ -682,8 +682,8 @@
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
-				<onup>300</onup>
-				<ondown>300</ondown>
+				<onup>200</onup>
+				<ondown>200</ondown>
 				<orientation>vertical</orientation>
 				<usecontrolcoords>true</usecontrolcoords>
 				<scrolltime tween="sine" easing="out">240</scrolltime>

--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -629,7 +629,7 @@
 	</variable>
 
 	<variable name="VideoPlayerChannelNumber">
-		<value condition="VideoPlayer.Content(LiveTV)">$INFO[VideoPlayer.ChannelName]$INFO[VideoPlayer.ChannelNumberLabel, (,)]</value>
+		<value condition="VideoPlayer.Content(LiveTV)">$INFO[VideoPlayer.ChannelName,[B],[/B]]$INFO[VideoPlayer.ChannelNumberLabel, &#8226; [B],[/B]]</value>
 	</variable>
 
 	<variable name="VideoPlayerNext">

--- a/16x9/VideoFullScreen.xml
+++ b/16x9/VideoFullScreen.xml
@@ -4,7 +4,7 @@
 	<defaultcontrol></defaultcontrol>
 
 	<controls>
-
+		
 		<control type="group">
 			<left>150</left>
 			<top>75</top>
@@ -57,7 +57,7 @@
 		<!-- Seek Numeric -->
 		<control type="group" id="1">
 			<visible>!String.IsEmpty(Player.SeekNumeric) + !Window.IsVisible(VideoOSD)</visible>
-			<animation type="Visible" condition="!Window.IsVisible(SeekBar)">
+			<animation type="Visible">
 				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
 				<effect type="fade" start="0" end="100" time="200"/>
 			</animation>
@@ -124,6 +124,35 @@
 
 			</control>
 
+			<!-- Timeshift status -->
+			<control type="group">
+				<visible>Pvr.IsTimeShift</visible>
+				<left>430</left>
+				<top>870</top>
+				<width>920</width>
+				<height>60</height>
+				<animation type="Visible">
+					<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+					<effect type="fade" start="0" end="100" time="200"/>
+				</animation>
+
+				<control type="image">
+					<width>920</width>
+					<height>60</height>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				</control>
+				
+				<control type="label">
+					<left>20</left>
+					<width>880</width>
+					<height>60</height>
+					<font>Font27</font>
+					<align>center</align>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$LOCALIZE[31112] $INFO[PVR.TimeshiftCur(hh:mm xx)] (-$INFO[PVR.TimeshiftOffset])</label>
+				</control>
+			</control>
+			
 			<!-- Progress -->
 			<control type="group" id="1">
 				<left>150</left>
@@ -146,6 +175,18 @@
 					<font>Font27</font>
 					<textcolor>$VAR[TextColor2]</textcolor>
 					<label>$INFO[Player.Time]$INFO[Player.Duration, / ,]</label>
+					<visible>!Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!--  PVR current position/Time remaining -->
+				<control type="label">
+					<left>20</left>
+					<width>260</width>
+					<height>60</height>
+					<font>Font27</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration, / ,]</label>
+					<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 				</control>
 
 				<!--  Progress bar -->
@@ -160,6 +201,22 @@
 					<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
 					<righttexture></righttexture>
 					<overlaytexture></overlaytexture>
+					<visible>!Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!--  PVR progress bar -->
+				<control type="progress">
+					<left>280</left>
+					<top>20</top>
+					<width>920</width>
+					<height>20</height>
+					<info>PVR.EpgEventProgress</info>
+					<texturebg border="2" colordiffuse="$VAR[DialogColor2]">osd/OSDProgressBack.png</texturebg>
+					<lefttexture></lefttexture>
+					<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
+					<righttexture></righttexture>
+					<overlaytexture></overlaytexture>
+					<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 				</control>
 
 				<!--  Cache bar -->
@@ -185,7 +242,19 @@
 					<font>Font27</font>
 					<textcolor>$VAR[TextColor2]</textcolor>
 					<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
-					<visible>Integer.IsGreater(Player.Duration,0)</visible>
+					<visible>Integer.IsGreater(Player.Duration,0) + !Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!-- PVR current Time/End Time -->
+				<control type="label">
+					<left>1001</left>
+					<width>600</width>
+					<height>60</height>
+					<align>right</align>
+					<font>Font27</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081] ,]</label>
+					<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 				</control>
 
 			</control>

--- a/16x9/VideoOSD.xml
+++ b/16x9/VideoOSD.xml
@@ -9,6 +9,33 @@
 
 	<controls>
 
+		<!-- PVR channel number input -->
+		<control type="group">
+			<left>0</left>
+			<top>0</top>
+			<width>1920</width>
+			<height>1080</height>
+			<visible>!String.IsEmpty(PVR.ChannelNumberInput)</visible>
+			<control type="image">
+				<centerleft>50%</centerleft>
+				<centertop>50%</centertop>
+				<width>140</width>
+				<height>140</height>
+				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+			</control>
+			<control type="label">
+				<label>$INFO[PVR.ChannelNumberInput]</label>
+				<centerleft>50%</centerleft>
+				<centertop>50%</centertop>
+				<align>center</align>
+				<font>Font72</font>
+				<width>140</width>
+				<height>140</height>
+				<textcolor>$VAR[TextColor1]</textcolor>
+				<aligny>center</aligny>
+			</control>
+		</control>
+		
 		<!-- Player forwarding/rewinding -->
 		<control type="group">
 			<left>150</left>
@@ -17,14 +44,6 @@
 			<height>60</height>
 			<visible>!Window.IsVisible(VideoBookmarks) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(DialogConfirm.xml)</visible>
 			<visible>player.forwarding | player.rewinding | player.paused | player.istempo</visible>
-			<animation type="WindowOpen" condition="!Window.IsActive(seekbar) + !Window.IsActive(fullscreeninfo)">
-				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
-				<effect type="fade" start="0" end="100" time="200"/>
-			</animation>
-			<animation type="WindowClose" condition="!Window.IsActive(seekbar) + !Window.IsActive(fullscreeninfo)">
-				<effect type="zoom" start="100" end="90" center="auto" easing="in" time="200"/>
-				<effect type="fade" start="100" end="0" time="200"/>
-			</animation>
 
 			<!-- Background -->
 			<control type="image">
@@ -105,6 +124,38 @@
 
 		</control>
 
+		<!-- Timeshift status -->
+		<control type="group">
+			<visible>!Window.IsVisible(VideoBookmarks) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(DialogConfirm.xml)</visible>
+			<visible>Pvr.IsTimeShift</visible>
+			<left>430</left>
+			<top>795</top>
+			<width>920</width>
+			<height>60</height>
+			<animation type="Visible">
+				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
+				<effect type="fade" start="0" end="100" time="200"/>
+			</animation>
+			
+			<control type="image">
+				<width>920</width>
+				<height>60</height>
+				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				<visible>Pvr.IsTimeShift</visible>
+			</control>
+			
+			<control type="label">
+				<left>20</left>
+				<width>880</width>
+				<height>60</height>
+				<font>Font27</font>
+				<align>center</align>
+				<textcolor>$VAR[TextColor2]</textcolor>
+				<label>$LOCALIZE[31112] $INFO[PVR.TimeshiftCur(hh:mm xx)] (-$INFO[PVR.TimeshiftOffset])</label>
+				<visible>Pvr.IsTimeShift</visible>
+			</control>
+		</control>
+		
 		<!-- Progress -->
 		<control type="group">
 			<visible>!Window.IsVisible(DialogSettings.xml)</visible>
@@ -112,15 +163,7 @@
 			<top>870</top>
 			<width>1620</width>
 			<height>60</height>
-			<animation type="WindowOpen" condition="!Window.IsActive(seekbar) + !Window.IsActive(fullscreeninfo)">
-				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
-				<effect type="fade" start="0" end="100" time="200"/>
-			</animation>
-			<animation type="WindowClose" condition="!Window.IsActive(seekbar) + !Window.IsActive(fullscreeninfo)">
-				<effect type="zoom" start="100" end="90" center="auto" easing="in" time="200"/>
-				<effect type="fade" start="100" end="0" time="200"/>
-			</animation>
-
+			
 			<!-- Background -->
 			<control type="image">
 				<width>1620</width>
@@ -136,8 +179,20 @@
 				<font>Font27</font>
 				<textcolor>$VAR[TextColor2]</textcolor>
 				<label>$INFO[Player.Time]$INFO[Player.Duration, / ,]</label>
+				<visible>!Pvr.IsPlayingTv</visible>
 			</control>
-
+			
+			<!--  PVR current position/Time remaining -->
+			<control type="label">
+				<left>20</left>
+				<width>260</width>
+				<height>60</height>
+				<font>Font27</font>
+				<textcolor>$VAR[TextColor2]</textcolor>
+				<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration, / ,]</label>
+				<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
+			</control>
+			
 			<!-- Seek slider -->
 			<control type="slider">
 				<left>280</left>
@@ -162,6 +217,22 @@
 				<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
 				<righttexture></righttexture>
 				<overlaytexture></overlaytexture>
+				<visible>!Pvr.IsPlayingTv</visible>
+			</control>
+			
+			<!--  PVR progress bar -->
+			<control type="progress">
+				<left>280</left>
+				<top>20</top>
+				<width>920</width>
+				<height>20</height>
+				<info>PVR.EpgEventProgress</info>
+				<texturebg border="2" colordiffuse="$VAR[DialogColor2]">osd/OSDProgressBack.png</texturebg>
+				<lefttexture></lefttexture>
+				<midtexture border="2" colordiffuse="$VAR[DialogColor1]">osd/OSDProgressBar.png</midtexture>
+				<righttexture></righttexture>
+				<overlaytexture></overlaytexture>
+				<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 			</control>
 
 			<!--  Cache bar -->
@@ -177,7 +248,7 @@
 				<righttexture></righttexture>
 				<overlaytexture></overlaytexture>
 			</control>
-
+			
 			<!-- Current Time/End Time -->
 			<control type="label">
 				<left>1001</left>
@@ -187,7 +258,19 @@
 				<font>Font27</font>
 				<textcolor>$VAR[TextColor2]</textcolor>
 				<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
-				<visible>Integer.IsGreater(Player.Duration,0)</visible>
+				<visible>Integer.IsGreater(Player.Duration,0) + !Pvr.IsPlayingTv</visible>
+			</control>
+
+			<!-- PVR current Time/End Time -->
+			<control type="label">
+				<left>1001</left>
+				<width>600</width>
+				<height>60</height>
+				<align>right</align>
+				<font>Font27</font>
+				<textcolor>$VAR[TextColor2]</textcolor>
+				<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081] ,]</label>
+				<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 			</control>
 
 		</control>
@@ -198,14 +281,6 @@
 			<width>1620</width>
 			<height>60</height>
 			<visible>!Window.IsVisible(VideoBookmarks) + !Window.IsVisible(DialogSettings.xml)</visible>
-			<animation type="WindowOpen" condition="!Window.IsActive(seekbar) + !Window.IsActive(fullscreeninfo)">
-				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
-				<effect type="fade" start="0" end="100" time="200"/>
-			</animation>
-			<animation type="WindowClose" condition="!Window.IsActive(seekbar) + !Window.IsActive(fullscreeninfo)">
-				<effect type="zoom" start="100" end="90" center="auto" easing="in" time="200"/>
-				<effect type="fade" start="100" end="0" time="200"/>
-			</animation>
 
 			<!-- Background -->
 			<control type="image">
@@ -243,7 +318,7 @@
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDTrickBackwardEnd.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDTrickBackwardEnd.png</texturenofocus>
 					<onclick>PlayerControl(Previous)</onclick>
-					<visible>!VideoPlayer.Content(LiveTV)</visible>
+					<visible>[VideoPlayer.Content(LiveTV) + Player.SeekEnabled] | !VideoPlayer.Content(LiveTV)</visible>
 				</control>
 				<!-- Rewind -->
 				<control type="togglebutton" id="2">
@@ -285,7 +360,7 @@
 				</control>
 
 				<!-- Up -->
-				<control type="button" id="4">
+				<!-- <control type="button" id="4">
 					<width>60</width>
 					<height>60</height>
 					<onleft>4</onleft>
@@ -293,8 +368,8 @@
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDUpNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDUpNF.png</texturenofocus>
 					<onclick>PlayerControl(Previous)</onclick>
-					<visible>VideoPlayer.Content(LiveTV)</visible>
-				</control>
+					<visible>VideoPlayer.Content(LiveTV) + !Player.SeekEnabled</visible>
+				</control> -->
 
 				<!-- Play/Pause -->
 				<include condition="Player.PauseEnabled">OSDPlayStopButtons</include>
@@ -302,7 +377,7 @@
 				<include condition="!Player.PauseEnabled">OSDStopButton</include>
 
 				<!-- Down -->
-				<control type="button" id="7">
+				<!-- <control type="button" id="7">
 					<width>60</width>
 					<height>60</height>
 					<onleft>5</onleft>
@@ -310,8 +385,8 @@
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDDownNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDDownNF.png</texturenofocus>
 					<onclick>PlayerControl(Next)</onclick>
-					<visible>VideoPlayer.Content(LiveTV)</visible>
-				</control>
+					<visible>VideoPlayer.Content(LiveTV) + !Player.SeekEnabled</visible>
+				</control> -->
 
 				<!-- Spacer -->
 				<control type="image" id="42">
@@ -360,7 +435,7 @@
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDTrickForwardEnd.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDTrickForwardEnd.png</texturenofocus>
 					<onclick>PlayerControl(Next)</onclick>
-					<visible>!VideoPlayer.Content(LiveTV)</visible>
+					<visible>[VideoPlayer.Content(LiveTV) + Player.SeekEnabled] | !VideoPlayer.Content(LiveTV)</visible>
 				</control>
 
 				<!-- Spacer -->

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ _New_
 - add player icon to now playing dialog
 - add new dependency button in addon info dialog to match v18 requirements
 - new color options (color sets, background gradients, adjustable opacity)
+- add PVR channel number input dialog
+- add PVR timeshift status dialog
 
 _Improved_
 - adjust syntax, values, labels and infobools to match v18 requirements
@@ -16,6 +18,8 @@ _Improved_
 _Fixed_
 - show proper game widget title when not using skinshortcuts script
 - highlighting is now more consistent
+- fix current position/time remaining and current time/end time for PVR playback
+- hide deprecated previous/next channel buttons in PVR playback OSD
 
 **Changelog v18.0.0**
 
@@ -117,6 +121,12 @@ DialogFavourites.xml:
 
 DialogFullScreenInfo.xml:
 - replace colors by new color variables
+- turn title and TV channel name/number labels into fadelabels
+- add PVR channel number input dialog
+- add PVR timeshift status dialog
+- fix current position/time remaining for PVR playback
+- add PVR progress bar
+- fix current time/end time for PVR playback
 
 DialogGameControllers.xml:
 - replace colors by new color variables
@@ -165,6 +175,12 @@ DialogPVRInfo.xml:
 
 DialogSeekBar.xml:
 - replace colors by new color variables
+- fix animations
+- add PVR channel number input dialog
+- add PVR timeshift status dialog
+- fix current position/time remaining for PVR playback
+- add PVR progress bar
+- fix current time/end time for PVR playback
 
 DialogSelect.xml:
 - replace colors by new color variables
@@ -314,6 +330,7 @@ SkinSettings.xml:
 - rework default background image option
 - remove old background and overlay color options
 - add skin settings backup and restore option
+- fix onup and ondown for addons submenu
 
 SmartPlaylistEditor.xml:
 - replace colors by new color variables
@@ -329,12 +346,24 @@ Variables.xml:
 - remove focus variable
 - add new buttonfocus variable
 - replace colors by new color variables
+- change PVR video player info variable
 
 VideoFullScreen.xml:
 - replace colors by new color variables
+- add PVR timeshift status dialog
+- fix current position/time remaining for PVR playback
+- add PVR progress bar
+- fix current time/end time for PVR playback
 
 VideoOSD.xml:
 - replace colors by new color variables
+- add PVR channel number input dialog
+- fix animations
+- add PVR timeshift status dialog
+- fix current position/time remaining for PVR playback
+- add PVR progress bar
+- fix current time/end time for PVR playback
+- hide deprecated previous/next channel buttons
 
 VideoOSDBookmarks.xml:
 - replace colors by new color variables
@@ -363,6 +392,7 @@ Viewtype55.xml:
 
 strings.po:
 - add new localizes for reworked skin settings (31052, 31097, 31107, 31108, 31109, 31110, 31111)
+- add new localize for new PVR timeshift status dialog (31112)
 
 Textures.xbt:
 - update file with new resolution select icon included

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="skin.osmc.v18alpha"
 	version="18.0.0"
-	name="OSMC Skin (v18 RC1)"
+	name="OSMC Skin (v18 RC5.2)"
 	provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.14.0"/>
@@ -14,7 +14,7 @@
 		<platform>all</platform>
 		<summary lang="en">The default skin for OSMC</summary>
 		<description lang="en">Original skin: Andy Morton[CR]Original design: Simon Brunton[CR]Skinner: Julian Michel</description>
-		<news>Kodi v18 RC1 update[CR][CR][B]New[/B][CR]- add new v18 subtitle settings OSD during fullscreen video playback[CR]- add new games section to match v18 requirements[CR]- add games section[CR]- add new resolution select button/dialog in video player[CR]- add player icon to now playing dialog[CR]- add new dependency button in addon info dialog to match v18 requirements[CR]- new color options (color sets, background gradients, adjustable opacity)[CR][CR][B]Improved[/B][CR]- adjust syntax, values, labels and infobools to match v18 requirements[CR]- adjust PVR section to match v18 requirements[CR]- highlighting color now adjusts according to text color[CR][CR][B]Fixed[/B][CR]- show proper game widget title when not using skinshortcuts script[CR]- highlighting is now more consistent</news>
+		<news>Kodi v18 RC5.2 update[CR][CR][B]New[/B][CR]- add new v18 subtitle settings OSD during fullscreen video playback[CR]- add new games section to match v18 requirements[CR]- add games section[CR]- add new resolution select button/dialog in video player[CR]- add player icon to now playing dialog[CR]- add new dependency button in addon info dialog to match v18 requirements[CR]- new color options (color sets, background gradients, adjustable opacity)[CR]- add PVR channel number input dialog[CR]- add PVR timeshift status dialog[CR][CR][B]Improved[/B][CR]- adjust syntax, values, labels and infobools to match v18 requirements[CR]- adjust PVR section to match v18 requirements[CR]- highlighting color now adjusts according to text color[CR][CR][B]Fixed[/B][CR]- show proper game widget title when not using skinshortcuts script[CR]- highlighting is now more consistent[CR]- fix current position/time remaining and current time/end time for PVR playback[CR]- hide deprecated previous/next channel buttons in PVR playback OSD</news>
 	</extension>
 	<assets>
 		<icon>icon.png</icon>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -524,3 +524,8 @@ msgstr ""
 msgctxt "#31111"
 msgid "Background color gradient (default: Left-right)"
 msgstr ""
+
+#: /16x9/VideoOSD.xml
+msgctxt "#31112"
+msgid "Timeshift:"
+msgstr ""


### PR DESCRIPTION
DialogFullScreenInfo.xml:
- turn title and TV channel name/number labels into fadelabels
- add PVR channel number input dialog
- add PVR timeshift status dialog
- fix current position/time remaining for PVR playback
- add PVR progress bar
- fix current time/end time for PVR playback

DialogSeekBar.xml:
- fix animations
- add PVR channel number input dialog
- add PVR timeshift status dialog
- fix current position/time remaining for PVR playback
- add PVR progress bar
- fix current time/end time for PVR playback

SkinSettings.xml:
- fix onup and ondown for addons submenu

Variables.xml:
- change PVR video player info variable

VideoFullScreen.xml:
- add PVR timeshift status dialog
- fix current position/time remaining for PVR playback
- add PVR progress bar
- fix current time/end time for PVR playback

VideoOSD.xml:
- add PVR channel number input dialog
- fix animations
- add PVR timeshift status dialog
- fix current position/time remaining for PVR playback
- add PVR progress bar
- fix current time/end time for PVR playback
- hide deprecated previous/next channel buttons

strings.po:
- add new localize for new timeshift status dialog (31112)

addon.xml:
- update changelog

Changelog.md:
- update changelog