### PR TITLE
Modified "SystemInfo" on fontset "Arial"

### DIFF
--- a/16x9/Font.xml
+++ b/16x9/Font.xml
@@ -189,7 +189,7 @@
 		<!-- System Info fixed width -->
 		<font>
 			<name>SystemInfo</name>
-			<filename>LiberationMono-Regular.ttf</filename>
+			<filename>teletext.ttf</filename>
 			<size>24</size>
 		</font>
 


### PR DESCRIPTION
In order to use it in non-English, "fontset Arial" "SystemInfo"
It returned from LiberationMono-Regular.ttf to teletext.ttf.

"~/.kodi/media/Fonts/" Add an alternative font (teletext.ttf) below.