### PR TITLE
Improve video info dialog, new view and adjust video duration setting

### DIFF
--- a/16x9/AddonBrowser.xml
+++ b/16x9/AddonBrowser.xml
@@ -39,6 +39,7 @@
 	<onload condition="String.IsEmpty(Skin.String(OSMCBackgroundOverlay))">Skin.SetString(OSMCBackgroundOverlay,1)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfostartduration))">Skin.SetString(videoinfostartduration,10s)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfoendduration))">Skin.SetString(videoinfoendduration,10s)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videodurationformat))">Skin.SetString(videodurationformat,Minutes)</onload>
 
 	<controls>
 

--- a/16x9/DialogAddonInfo.xml
+++ b/16x9/DialogAddonInfo.xml
@@ -129,7 +129,7 @@
 							<textcolor>$VAR[TextColor2]</textcolor>
 						</control>
 						<control type="label">
-						<top>-6</top>
+							<top>-6</top>
 							<left>220</left>
 							<width>950</width>
 							<height>112</height>

--- a/16x9/DialogVideoInfo.xml
+++ b/16x9/DialogVideoInfo.xml
@@ -2,10 +2,12 @@
 <window>
 	<!-- movieinformation -->
 	<defaultcontrol always="true">8</defaultcontrol>
+	<onload condition="!String.IsEmpty(Window(12003).Property(extended))">ClearProperty(extended,12003)</onload>
 	<onload condition="String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])">SendClick(50)</onload>
 	<onload condition="System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
 	<onload condition="String.IsEmpty(Skin.String(Ratings))">Skin.SetString(Ratings,imdb)</onload>
 	<onunload condition="String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])">SendClick(50)</onunload>
+	<onunload>ClearProperty(extended,12003)</onunload>
 
 	<controls>
 		<!-- Window Background -->
@@ -23,7 +25,7 @@
 
 			<!-- Poster image -->
 			<control type="group">
-				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])</visible>
+				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				<control type="image">
 					<left>150</left>
 					<top>225</top>
@@ -37,14 +39,14 @@
 
 			<!-- Actor image -->
 			<control type="group">
-				<visible>String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])</visible>
+				<visible>String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				<control type="image">
-					<left>120</left>
+					<left>150</left>
 					<top>225</top>
 					<width>405</width>
 					<height>600</height>
+					<fadetime>100</fadetime>
 					<texture>$INFO[Container(50).ListItem.Icon]</texture>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
 					<aspectratio align="center" aligny="center">keep</aspectratio>
 				</control>
 			</control>
@@ -66,12 +68,12 @@
 			<control type="group">
 				<left>600</left>
 				<top>235</top>
-				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])</visible>
+				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
 
 				<!-- Details -->
 				<control type="grouplist">
 					<width>1170</width>
-					<height>336</height>
+					<height>456</height>
 					<itemgap>12</itemgap>
 					<orientation>vertical</orientation>
 					<usecontrolcoords>true</usecontrolcoords>
@@ -223,18 +225,18 @@
 							<textcolor>$VAR[TextColor1]</textcolor>
 						</control>
 					</control>
-
+					
 					<!-- Rating -->
 					<control type="group">
 						<height>36</height>
 						<width>1170</width>
-						<visible>!String.IsEmpty(ListItem.RatingAndVotes) + String.IsEmpty(ListItem.RatingAndVotes(imdb)) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb))</visible>
+						<visible>!String.IsEmpty(ListItem.Rating)</visible>
 						<control type="label">
 							<width>200</width>
 							<height>36</height>
 							<align>right</align>
 							<font>Font36</font>
-							<label>$LOCALIZE[563]</label>
+							<label>563</label>
 							<textcolor>$VAR[TextColor2]</textcolor>
 						</control>
 						<control type="label">
@@ -242,95 +244,7 @@
 							<width>950</width>
 							<height>36</height>
 							<font>Font36</font>
-							<label>$INFO[ListItem.RatingAndVotes]</label>
-							<textcolor>$VAR[TextColor1]</textcolor>
-						</control>
-					</control>
-					
-					<control type="group">
-						<height>36</height>
-						<width>1170</width>
-						<visible>!String.IsEmpty(ListItem.RatingAndVotes(imdb)) + String.IsEqual(Skin.String(Ratings),imdb)</visible>
-						<control type="label">
-							<width>200</width>
-							<height>36</height>
-							<align>right</align>
-							<font>Font36</font>
-							<label>$LOCALIZE[563]</label>
-							<textcolor>$VAR[TextColor2]</textcolor>
-						</control>
-						<control type="label">
-							<left>220</left>
-							<width>950</width>
-							<height>36</height>
-							<font>Font36</font>
-							<label>$INFO[ListItem.RatingAndVotes(imdb)]$COMMA $LOCALIZE[368]</label>
-							<textcolor>$VAR[TextColor1]</textcolor>
-						</control>
-					</control>
-					
-					<control type="group">
-						<height>36</height>
-						<width>1170</width>
-						<visible>!String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + String.IsEqual(Skin.String(Ratings),metacritic)</visible>
-						<control type="label">
-							<width>200</width>
-							<height>36</height>
-							<align>right</align>
-							<font>Font36</font>
-							<label>$LOCALIZE[563]</label>
-							<textcolor>$VAR[TextColor2]</textcolor>
-						</control>
-						<control type="label">
-							<left>220</left>
-							<width>950</width>
-							<height>36</height>
-							<font>Font36</font>
-							<label>$INFO[ListItem.RatingAndVotes(metacritic)]$COMMA $LOCALIZE[31120]</label>
-							<textcolor>$VAR[TextColor1]</textcolor>
-						</control>
-					</control>
-					
-					<control type="group">
-						<height>36</height>
-						<width>1170</width>
-						<visible>!String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + String.IsEqual(Skin.String(Ratings),rottentomatoes)</visible>
-						<control type="label">
-							<width>200</width>
-							<height>36</height>
-							<align>right</align>
-							<font>Font36</font>
-							<label>$LOCALIZE[563]</label>
-							<textcolor>$VAR[TextColor2]</textcolor>
-						</control>
-						<control type="label">
-							<left>220</left>
-							<width>950</width>
-							<height>36</height>
-							<font>Font36</font>
-							<label>$INFO[ListItem.RatingAndVotes(rottentomatoes)]$COMMA $LOCALIZE[31121]</label>
-							<textcolor>$VAR[TextColor1]</textcolor>
-						</control>
-					</control>
-					
-					<control type="group">
-						<height>36</height>
-						<width>1170</width>
-						<visible>!String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) + String.IsEqual(Skin.String(Ratings),themoviedb)</visible>
-						<control type="label">
-							<width>200</width>
-							<height>36</height>
-							<align>right</align>
-							<font>Font36</font>
-							<label>$LOCALIZE[563]</label>
-							<textcolor>$VAR[TextColor2]</textcolor>
-						</control>
-						<control type="label">
-							<left>220</left>
-							<width>950</width>
-							<height>36</height>
-							<font>Font36</font>
-							<label>$INFO[ListItem.RatingAndVotes(themoviedb)]$COMMA $LOCALIZE[31122]</label>
+							<label>$INFO[ListItem.Rating]</label>
 							<textcolor>$VAR[TextColor1]</textcolor>
 						</control>
 					</control>
@@ -380,18 +294,41 @@
 							<textcolor>$VAR[TextColor1]</textcolor>
 						</control>
 					</control>
+					
+					<!-- Audio -->
+					<control type="group">
+						<height>36</height>
+						<width>1170</width>
+						<visible>!String.IsEmpty(ListItem.AudioCodec)</visible>
+						<control type="label">
+							<width>200</width>
+							<height>36</height>
+							<align>right</align>
+							<font>Font36</font>
+							<label>292</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+						</control>
+						<control type="label">
+							<left>220</left>
+							<width>950</width>
+							<height>36</height>
+							<font>Font36</font>
+							<label>$VAR[Audio]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+						</control>
+					</control>
 
 				</control>
 
 				<!-- Plot -->
 				<control type="group">
-					<top>370</top>
+					<top>394</top>
 					<width>1170</width>
-					<height>210</height>
+					<height>186</height>
 					<control type="textbox">
 						<align>left</align>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>[LIGHT]$VAR[Plot][/LIGHT]</label>
+						<label>[LIGHT]$VAR[PlotInfoDialog][/LIGHT]</label>
 						<autoscroll delay="10000" time="2000" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,S light)</visible>
 					</control>
@@ -399,7 +336,7 @@
 						<align>left</align>
 						<font>Font30</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>[LIGHT]$VAR[Plot][/LIGHT]</label>
+						<label>[LIGHT]$VAR[PlotInfoDialog][/LIGHT]</label>
 						<autoscroll delay="10000" time="1900" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,M light)</visible>
 					</control>
@@ -407,7 +344,7 @@
 						<align>left</align>
 						<font>Font33</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>[LIGHT]$VAR[Plot][/LIGHT]</label>
+						<label>[LIGHT]$VAR[PlotInfoDialog][/LIGHT]</label>
 						<autoscroll delay="10000" time="1800" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,L light)</visible>
 					</control>
@@ -415,7 +352,7 @@
 						<align>left</align>
 						<font>Font36</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>[LIGHT]$VAR[Plot][/LIGHT]</label>
+						<label>[LIGHT]$VAR[PlotInfoDialog][/LIGHT]</label>
 						<autoscroll delay="10000" time="1700" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,XL light)</visible>
 					</control>
@@ -423,7 +360,7 @@
 					<control type="textbox">
 						<align>left</align>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>$VAR[Plot]</label>
+						<label>$VAR[PlotInfoDialog]</label>
 						<autoscroll delay="10000" time="2000" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,S)</visible>
 					</control>
@@ -431,7 +368,7 @@
 						<align>left</align>
 						<font>Font30</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>$VAR[Plot]</label>
+						<label>$VAR[PlotInfoDialog]</label>
 						<autoscroll delay="10000" time="1900" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,M)</visible>
 					</control>
@@ -439,7 +376,7 @@
 						<align>left</align>
 						<font>Font33</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>$VAR[Plot]</label>
+						<label>$VAR[PlotInfoDialog]</label>
 						<autoscroll delay="10000" time="1800" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,L)</visible>
 					</control>
@@ -447,7 +384,7 @@
 						<align>left</align>
 						<font>Font36</font>
 						<textcolor>$VAR[TextColor2]</textcolor>
-						<label>$VAR[Plot]</label>
+						<label>$VAR[PlotInfoDialog]</label>
 						<autoscroll delay="10000" time="1700" repeat="12000">True</autoscroll>
 						<visible>Skin.String(PlotFont,XL)</visible>
 					</control>
@@ -456,9 +393,9 @@
 
 			<!-- Cast -->
 			<control type="list" id="50">
-				<left>600</left>
+				<left>630</left>
 				<top>235</top>
-				<width>1170</width>
+				<width>1140</width>
 				<height>580</height>
 				<onup>50</onup>
 				<ondown>50</ondown>
@@ -468,7 +405,7 @@
 				<viewtype label="">list</viewtype>
 				<pagecontrol>60</pagecontrol>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible allowhiddenfocus="true">String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])</visible>
+				<visible allowhiddenfocus="true">String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
 
 				<itemlayout width="1170" height="58">
 					<control type="label">
@@ -515,7 +452,7 @@
 			
 			<!-- Scrollbar -->
 			<control type="scrollbar" id="60">
-				<left>563</left>
+				<left>593</left>
 				<top>235</top>
 				<width>20</width>
 				<height>580</height>
@@ -529,7 +466,156 @@
 				<texturesliderbarfocus border="11,1,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripFO.png</texturesliderbarfocus>
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
-				<visible>!Skin.HasSetting(Scrollbars) + String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])</visible>
+				<visible>!Skin.HasSetting(Scrollbars) + String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
+			</control>
+			
+			<!-- Extended info -->
+			<control type="group">
+				<left>150</left>
+				<top>235</top>
+				<visible>!String.IsEmpty(Window(12003).Property(extended))</visible>
+
+				<!-- Details -->
+				<control type="grouplist">
+					<width>500</width>
+					<height>580</height>
+					<itemgap>12</itemgap>
+					<orientation>vertical</orientation>
+					<usecontrolcoords>true</usecontrolcoords>
+					
+					<!-- Ratings -->
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$LOCALIZE[563]</label>
+						<textcolor>$VAR[TextColor2]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.RatingAndVotes) | !String.IsEmpty(ListItem.RatingAndVotes(imdb)) | !String.IsEmpty(ListItem.RatingAndVotes(metacritic)) | !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) | !String.IsEmpty(ListItem.RatingAndVotes(themoviedb))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$INFO[ListItem.RatingAndVotes]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>String.IsEmpty(ListItem.RatingAndVotes(imdb)) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$INFO[ListItem.RatingAndVotes(imdb)]$COMMA $LOCALIZE[368]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.RatingAndVotes(imdb))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$INFO[ListItem.RatingAndVotes(metacritic)]$COMMA $LOCALIZE[31120]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.RatingAndVotes(metacritic))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$INFO[ListItem.RatingAndVotes(rottentomatoes)]$COMMA $LOCALIZE[31121]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$INFO[ListItem.RatingAndVotes(themoviedb)]$COMMA $LOCALIZE[31122]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.RatingAndVotes(themoviedb))</visible>
+					</control>
+					
+					<control type="image">
+						<height>14</height>
+						<texture>transparent.png</texture>
+					</control>
+					
+					<!-- Audio tracks -->
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>292</label>
+						<textcolor>$VAR[TextColor2]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(AudioCodec.1))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$VAR[AudioCodec.1,, ]$VAR[AudioChannels.1,, ]$INFO[ListItem.Property(AudioLanguage.1),([UPPERCASE],[/UPPERCASE])]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(AudioCodec.1))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$VAR[AudioCodec.2,, ]$VAR[AudioChannels.2,, ]$INFO[ListItem.Property(AudioLanguage.2),([UPPERCASE],[/UPPERCASE])]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(AudioCodec.2))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$VAR[AudioCodec.3,, ]$VAR[AudioChannels.3,, ]$INFO[ListItem.Property(AudioLanguage.3),([UPPERCASE],[/UPPERCASE])]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(AudioCodec.3))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$VAR[AudioCodec.4,, ]$VAR[AudioChannels.4]$INFO[ListItem.Property(AudioLanguage.4),([UPPERCASE],[/UPPERCASE])]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(AudioCodec.4))</visible>
+					</control>
+					
+					<control type="image">
+						<height>14</height>
+						<texture>transparent.png</texture>
+					</control>
+
+					<!-- Subtitles -->
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>287</label>
+						<textcolor>$VAR[TextColor2]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(SubtitleLanguage.1))</visible>
+					</control>
+					<control type="fadelabel">
+						<height>36</height>
+						<font>Font36</font>
+						<label>$INFO[ListItem.Property(SubtitleLanguage.1),[UPPERCASE],[/UPPERCASE]]$INFO[ListItem.Property(SubtitleLanguage.2),$COMMA [UPPERCASE],[/UPPERCASE]]$INFO[ListItem.Property(SubtitleLanguage.3),$COMMA [UPPERCASE],[/UPPERCASE]]$INFO[ListItem.Property(SubtitleLanguage.4),$COMMA [UPPERCASE],[/UPPERCASE]]</label>
+						<textcolor>$VAR[TextColor1]</textcolor>
+						<pauseatend>5000</pauseatend>
+						<visible>!String.IsEmpty(ListItem.Property(SubtitleLanguage.1))</visible>
+					</control>
+
+				</control>
+
+				<!-- Plot -->
+				<control type="textbox">
+					<width>1034</width>
+					<height>580</height>
+					<left>565</left>
+					<align>left</align>
+					<font>Font36</font>
+					<textcolor>$VAR[TextColor2]</textcolor>
+					<label>$VAR[Plot]</label>
+					<autoscroll delay="10000" time="1700" repeat="12000">True</autoscroll>
+				</control>
 			</control>
 
 			<!-- Button grouplist background -->
@@ -560,41 +646,38 @@
 					<width>Auto</width>
 					<label>206</label>
 					<onclick condition="String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])">SetFocus(50)</onclick>
-					<visible>!String.IsEmpty(ListItem.Cast)</visible>
+					<visible>!String.IsEmpty(ListItem.Cast) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
 				<!-- Director Button -->
 				<control type="button" id="13">
 					<width>Auto</width>
 					<label>20339</label>
-					<visible>!String.IsEmpty(ListItem.Director)</visible>
+					<visible>!String.IsEmpty(ListItem.Director) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
-				<!-- Ratings Button -->
+				<!-- Extended info Button -->
 				<control type="button" id="15">
 					<width>Auto</width>
-					<label>563</label>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),imdb) + !String.IsEmpty(ListItem.RatingAndVotes(metacritic))">Skin.SetString(Ratings,metacritic)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),imdb) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes))">Skin.SetString(Ratings,rottentomatoes)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),imdb) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + !String.IsEmpty(ListItem.RatingAndVotes(themoviedb))">Skin.SetString(Ratings,themoviedb)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),metacritic) + !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes))">Skin.SetString(Ratings,rottentomatoes)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),metacritic) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + !String.IsEmpty(ListItem.RatingAndVotes(themoviedb))">Skin.SetString(Ratings,themoviedb)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),metacritic) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) + !String.IsEmpty(ListItem.RatingAndVotes(imdb))">Skin.SetString(Ratings,imdb)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),rottentomatoes) + !String.IsEmpty(ListItem.RatingAndVotes(themoviedb))">Skin.SetString(Ratings,themoviedb)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),rottentomatoes) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) + !String.IsEmpty(ListItem.RatingAndVotes(imdb))">Skin.SetString(Ratings,imdb)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),rottentomatoes) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) + String.IsEmpty(ListItem.RatingAndVotes(imdb)) + !String.IsEmpty(ListItem.RatingAndVotes(metacritic))">Skin.SetString(Ratings,metacritic)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),themoviedb) + !String.IsEmpty(ListItem.RatingAndVotes(imdb))">Skin.SetString(Ratings,imdb)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),themoviedb) + String.IsEmpty(ListItem.RatingAndVotes(imdb)) + !String.IsEmpty(ListItem.RatingAndVotes(metacritic))">Skin.SetString(Ratings,metacritic)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(Ratings),themoviedb) + String.IsEmpty(ListItem.RatingAndVotes(imdb)) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes))">Skin.SetString(Ratings,rottentomatoes)</onclick>
-					<visible>!String.IsEmpty(ListItem.RatingAndVotes(imdb)) + !String.IsEmpty(ListItem.RatingAndVotes(metacritic)) | !String.IsEmpty(ListItem.RatingAndVotes(imdb)) + !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) | !String.IsEmpty(ListItem.RatingAndVotes(imdb)) + !String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) | !String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) | !String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + !String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) | !String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + !String.IsEmpty(ListItem.RatingAndVotes(themoviedb))</visible>
+					<label>22082</label>
+					<onclick>SetProperty(extended,14115,12003)</onclick>
+					<visible>String.IsEmpty(Window(12003).Property(extended)) + !String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + !Container.Content(musicvideos)</visible>
+				</control>
+				<control type="button" id="16">
+					<width>Auto</width>
+					<label>210</label>
+					<onclick>ClearProperty(extended,12003)</onclick>
+					<visible>!String.IsEmpty(Window(12003).Property(extended)) + !String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + !Container.Content(musicvideos)</visible>
 				</control>
 				<!-- Refresh Button -->
 				<control type="button" id="14">
 					<width>Auto</width>
 					<label>184</label>
+					<visible>String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
 				<!-- Get Thumb Button -->
 				<control type="button" id="10">
 					<width>Auto</width>
 					<label>13511</label>
+					<visible>String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
 				<!-- Artwork Downloader Button -->
 				<control type="button" id="20">
@@ -602,13 +685,13 @@
 					<label>31043</label>
 					<onclick condition="Container.Content(tvshows)">XBMC.RunScript(script.artwork.downloader, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
 					<onclick condition="Container.Content(movies)">XBMC.RunScript(script.artwork.downloader, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
-					<visible>System.HasAddon(script.artwork.downloader) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
+					<visible>System.HasAddon(script.artwork.downloader) + [Container.Content(movies) | Container.Content(tvshows)] + String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
 				<!-- Trailer Button -->
 				<control type="button" id="11">
 					<width>Auto</width>
 					<label>20410</label>
-					<visible>!String.IsEmpty(ListItem.Trailer)</visible>
+					<visible>!String.IsEmpty(ListItem.Trailer) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
 				<!-- Cinema Experience Button -->
 				<control type="button" id="21">
@@ -616,7 +699,7 @@
 					<label>31066</label>
 					<onclick>Dialog.Close(MovieInformation)</onclick>
 					<onclick>XBMC.RunScript(script.cinema.experience,movieid=$INFO[ListItem.DBID])</onclick>
-					<visible>System.HasAddon(script.cinema.experience) + Container.Content(movies)</visible>
+					<visible>System.HasAddon(script.cinema.experience) + Container.Content(movies) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				</control>
 
 			</control>

--- a/16x9/Home.xml
+++ b/16x9/Home.xml
@@ -51,6 +51,7 @@
 	<onload condition="String.IsEmpty(Skin.String(OSMCBackgroundOverlay))">Skin.SetString(OSMCBackgroundOverlay,1)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfostartduration))">Skin.SetString(videoinfostartduration,10s)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfoendduration))">Skin.SetString(videoinfoendduration,10s)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videodurationformat))">Skin.SetString(videodurationformat,Minutes)</onload>
 
 	<controls>
 

--- a/16x9/Includes.xml
+++ b/16x9/Includes.xml
@@ -15,6 +15,7 @@
 	<include file="Viewtype531.xml" />
 	<include file="Viewtype532.xml" />
 	<include file="Viewtype533.xml" />
+	<include file="Viewtype534.xml" />
 	<include file="Viewtype54.xml" />
 	<include file="Viewtype55.xml" />
 	<include file="Variables.xml" />

--- a/16x9/LoginScreen.xml
+++ b/16x9/LoginScreen.xml
@@ -45,6 +45,7 @@
 	<onload condition="String.IsEmpty(Skin.String(OSMCBackgroundOverlay))">Skin.SetString(OSMCBackgroundOverlay,1)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfostartduration))">Skin.SetString(videoinfostartduration,10s)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfoendduration))">Skin.SetString(videoinfoendduration,10s)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videodurationformat))">Skin.SetString(videodurationformat,Minutes)</onload>
 
 	<controls>
 

--- a/16x9/MyVideoNav.xml
+++ b/16x9/MyVideoNav.xml
@@ -4,7 +4,7 @@
 	<backgroundcolor>0x00000000</backgroundcolor>
 	<defaultcontrol always="true">50</defaultcontrol>
 	<onload condition="System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
-	<views>52,521,53,531,532,533,51,50,511</views>
+	<views>52,521,53,531,532,533,534,51,50,511</views>
 
 	<controls>
 
@@ -25,6 +25,7 @@
 			<include>Viewtype531</include>
 			<include>Viewtype532</include>
 			<include>Viewtype533</include>
+			<include>Viewtype534</include>
 
 			<!-- Scrollbar (list) -->
 			<control type="scrollbar" id="60">
@@ -42,7 +43,7 @@
 				<texturesliderbarfocus border="11,1,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripFO.png</texturesliderbarfocus>
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
-				<visible>!Skin.HasSetting(Scrollbars) + [Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(511) | Control.IsVisible(531)]</visible>
+				<visible>!Skin.HasSetting(Scrollbars) + [Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(511) | Control.IsVisible(533)]</visible>
 			</control>
 
 			<!-- Scrollbar (poster) -->
@@ -118,7 +119,7 @@
 				<texturesliderbarfocus border="8,1,6,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripFO.png</texturesliderbarfocus>
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
-				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(533)</visible>
+				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(532)</visible>
 			</control>
 			
 			<!-- Scrollbar (wall small) -->
@@ -138,6 +139,25 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(532)</visible>
+			</control>
+			
+			<!-- Scrollbar (wall info) -->
+			<control type="scrollbar" id="69">
+				<left>690</left>
+				<top>192</top>
+				<width>20</width>
+				<height>633</height>
+				<onleft condition="!Skin.HasSetting(KioskMode)">3001</onleft>
+				<onright>50</onright>
+				<showonepage>false</showonepage>
+				<orientation>vertical</orientation>
+				<colordiffuse>$VAR[OverlayColorNF]</colordiffuse>
+				<texturesliderbackground border="11,1,1,1">common/ScrollBackground.png</texturesliderbackground>
+				<texturesliderbar border="11,1,1,1">common/ScrollbarGripNF.png</texturesliderbar>
+				<texturesliderbarfocus border="11,1,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripFO.png</texturesliderbarfocus>
+				<textureslidernib></textureslidernib>
+				<textureslidernibfocus></textureslidernibfocus>
+				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(531)</visible>
 			</control>
 
 			<!-- Media flags -->

--- a/16x9/SettingsCategory.xml
+++ b/16x9/SettingsCategory.xml
@@ -35,6 +35,9 @@
 	<onload condition="String.IsEmpty(Skin.String(DefaultBackgroundOpacity))">Skin.SetString(DefaultBackgroundOpacity,High)</onload>
 	<onload condition="String.IsEmpty(Skin.String(DefaultOverlayOpacity))">Skin.SetString(DefaultOverlayOpacity,High)</onload>
 	<onload condition="String.IsEmpty(Skin.String(OSMCBackgroundOverlay))">Skin.SetString(OSMCBackgroundOverlay,1)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videoinfostartduration))">Skin.SetString(videoinfostartduration,10s)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videoinfoendduration))">Skin.SetString(videoinfoendduration,10s)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videodurationformat))">Skin.SetString(videodurationformat,Minutes)</onload>
 
 	<controls>
 

--- a/16x9/SkinSettings.xml
+++ b/16x9/SkinSettings.xml
@@ -36,6 +36,7 @@
 	<onload condition="String.IsEmpty(Skin.String(OSMCBackgroundOverlay))">Skin.SetString(OSMCBackgroundOverlay,1)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfostartduration))">Skin.SetString(videoinfostartduration,10s)</onload>
 	<onload condition="String.IsEmpty(Skin.String(videoinfoendduration))">Skin.SetString(videoinfoendduration,10s)</onload>
+	<onload condition="String.IsEmpty(Skin.String(videodurationformat))">Skin.SetString(videodurationformat,Minutes)</onload>
 
 	<controls>
 	
@@ -855,8 +856,21 @@
 					<focusedcolor>$VAR[TextColor1]</focusedcolor>
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
+				<!-- Adjust representation of video duration -->
+				<control type="button" id="304">
+					<width>1220</width>
+					<height>66</height>
+					<textwidth>1120</textwidth>
+					<font>Font33</font>
+					<label>$LOCALIZE[31134]</label>
+					<label2>$INFO[Skin.String(videodurationformat)]</label2>
+					<onclick condition="String.IsEqual(Skin.String(videodurationformat),Minutes)">Skin.SetString(videodurationformat,Hours and minutes)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(videodurationformat),Hours and minutes)">Skin.SetString(videodurationformat,Minutes)</onclick>
+					<focusedcolor>$VAR[TextColor1]</focusedcolor>
+					<textcolor>$VAR[TextColor2]</textcolor>
+				</control>
 				<!-- Kiosk mode -->
-				<control type="radiobutton" id="304">
+				<control type="radiobutton" id="305">
 					<width>1220</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>

--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -608,6 +608,11 @@
 		<value condition="!String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
 	</variable>
 	
+	<variable name="PlotInfoDialog">
+		<value condition="!String.IsEmpty(ListItem.PlotOutline)">$INFO[ListItem.PlotOutline]</value>
+		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
+	</variable>
+	
 	<variable name="PlotDialogGuide">
 		<value condition="!String.IsEmpty(Container(11).ListItem.Plot)">$INFO[Container(11).ListItem.Plot]</value>
 		<value condition="!String.IsEmpty(Container(11).ListItem.PlotOutline)">$INFO[Container(11).ListItem.PlotOutline]</value>
@@ -835,6 +840,50 @@
 		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,8)">7.1</value>
 		<value condition="Integer.IsEqual(VideoPlayer.AudioChannels,10)">9.1</value>
 	</variable>
+	
+	<variable name="AudioChannels.1">
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),1)">1.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),2)">2.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),4)">3.1/4.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),5)">4.1/5.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),6)">5.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),7)">6.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),8)">7.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.1),10)">9.1</value>
+	</variable>
+	
+	<variable name="AudioChannels.2">
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),1)">1.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),2)">2.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),4)">3.1/4.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),5)">4.1/5.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),6)">5.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),7)">6.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),8)">7.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.2),10)">9.1</value>
+	</variable>
+	
+	<variable name="AudioChannels.3">
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),1)">1.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),2)">2.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),4)">3.1/4.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),5)">4.1/5.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),6)">5.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),7)">6.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),8)">7.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.3),10)">9.1</value>
+	</variable>
+	
+	<variable name="AudioChannels.4">
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),1)">1.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),2)">2.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),4)">3.1/4.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),5)">4.1/5.0</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),6)">5.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),7)">6.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),8)">7.1</value>
+		<value condition="Integer.IsEqual(ListItem.Property(AudioChannels.4),10)">9.1</value>
+	</variable>
 
 		<!-- Audio Codec labels -->
 	<variable name="Audio">
@@ -917,11 +966,101 @@
 		<value condition="String.IsEqual(VideoPlayer.AudioCodec,wma) | String.IsEqual(VideoPlayer.AudioCodec,wmapro) | String.IsEqual(VideoPlayer.AudioCodec,wmav2)">WMA</value>
 		<value>$INFO[VideoPlayer.AudioCodec,[UPPERCASE],[/UPPERCASE]]</value>
 	</variable>
+	
+	<variable name="AudioCodec.1">
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1).1),aac) | String.IsEqual(ListItem.Property(AudioCodec.1),aac_latm)">AAC</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),aif) | String.IsEqual(ListItem.Property(AudioCodec.1),aiff)">AIFF</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),alac)">Apple</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),cdda)">Audio-CD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),dca) | String.IsEqual(ListItem.Property(AudioCodec.1),dts)">DTS</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),dolbydigital)">Dolby Digital</value>
+		<value condition="String.StartsWith(ListItem.Property(AudioCodec.1),dsd)">DSD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),dtshd_ma) | String.IsEqual(ListItem.Property(AudioCodec.1),dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),mp3float)">MP3</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),opus)">Opus</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),pcm) | String.IsEqual(ListItem.Property(AudioCodec.1),pcm_bluray) | String.IsEqual(ListItem.Property(AudioCodec.1),pcm_s16le) | String.IsEqual(ListItem.Property(AudioCodec.1),pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),wavpack)">WAVP</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.1),wma) | String.IsEqual(ListItem.Property(AudioCodec.1),wmapro) | String.IsEqual(ListItem.Property(AudioCodec.1),wmav2)">WMA</value>
+		<value>$INFO[ListItem.Property(AudioCodec.1),[UPPERCASE],[/UPPERCASE]]</value>
+	</variable>
+	
+	<variable name="AudioCodec.2">
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2).1),aac) | String.IsEqual(ListItem.Property(AudioCodec.2),aac_latm)">AAC</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),aif) | String.IsEqual(ListItem.Property(AudioCodec.2),aiff)">AIFF</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),alac)">Apple</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),cdda)">Audio-CD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),dca) | String.IsEqual(ListItem.Property(AudioCodec.2),dts)">DTS</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),dolbydigital)">Dolby Digital</value>
+		<value condition="String.StartsWith(ListItem.Property(AudioCodec.2),dsd)">DSD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),dtshd_ma) | String.IsEqual(ListItem.Property(AudioCodec.2),dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),mp3float)">MP3</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),opus)">Opus</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),pcm) | String.IsEqual(ListItem.Property(AudioCodec.2),pcm_bluray) | String.IsEqual(ListItem.Property(AudioCodec.2),pcm_s16le) | String.IsEqual(ListItem.Property(AudioCodec.2),pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),wavpack)">WAVP</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.2),wma) | String.IsEqual(ListItem.Property(AudioCodec.2),wmapro) | String.IsEqual(ListItem.Property(AudioCodec.2),wmav2)">WMA</value>
+		<value>$INFO[ListItem.Property(AudioCodec.2),[UPPERCASE],[/UPPERCASE]]</value>
+	</variable>
+	
+	<variable name="AudioCodec.3">
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3).1),aac) | String.IsEqual(ListItem.Property(AudioCodec.3),aac_latm)">AAC</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),aif) | String.IsEqual(ListItem.Property(AudioCodec.3),aiff)">AIFF</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),alac)">Apple</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),cdda)">Audio-CD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),dca) | String.IsEqual(ListItem.Property(AudioCodec.3),dts)">DTS</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),dolbydigital)">Dolby Digital</value>
+		<value condition="String.StartsWith(ListItem.Property(AudioCodec.3),dsd)">DSD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),dtshd_ma) | String.IsEqual(ListItem.Property(AudioCodec.3),dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),mp3float)">MP3</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),opus)">Opus</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),pcm) | String.IsEqual(ListItem.Property(AudioCodec.3),pcm_bluray) | String.IsEqual(ListItem.Property(AudioCodec.3),pcm_s16le) | String.IsEqual(ListItem.Property(AudioCodec.3),pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),wavpack)">WAVP</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.3),wma) | String.IsEqual(ListItem.Property(AudioCodec.3),wmapro) | String.IsEqual(ListItem.Property(AudioCodec.3),wmav2)">WMA</value>
+		<value>$INFO[ListItem.Property(AudioCodec.3),[UPPERCASE],[/UPPERCASE]]</value>
+	</variable>
+	
+	<variable name="AudioCodec.4">
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4).1),aac) | String.IsEqual(ListItem.Property(AudioCodec.4),aac_latm)">AAC</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),ac3)">Dolby Digital</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),aif) | String.IsEqual(ListItem.Property(AudioCodec.4),aiff)">AIFF</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),alac)">Apple</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),cdda)">Audio-CD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),dca) | String.IsEqual(ListItem.Property(AudioCodec.4),dts)">DTS</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),dolbydigital)">Dolby Digital</value>
+		<value condition="String.StartsWith(ListItem.Property(AudioCodec.4),dsd)">DSD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),dtshd_hra)">DTS-HD HRA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),dtshd_ma) | String.IsEqual(ListItem.Property(AudioCodec.4),dtsma)">DTS-HD MA</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),eac3)">Dolby Digital+</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),mp3float)">MP3</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),opus)">Opus</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),pcm) | String.IsEqual(ListItem.Property(AudioCodec.4),pcm_bluray) | String.IsEqual(ListItem.Property(AudioCodec.4),pcm_s16le) | String.IsEqual(ListItem.Property(AudioCodec.4),pcm_s24le)">PCM</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),truehd)">Dolby TrueHD</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),vorbis)">Vorbis</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),wavpack)">WAVP</value>
+		<value condition="String.IsEqual(ListItem.Property(AudioCodec.4),wma) | String.IsEqual(ListItem.Property(AudioCodec.4),wmapro) | String.IsEqual(ListItem.Property(AudioCodec.4),wmav2)">WMA</value>
+		<value>$INFO[ListItem.Property(AudioCodec.4),[UPPERCASE],[/UPPERCASE]]</value>
+	</variable>
 
 		<!-- Audio/Video Duration -->
 	<variable name="Duration">
 		<value condition="Container.Content(songs)">$INFO[ListItem.Duration,, ]</value>
-		<value>$INFO[ListItem.Duration(mins),, $LOCALIZE[12391]]</value>
+		<value condition="String.IsEqual(Skin.String(videodurationformat),Hours and minutes) + !Integer.IsEqual(ListItem.Duration(h),0)">$INFO[ListItem.Duration(h)]h $INFO[ListItem.Duration(m)]m</value>
+		<value condition="String.IsEqual(Skin.String(videodurationformat),Hours and minutes) + Integer.IsEqual(ListItem.Duration(h),0)">$INFO[ListItem.Duration(mins),, $LOCALIZE[12391]]</value>
+		<value condition="String.IsEqual(Skin.String(videodurationformat),Minutes)">$INFO[ListItem.Duration(mins),, $LOCALIZE[12391]]</value>
 	</variable>
 	
 	<!-- Audio language labels -->

--- a/16x9/Viewtype51.xml
+++ b/16x9/Viewtype51.xml
@@ -110,12 +110,14 @@
 					<width>450</width>
 					<height>190</height>
 					<control type="textbox">
+						<align>left</align>
 						<label>$VAR[Plot]</label>
 						<textcolor>$VAR[TextColor1]</textcolor>
 						<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>
 						<visible>Skin.String(PlotFont,S) | Skin.String(PlotFont,S light)</visible>
 					</control>
 					<control type="textbox">
+						<align>left</align>
 						<font>Font30</font>
 						<label>$VAR[Plot]</label>
 						<textcolor>$VAR[TextColor1]</textcolor>
@@ -123,6 +125,7 @@
 						<visible>Skin.String(PlotFont,M) | Skin.String(PlotFont,M light)</visible>
 					</control>
 					<control type="textbox">
+						<align>left</align>
 						<font>Font33</font>
 						<label>$VAR[Plot]</label>
 						<textcolor>$VAR[TextColor1]</textcolor>

--- a/16x9/Viewtype511.xml
+++ b/16x9/Viewtype511.xml
@@ -54,12 +54,14 @@
 				<height>190</height>
 				<visible>Container.Content(movies) | Container.Content(tvshows)</visible>
 				<control type="textbox">
+					<align>left</align>
 					<label>$VAR[Plot]</label>
 					<textcolor>$VAR[TextColor1]</textcolor>
 					<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>
 					<visible>Skin.String(PlotFont,S) | Skin.String(PlotFont,S light)</visible>
 				</control>
 				<control type="textbox">
+					<align>left</align>
 					<font>Font30</font>
 					<label>$VAR[Plot]</label>
 					<textcolor>$VAR[TextColor1]</textcolor>
@@ -67,6 +69,7 @@
 					<visible>Skin.String(PlotFont,M) | Skin.String(PlotFont,M light)</visible>
 				</control>
 				<control type="textbox">
+					<align>left</align>
 					<font>Font33</font>
 					<label>$VAR[Plot]</label>
 					<textcolor>$VAR[TextColor1]</textcolor>

--- a/16x9/Viewtype531.xml
+++ b/16x9/Viewtype531.xml
@@ -62,12 +62,14 @@
 					<height>420</height>
 					<visible>!String.IsEmpty(ListItem.Plot) | !String.IsEmpty(ListItem.PlotOutline)</visible>
 					<control type="textbox">
+						<align>left</align>
 						<label>$VAR[Plot]</label>
 						<textcolor>$VAR[TextColor1]</textcolor>
 						<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>
 						<visible>Skin.String(PlotFont,S) | Skin.String(PlotFont,S light)</visible>
 					</control>
 					<control type="textbox">
+						<align>left</align>
 						<font>Font30</font>
 						<label>$VAR[Plot]</label>
 						<textcolor>$VAR[TextColor1]</textcolor>
@@ -75,6 +77,7 @@
 						<visible>Skin.String(PlotFont,M) | Skin.String(PlotFont,M light)</visible>
 					</control>
 					<control type="textbox">
+						<align>left</align>
 						<font>Font33</font>
 						<label>$VAR[Plot]</label>
 						<textcolor>$VAR[TextColor1]</textcolor>
@@ -89,19 +92,19 @@
 			<!-- Thumbs -->
 			<control type="panel" id="531">
 				<left>750</left>
-				<centertop>50%</centertop>
+				<top>175</top>
 				<width>1020</width>
-				<height>720</height>
-				<onleft>60</onleft>
+				<height>666</height>
+				<onleft>69</onleft>
 				<onup>531</onup>
 				<ondown>531</ondown>
-				<pagecontrol>60</pagecontrol>
+				<pagecontrol>69</pagecontrol>
 				<preloaditems>4</preloaditems>
-				<viewtype label="$LOCALIZE[31116]">list</viewtype>
+				<viewtype label="$LOCALIZE[31133]">list</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
 				<visible>Container.Content(movies) | Container.Content(tvshows)</visible>
 
-				<itemlayout width="170" height="240">
+				<itemlayout width="255" height="333">
 					<!-- Image - Movies -->
 					<include content="image-531">
 						<param name="fallback">DefaultMovie.png</param>
@@ -116,10 +119,10 @@
 					</include>
 					<!-- Collection -->
 					<control type="group">
-						<left>17</left>
+						<left>44</left>
 						<bottom>10</bottom>
-						<width>61</width>
-						<height>61</height>
+						<width>63</width>
+						<height>63</height>
 						<visible>ListItem.IsCollection</visible>
 						<control type="image">
 							<texture background="true">views/OverlayCornerLeft.png</texture>
@@ -132,10 +135,10 @@
 					</control>
 					<!-- Watched status -->
 					<control type="group">
-						<right>16</right>
+						<right>44</right>
 						<bottom>10</bottom>
-						<width>61</width>
-						<height>61</height>
+						<width>63</width>
+						<height>63</height>
 						<visible>!ListItem.IsCollection</visible>
 						<control type="image">
 							<texture background="true">views/OverlayCornerRight.png</texture>
@@ -149,10 +152,10 @@
 					</control>
 				</itemlayout>
 
-				<focusedlayout width="170" height="240">
+				<focusedlayout width="255" height="333">
 					<control type="group">
-						<animation effect="zoom" start="87" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
-						<animation effect="zoom" start="100" end="87" center="auto" time="30" tween="linear" reversible="false">Unfocus</animation>
+						<animation effect="zoom" start="88" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+						<animation effect="zoom" start="100" end="88" center="auto" time="30" tween="linear" reversible="false">Unfocus</animation>
 						<!-- Image - Movies -->
 						<include content="image-531-focused">
 							<param name="fallback">DefaultMovie.png</param>
@@ -165,7 +168,7 @@
 						</include>
 						<!-- Collection -->
 						<control type="group">
-							<left>6</left>
+							<left>29</left>
 							<bottom>0</bottom>
 							<width>72</width>
 							<height>72</height>
@@ -179,7 +182,7 @@
 						</control>
 						<!-- Watched status -->
 						<control type="group">
-							<right>6</right>
+							<right>29</right>
 							<bottom>0</bottom>
 							<width>72</width>
 							<height>72</height>
@@ -207,9 +210,9 @@
 		<definition>
 			<control type="image">
 				<bottom>10</bottom>
-				<left>17</left>
-				<width>137</width>
-				<height>208</height>
+				<left>44</left>
+				<width>182</width>
+				<height>288</height>
 				<colordiffuse>$PARAM[colordiffuse]</colordiffuse>
 				<texture fallback="$PARAM[fallback]" background="true">$VAR[mediaImages]</texture>
 				<aspectratio align="center" aligny="bottom">keep</aspectratio>
@@ -225,9 +228,9 @@
 		<definition>
 			<control type="image">
 				<bottom>0</bottom>
-				<left>6</left>
-				<width>158</width>
-				<height>240</height>
+				<left>29</left>
+				<width>212</width>
+				<height>333</height>
 				<colordiffuse>$PARAM[colordiffuse]</colordiffuse>
 				<texture fallback="$PARAM[fallback]" background="true">$VAR[mediaImages]</texture>
 				<aspectratio align="center" aligny="bottom">keep</aspectratio>

--- a/16x9/Viewtype534.xml
+++ b/16x9/Viewtype534.xml
@@ -1,128 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 
-	<include name="Viewtype533">
+	<include name="Viewtype534">
 
 		<control type="group">
-			<visible>Control.IsVisible(533)</visible>
+			<visible>Control.IsVisible(534)</visible>
 
-			<!-- Movie/TV show info -->
-			<control type="group">
-				<left>120</left>
-				<top>190</top>
-				<visible>Container.Content(movies) | Container.Content(tvshows)</visible>
-				
-				<!-- Title -->
-				<control type="fadelabel">
-					<left>0</left>
-					<top>52</top>
-					<width>450</width>
-					<height>45</height>
-					<font>Font42</font>
-					<align>center</align>
-					<textcolor>$VAR[TextColor1]</textcolor>
-					<label>$VAR[Label1]</label>
-					<visible>!String.IsEmpty(ListItem.Plot) | !String.IsEmpty(ListItem.PlotOutline)</visible>
-				</control>
-				
-				<!-- Title -->
-				<control type="fadelabel">
-					<left>0</left>
-					<top>350</top>
-					<width>450</width>
-					<height>45</height>
-					<font>Font42</font>
-					<align>center</align>
-					<textcolor>$VAR[TextColor1]</textcolor>
-					<label>$VAR[Label1]</label>
-					<pauseatend>5000</pauseatend>
-					<visible>String.IsEmpty(ListItem.Plot) + String.IsEmpty(ListItem.PlotOutline)</visible>
-				</control>
-
-				<!-- Details -->
-				<control type="fadelabel">
-					<left>0</left>
-					<top>131</top>
-					<width>450</width>
-					<height>54</height>
-					<font>Font27</font>
-					<align>center</align>
-					<aligny>top</aligny>
-					<label>$VAR[Label2]</label>
-					<textcolor>$VAR[TextColor1]</textcolor>
-					<pauseatend>5000</pauseatend>
-					<visible>!String.IsEmpty(ListItem.Plot) | !String.IsEmpty(ListItem.PlotOutline)</visible>
-				</control>
-				
-				<!-- Plot -->
-				<control type="group">
-					<left>0</left>
-					<top>194</top>
-					<width>450</width>
-					<height>420</height>
-					<visible>!String.IsEmpty(ListItem.Plot) | !String.IsEmpty(ListItem.PlotOutline)</visible>
-					<control type="textbox">
-						<align>left</align>
-						<label>$VAR[Plot]</label>
-						<textcolor>$VAR[TextColor1]</textcolor>
-						<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>
-						<visible>Skin.String(PlotFont,S) | Skin.String(PlotFont,S light)</visible>
-					</control>
-					<control type="textbox">
-						<align>left</align>
-						<font>Font30</font>
-						<label>$VAR[Plot]</label>
-						<textcolor>$VAR[TextColor1]</textcolor>
-						<autoscroll delay="5000" time="1300" repeat="10000">true</autoscroll>
-						<visible>Skin.String(PlotFont,M) | Skin.String(PlotFont,M light)</visible>
-					</control>
-					<control type="textbox">
-						<align>left</align>
-						<font>Font33</font>
-						<label>$VAR[Plot]</label>
-						<textcolor>$VAR[TextColor1]</textcolor>
-						<autoscroll delay="5000" time="1200" repeat="10000">true</autoscroll>
-						<visible>Skin.String(PlotFont,L) | Skin.String(PlotFont,XL) | Skin.String(PlotFont,L light) | Skin.String(PlotFont,XL light)</visible>
-					</control>
-				</control>
-
-			</control>
-			
-			
 			<!-- Thumbs -->
-			<control type="panel" id="533">
-				<left>750</left>
-				<centertop>50%</centertop>
-				<width>1020</width>
-				<height>720</height>
-				<onleft>60</onleft>
-				<onup>533</onup>
-				<ondown>533</ondown>
-				<pagecontrol>60</pagecontrol>
+			<control type="panel" id="534">
+				<left>150</left>
+				<top>420</top>
+				<width>1620</width>
+				<height>400</height>
+				<onleft>67</onleft>
+				<onup>534</onup>
+				<ondown>534</ondown>
+				<pagecontrol>67</pagecontrol>
 				<preloaditems>4</preloaditems>
-				<viewtype label="$LOCALIZE[31116]">list</viewtype>
+				<viewtype label="$LOCALIZE[31113]">icon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(movies) | Container.Content(tvshows)</visible>
+				<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 
-				<itemlayout width="170" height="240">
+				<itemlayout width="162" height="200">
 					<!-- Image - Movies -->
-					<include content="image-533">
+					<include content="image-534">
 						<param name="fallback">DefaultMovie.png</param>
 						<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
 						<param name="visible">Container.Content(movies)</param>
 					</include>
 					<!-- Image - TV -->
-					<include content="image-533">
+					<include content="image-534">
 						<param name="fallback">DefaultTVShows.png</param>
 						<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
 						<param name="visible">!Container.Content(movies)</param>
 					</include>
 					<!-- Collection -->
 					<control type="group">
-						<left>17</left>
-						<bottom>10</bottom>
-						<width>61</width>
-						<height>61</height>
+						<left>24</left>
+						<bottom>6</bottom>
+						<width>51</width>
+						<height>51</height>
 						<visible>ListItem.IsCollection</visible>
 						<control type="image">
 							<texture background="true">views/OverlayCornerLeft.png</texture>
@@ -135,10 +52,10 @@
 					</control>
 					<!-- Watched status -->
 					<control type="group">
-						<right>16</right>
-						<bottom>10</bottom>
-						<width>61</width>
-						<height>61</height>
+						<right>24</right>
+						<bottom>6</bottom>
+						<width>51</width>
+						<height>51</height>
 						<visible>!ListItem.IsCollection</visible>
 						<control type="image">
 							<texture background="true">views/OverlayCornerRight.png</texture>
@@ -152,26 +69,26 @@
 					</control>
 				</itemlayout>
 
-				<focusedlayout width="170" height="240">
+				<focusedlayout width="162" height="200">
 					<control type="group">
 						<animation effect="zoom" start="87" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 						<animation effect="zoom" start="100" end="87" center="auto" time="30" tween="linear" reversible="false">Unfocus</animation>
 						<!-- Image - Movies -->
-						<include content="image-533-focused">
+						<include content="image-534-focused">
 							<param name="fallback">DefaultMovie.png</param>
 							<param name="visible">Container.Content(movies)</param>
 						</include>
 						<!-- Image - TV -->
-						<include content="image-533-focused">
+						<include content="image-534-focused">
 							<param name="fallback">DefaultTVShows.png</param>
 							<param name="visible">!Container.Content(movies)</param>
 						</include>
 						<!-- Collection -->
 						<control type="group">
-							<left>6</left>
+							<left>15</left>
 							<bottom>0</bottom>
-							<width>72</width>
-							<height>72</height>
+							<width>60</width>
+							<height>60</height>
 							<visible>ListItem.IsCollection</visible>
 							<control type="image">
 								<texture background="true">views/OverlayCornerLeft.png</texture>
@@ -182,10 +99,10 @@
 						</control>
 						<!-- Watched status -->
 						<control type="group">
-							<right>6</right>
+							<right>15</right>
 							<bottom>0</bottom>
-							<width>72</width>
-							<height>72</height>
+							<width>60</width>
+							<height>60</height>
 							<visible>!ListItem.IsCollection</visible>
 							<control type="image">
 								<texture background="true">views/OverlayCornerRight.png</texture>
@@ -199,20 +116,58 @@
 				</focusedlayout>
 			</control>
 
+			<control type="group">
+				<!-- <centerleft>75%</centerleft> -->
+				<left>410</left>
+				<top>850</top>
+				<width>920</width>
+				<height>100</height>
+
+				<!-- Title -->
+				<control type="fadelabel">
+					<left>90</left>
+					<top>0</top>
+					<width>920</width>
+					<height>72</height>
+					<font>Font72</font>
+					<align>center</align>
+					<textcolor>$VAR[TextColor1]</textcolor>
+					<label>$VAR[Label1]</label>
+					<pauseatend>5000</pauseatend>
+					<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(534)">Conditional</animation>
+				</control>
+
+				<!-- Details -->
+				<control type="fadelabel">
+					<left>90</left>
+					<top>88</top>
+					<width>920</width>
+					<height>54</height>
+					<font>Font27</font>
+					<align>center</align>
+					<aligny>top</aligny>
+					<label>$VAR[Label2]</label>
+					<textcolor>$VAR[TextColor1]</textcolor>
+					<pauseatend>5000</pauseatend>
+					<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(534)">Conditional</animation>
+				</control>
+
+			</control>
+
 		</control>
 
 	</include>
 
-	<include name="image-533">
+	<include name="image-534">
 		<param name="fallback">DefaultVideos.png</param>
 		<param name="colordiffuse">FFFFFFFF</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">
-				<bottom>10</bottom>
-				<left>17</left>
-				<width>137</width>
-				<height>208</height>
+				<bottom>6</bottom>
+				<left>24</left>
+				<width>114</width>
+				<height>173</height>
 				<colordiffuse>$PARAM[colordiffuse]</colordiffuse>
 				<texture fallback="$PARAM[fallback]" background="true">$VAR[mediaImages]</texture>
 				<aspectratio align="center" aligny="bottom">keep</aspectratio>
@@ -221,16 +176,16 @@
 		</definition>
 	</include>
 	
-	<include name="image-533-focused">
+	<include name="image-534-focused">
 		<param name="fallback">DefaultVideos.png</param>
 		<param name="colordiffuse">FFFFFFFF</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">
 				<bottom>0</bottom>
-				<left>6</left>
-				<width>158</width>
-				<height>240</height>
+				<left>15</left>
+				<width>132</width>
+				<height>200</height>
 				<colordiffuse>$PARAM[colordiffuse]</colordiffuse>
 				<texture fallback="$PARAM[fallback]" background="true">$VAR[mediaImages]</texture>
 				<aspectratio align="center" aligny="bottom">keep</aspectratio>

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,627 +1,108 @@
 **Changes**
 
 _New_
-- add new v18 subtitle settings OSD during fullscreen video playback
-- add new games section to match v18 requirements
-- add new resolution select button/dialog in video player
-- add player icon to now playing dialog
-- add new dependency button in addon info dialog to match v18 requirements
-- new color options (color sets, background gradients, adjustable opacity)
-- add PVR channel number input dialog
-- add PVR timeshift status dialog
-- add welcome dialog on non-OSMC devices
-- add director button to video info dialog
-- add new views (wide low, wall small, wall low, wall info, list info)
-- add new sub-menu indicator icon
-- add "Random TV shows" widget as new standard for TV shows home menu entry
-- add new dialog navigation indicators
-- add ratings toggle for IMDb, Metacritic, Rotten Tomatoes and TVDb
 - add new video player OSD settings (show OSD after beginning of playback and before end of playback)
+- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)
+- add new wall info view (based on wall view)
+- add new adjust representation of video duration setting
 
 _Improved_
-- adjust syntax, values, labels and infobools to match v18 requirements
-- adjust PVR section to match v18 requirements
-- highlighting color now adjusts according to text color
-- streamline OSD animations
-- add missing adjustable plot fonts
-- let favourites dialog behave like a normal window
-- add file path and name to refresh button in video info dialog
-- add song/album year to music player
-- add wide list as music view
-- add music OSD album art size switch
-- adjust widget headings to always show and adjust animations to match widget animations
-- add option to change widget labels
+- add audio information to video info dialog
 
 _Fixed_
-- show proper game widget title when not using skinshortcuts script
-- highlighting is now more consistent
-- fix current position/time remaining and current time/end time for PVR playback
-- hide deprecated previous/next channel buttons in PVR playback OSD
-- fix background of subtitle settings window
-- fix layout of PVR playback dialogs
-- fix dialog list navigation
-- change font size of media tags to prevent overlap with titles/details
 - only offer rip CD feature when an audio CD is present
 
-**Changelog v18.0.0**
-
-_Adjust syntax, values, labels and infobools to match v18 requirements:_
-- remove hyphen as none value
-- remove <onclick>noop</onclick> (not needed anymore)
-
-_Adjust PVR section to match v18 requirements:_
-- add views 50 to PVR windows (otherwise they're empty)
-- remove deprecated views from PVR guid (everything except the EPG guide)
-- remove NextChannelGroup action of guide and channel button
-- hide selection buttons for windows currently open in PVR context menu
-
-_Add new subtitle selection to match v18 requirements:_
-- move subtitle settings one left on fullscreen video OSD
-- rework link to new osdsubtitlesettings window
-
-_Add new games section to match v18 requirements:_
-- add GameOSD window
-- add MyGames window
-- add games to home menu
-- add games settings category
-- add game view mode and game filter dialogs
-- add game widget
-- add game control types
-- fix gamecontroller dialog
-
-_Add new resolution select dialog in video player to match v18 requirements:_
-- add new button for resolution select dialog in video OSD
-
-
-_Add new dependency button in addon info dialog to match v18 requirements:_
-- add new dependencies button in addon info dialog
+**Changelog v18.0.1**
 
 Addon.Browser.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add onload to show welcome screen after installing the skin from zip
-- add submenu indicator
 - add onloads for new OSD settings
-
-Custom_Backup.xml:
-- add new dialog prompt when skin helper service skin backup script is disabled
-
-Custom_Cache_Progress.xml:
-- replace colors by new color variables
-
-Custom_Customization.xml:
-- add new dialog prompt when skin helper script is disabled
-
-Custom_Disabled_Add-on.xml:
-- add new dialog prompt when supported skin add-ons are disabled
-
-Custom_Welcome.xml
-- add new Welcome dialog for non-OSMC devices
-
-Defaults.xml:
-- replace colors by new color variables
-- replace focus variable for button highlighting
+- add onload for new video duration setting
 
 DialogAddonInfo.xml:
-- replace colors by new color variables
-
-DialogAddonSettings.xml
-- change grouplist id="9" to id="3"
-- change button id="13" to id="10"
-- change grouplist id="2" to id="5"
-- change button id="3" to id="7"
-- change radio button id="4" to id="8"
-- change spincontrolex id="5" to id="9"
-- change image id="6" to id="11"
-- add edit id="12"
-- change sliderex id="8" to id="13"
-- change label id="7" to id="14"
-- change button id="10" to id="28"
-- change button id="11" to id="29"
-- change button id="12" to id="30"
-- replace colors by new color variables
-- fix ondown, onup and onleft of lists
-- add new navigation indicator
-
-DialogBusy.xml:
-- replace colors by new color variables
-
-DialogButtonMenu.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-
-DialogConfirm.xml:
-- replace colors by new color variables
-
-DialogContextMenu.xml:
-- enable controls cycling from top to bottom and bottom to top in context menu
-- replace focus variable for button highlighting
-- rename DialogPVRGuideOSD.xml to DialogPVRChannelGuide.xml
-- replace infolabel ListItem.ChannelNumber by ListItem.ChannelNumberLabel
-- replace infolabel VideoPlayer.ChannelNumber by VideoPlayer.ChannelNumberLabel
-- replace duration labels by new duration variable
-- replace IsEmpty() by String.IsEmpty()
-- replace StringCompare() by String.IsEqual()
-- replace IntegerGreaterThan() by Integer.IsGreater()
-- add all/watched/unwatched toggle button to PVR recordings
-- replace localize values under the skin settings section with new values (Background label)
-- replace Player.Recording infolabel by PVR.IsRecordingPlayingChannel
-- replace PlayerControl(Record) command by PVR.ToggleRecordPlayingChannel
-- replace Player.CanRecord infolabel by PVR.CanRecordPlayingChannel
-- replace Movies, TV Show and Music home menu links
-
-DialogExtendedProgressBar.xml:
-- replace colors by new color variables
-
-DialogFavourites.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- change behaviour to mimic normal window behaviour (not dialog behaviour)
-- fix onup/ondown behaviour
-- add submenu indicator
+- fix syntax
 
 DialogFullScreenInfo.xml:
-- replace colors by new color variables
-- turn title and TV channel name/number labels into fadelabels
-- add PVR channel number input dialog
-- add PVR timeshift status dialog
-- fix current position/time remaining for PVR playback
-- add PVR progress bar
-- fix current time/end time for PVR playback
 - remove info dialog
 
-DialogGameControllers.xml:
-- replace colors by new color variables
-- fix ondown and onup of lists
-- add new navigation indicator
-
-DialogKeyboard.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-
-DialogMediaSources.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown and onleft of lists
-
-DialogMusicInfo.xml:
-- replace colors by new color variables
-- remove unused tracks/discography list (id 50)
-
-DialogNumeric.xml:
-- replace colors by new color variables
-
-DialogPictureInfo.xml:
-- replace colors by new color variables
-- fix ondown and onup of the list
-- add missing hightlighting
-- add new navigation indicator
-
-DialogPlayerProcessInfo.xml:
-- replace colors by new color variables
-
-DialogPVRChannelGuide.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- rework window layout
-- add adjustable plot font
-
-DialogPVRChannelManager.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown, onup, onleft and onright of lists
-- add new navigation indicator
-
-DialogPVRChannelsOSD.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- rework window layout
-- add adjustable plot font
-
-DialogPVRGroupManager.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown, onup, onleft and onright of lists
-- add new navigation indicator
-
-DialogPVRGuideSearch.xml:
-- replace colors by new color variables
-- fix onleft and onright of lists
-
-DialogPVRInfo.xml:
-- replace colors by new color variables
-
 DialogSeekBar.xml:
-- replace colors by new color variables
-- fix animations
-- add PVR channel number input dialog
-- add PVR timeshift status dialog
-- fix current position/time remaining for PVR playback
-- add PVR progress bar
-- fix current time/end time for PVR playback
 - remove PVR channel number input dialog
 
-DialogSelect.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown and onup of lists
-- add new navigation indicator
-
-DialogSubtitles.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown, onup and onleft of lists
-- add new navigation indicator
-
 DialogVideoInfo.xml:
-- replace colors by new color variables
-- add director button
-- add file path and name to refresh button
-- fix ondown, onup and onleft of lists
-- add scrollbar to actor list
-- add new navigation indicator
-- add new ratings toggle for IMDb, Metacritic, Rotten Tomatoes and TVDb
-
-EventLog.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add submenu indicator include
-
-FileBrowser.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown and onup of lists
-- add new navigation indicator
-
-FileManager.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix ondown and onup of lists
-
-Font.xml:
-- change systeminfo font from LiberationMono-Regular.ttf to SourceSansPro-Regular.tff (default font)
-- add new font 29 for media tags
-
-GameOSD.xml:
-- replace colors by new color variables
+- add onload and onunload for new second info screen
+- fix conditional visibility of poster/actor images, info list and cast list for use with new second info screen
+- fix positioning of actor image
+- add audio information
+- adjust plot text box and make it show plot outline (shorter and no spoilers)
+- fix positioning of cast list
+- fix positioning of cast list scrollbar
+- add second info screen (with extended rating, audio and subtitle information and bigger plot text box)
+- add conditional visiblity to only show play and return button in second info screen
+- add extended info button
 
 Home.xml:
-- add new onloads
-- replace colors by new color variables
-- add onload to show welcome screen when Home screen first shows up
 - add onloads for new OSD settings
-
-Include_DialogSettings.xml:
-- replace colors by new color variables
-- fix ondown, onup, onleft and onright of lists
-- add new navigation indicator include
-
-Include_Home_OSMC.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- change submenu animations for new submenu indicator behaviour
-- add submenu indicator
-- add scrolling to focused main menu list labels
-- remove reloading indicator for widgets
+- add onload for new video duration setting
 
 Includes.xml:
-- add player icon to now playing dialog
-- rework Overlay include
-- remove Custom color Overlay include
-- replace colors by new color variables
-- add new include files
-- fix position and size of duration icon
-- prevent size from being shown when file is 0B on all platforms
-- add new SubmenuIndicator include
-- fix duration icon of media flags
-- add new dialogButtonIndicator include
-- change font of media tags to prevent overlap in certain views
-
-Includes_Widgets.xml:
-- replace colors by new color variables
-- always show widget headings (when focused and non-focused)
-- add reload indicator to widget headings
-- change widget heading animations to match widget animations
+- add new include file for new view
 
 LoginScreen.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix onright of the list
-- add submenu indicator
 - add onloads for new OSD settings
-
-MusicOSD.xml:
-- replace colors by new color variables
-
-MusicVisualisation.xml:
-- replace colors by new color variables
-- add album year
-- add bigger cover art
-
-MyGames.xml:
-- replace colors by new color variables
-- add submenu indicator include
-
-MyMusicNav.xml:
-- replace colors by new color variables
-- add wide list to music
-- add new scrollbar for new view
-- add submenu indicator include
-- add clean library option to sub-menu
-
-MyMusicPlaylistEditor.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- fix onup and ondown of button list
-
-MyPics.xml:
-- replace colors by new color variables
-- add submenu indicator include
-
-MyPlaylist.xml:
-- replace colors by new color variables
-- add submenu indicator include
-
-MyPrograms.xml:
-- replace colors by new color variables
-- add submenu indicator include
-
-MyPVRChannels.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add adjustable plot font
-- add submenu indicator include
-
-MyPVRGuide.xml:
-- replace colors by new color variables
-- remove scrollbar
-- add highlighting
-- add adjustable plot font
-- add submenu indicator
-
-MyPVRRecordings.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add adjustable plot font
-- add submenu indicator include
-
-MyPVRSearch.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add adjustable plot font
-- add submenu indicator include
-
-MyPVRTimers.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add submenu indicator include
+- add onload for new video duration setting
 
 MyVideoNav.xml:
-- replace colors by new color variables
-- add new wide list low view to video
-- add new wall low view to video
-- add new wall small view to video
-- add new scrollbars for new views
-- add submenu indicator include
-- add new list info view to video
-- add new wall info view to video
-- add clean library option to sub-menu
-
-MyWeather.xml:
-- replace colors by new color variables
-- add submenu indicator include
-
-PlayerControls.xml:
-- replace colors by new color variables
-
-script-nextup-notification-NextUpInfo.xml:
-- replace focus variable for button highlighting
-- replace colors by new color variables
-
-script-nextup-notification-StillWatchingInfo.xml:
-- replace focus variable for button highlighting
-- replace colors by new color variables
-
-script-skin_helper_service-ColorPicker.xml:
-- replace colors by new color variables
-- fix ondown, onup, onright and onleft of lists
-- add new navigation indicator include
+- add new view 534 and rename 531, 532 and 533
+- add new scrollbar for new wall info view (old wall info is now wall small info)
 
 script.skinshortcuts-static-xml:
-- hack game widget to show proper widget title
-- replace colors by new color variables
-- change standard TV shows widget to "Random TV shows"
-- adjust game widget heading to match new widget headings
-- remove special non-focused heading
-- add location to weather widget heading
 - fix conditional visibility for Rip CD feature (only show for audio CDs)
 
-script-skinshortcuts.xml:
-- replace colors by new color variables
-- fix ondown, onup, onright and onleft of lists
-- add new navigation indicator include
-- add option to change widget labels
-
-Settings.xml:
-- replace colors by new color variables
-
 SettingsCategory.xml:
-- replace colors by new color variables
-- replace focus variable for button highlighting
-- add onload to show welcome screen after activating the skin from settings
-- add submenu indicator
-
-SettingsProfile.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- replace focus variable for button highlighting
-- add submenu indicator
-
-SettingsScreenCalibration.xml:
-- replace colors by new color variables
-
-SettingsSystemInfo.xml:
-- replace colors by new color variables
-- replace focus variable for button highlighting
-- add submenu indicator
+- add missing onloads
 
 SkinSettings.xml:
-- add new onloads
-- replace colors by new color variables
-- add new color category
-- add page indicators to new color category
-- rework default background image option
-- remove old background and overlay color options
-- add skin settings backup and restore option
-- fix onup and ondown for addons submenu
-- add new adjust music OSD album art size option to advanced skin settings
-- un-comment skinhelper widgets button
-- add page indicators to longer add-ons category
-- rework add-ons category
-- comment out next-up notification add-on (it's broken)
 - add onloads for new OSD settings
 - add new OSD settings section
-
-SmartPlaylistEditor.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- replace focus variable for button highlighting
-- fix onup and ondown of the list
-
-SmartPlaylistRule.xml:
-- replace colors by new color variables
+- add onload for new video duration setting
+- add new adjust representation of video duration setting
 
 Variables.xml:
-- add new color variables
-- add OSMCBackgroundOverlayName variable for reworked default background image option
-- remove focus variable
-- add new buttonfocus variable
-- replace colors by new color variables
-- change PVR video player info variable
-- add new PVRCHannelIconDialogOSD variable
-- add new PlotDialogGuide variable
-- add new PVRDescriptionDialogGuide variable
-- fix StatusOverlay and StatusOverlayWide variables for resumable items
-- fix Duration variable formatting used for media flags
-- un-comment addon-skinhelperwidgets variable
 - update VideoPlayerPlot, VideoPlayerTitle and VideoPlayerNext variables for new OSD settings
+- add new PlotInfoDialog variable (preferring plot outline over plot for video info dialog)
+- add new AudioChannels.1-.4 variables for new second info dialog screen
+- add new AudioCodec.1-.4 variables for new second info dialog screen
+- adjust Duration variable for new video duration setting
 
 VideoFullScreen.xml:
-- replace colors by new color variables
-- add PVR timeshift status dialog
-- fix current position/time remaining for PVR playback
-- add PVR progress bar
-- fix current time/end time for PVR playback
 - add onloads for OSD settings alarm
 - adjust conditional visibility of progress bar and info dialog for new OSD settings
 - add elements formerly present in fullscreen info and seekbar dialog
 
-VideoOSD.xml:
-- replace colors by new color variables
-- add PVR channel number input dialog
-- fix animations
-- add PVR timeshift status dialog
-- fix current position/time remaining for PVR playback
-- add PVR progress bar
-- fix current time/end time for PVR playback
-- hide deprecated previous/next channel buttons
-
-VideoOSDBookmarks.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-
-Viewtype50.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- remove onright submenu
-
 Viewtype51.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- add adjustable plot font
-- remove onright submenu
-
-Viewtype52.xml:
-- replace colors by new color variables
-- add albums and artists as allowed container content to conditional visibility
-- add required image thumbs for artists and albums
-- remove onup submenu
-
-Viewtype53.xml:
-- replace colors by new color variables
-- remove onright submenu
-
-Viewtype54.xml:
-- replace colors by new color variables
-- fix highlighting in focusedlayout of grouplists
-- remove onright submenu
-
-Viewtype55.xml:
-- replace colors by new color variables
-- remove onright submenu
-
-Viewtype56.xml -> Viewtype521.xml:
-- new wide list low view
-- remove onup submenu
-- rename to Viewtype521
-
-Viewtype57.xml -> Viewtype533.xml:
-- new wall low view
-- remove onright submenu
-- rename to Viewtype533
-
-Viewtype58.xml -> Viewtype532.xml:
-- new wall small view
-- remove onright submenu
-- rename to Viewtype532
+- fix alignment of plot textbox
 
 Viewtype511.xml:
-- new list info view
+- fix alignment of plot textbox
 
 Viewtype531.xml:
-- new wall info view
+- fix alignment of plot textbox
+- adjust size and amount of movie poster thumbs for new wall info view
 
-last_watched_TV_shows.xsp:
-- add new "Last watched TV shows" smart playlist for widgets
+Viewtype533.xml:
+- make old wall info view new wall small info view
 
-random_artists.xsp:
-- add new "Random artists" smart playlist for widgets
-
-random_TV_shows.xsp:
-- add new "Random TV shows" smart playlist for new standard TV shows widget
-
-recent_watched_TV_shows.xsp:
-- add new "Recent TV shows" smart playlist for widgets
+Viewtype534.xml:
+- new viewtype file for old wall low view
 
 strings.po:
-- add new localizes for reworked skin settings (31052, 31097, 31107, 31108, 31109, 31110, 31111)
-- add new localizes for new views (31112, 31113, 31114)
-- add new localize for new music OSD album art size option (31115)
-- change localizes for views (31112, 31113, 31114)
-- add new localizes for new views (31116, 31117)
-- add new localize for new standard TV shows widget (31118)
-- add new localize for adjusted skin settings add-ons list (31119)
-- add new localizes for new ratings toggle (31120, 31121, 31122)
+- add new localizes for extended ratings in second video info dialog screen (31120, 31121, 31122)
 - add new localizes for new OSD settings (31123, 31124, 31125, 31126, 31127, 31128, 31129, 31130, 31131, 31132)
-
-Textures.xbt:
-- update file with new resolution select icon included
-- update file with new background gradient overlays and removed old background PNGs
-- update file with new submenu indicator icons
-- update file with new navigation indicator icons
+- change view localizes (31112, 31113, 31114, 31116, 31117)
+- add new localize for new wall info view (31133)
+- add new localize for new video duration setting (31134)
 
 341.DATA.xml:
 - fix conditional visibility for Rip CD feature (only show for audio CDs)
 
-overrides.xml:
-- simplify game home menu entry and game widget
-- change standard TV shows widget to "Random TV shows"
-- remove unused Skin helper widgets node
-
-template.xml:
-- replace colors by new color variables
-- remove special non-focused heading
-- add location to weather widget heading
-
 addon.xml:
-- bump version to 18.0.0
+- bump version to 18.0.1

--- a/addon.xml
+++ b/addon.xml
@@ -14,7 +14,7 @@
 		<platform>all</platform>
 		<summary lang="en">The default skin for OSMC</summary>
 		<description lang="en">Original skin: Andy Morton[CR]Original design: Simon Brunton[CR]Skinner: Julian Michel</description>
-		<news>[B]New[/B][CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR][CR][B]Improved[/B][CR]- add audio information to video info dialog[CR][CR][B]Fixed[/B][CR]- only offer rip CD feature when an audio CD is present</news>
+		<news>[B]New[/B][CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR]- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)[CR]- add new wall info view (based on wall view)[CR]- add new adjust representation of video duration setting[CR][CR][B]Improved[/B][CR]- add audio information to video info dialog[CR][CR][B]Fixed[/B][CR]- only offer rip CD feature when an audio CD is present</news>
 	</extension>
 	<assets>
 		<icon>icon.png</icon>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
 	id="skin.osmc"
-	version="18.0.0"
+	version="18.0.1"
 	name="OSMC Skin"
 	provider-name="OSMC">
 	<requires>
@@ -14,7 +14,7 @@
 		<platform>all</platform>
 		<summary lang="en">The default skin for OSMC</summary>
 		<description lang="en">Original skin: Andy Morton[CR]Original design: Simon Brunton[CR]Skinner: Julian Michel</description>
-		<news>OSMC Kodi v18 update[CR][CR][B]New[/B][CR]- add new v18 subtitle settings OSD during fullscreen video playback[CR]- add new games section to match v18 requirements[CR]- add games section[CR]- add new resolution select button/dialog in video player[CR]- add player icon to now playing dialog[CR]- add new dependency button in addon info dialog to match v18 requirements[CR]- new color options (color sets, background gradients, adjustable opacity)[CR]- add PVR channel number input dialog[CR]- add PVR timeshift status dialog[CR]- add welcome dialog on non-OSMC devices[CR]- add director button to video info dialog[CR]- add new views (wide low, wall small, wall low, wall info, list info)[CR]- add new sub-menu indicator icon[CR]- add "Random TV shows" widget as new standard for TV shows home menu entry[CR]- add new dialog navigation indicators[CR]- add ratings toggle for IMDb, Metacritic, Rotten Tomatoes and TVDb[CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR][CR][B]Improved[/B][CR]- adjust syntax, values, labels and infobools to match v18 requirements[CR]- adjust PVR section to match v18 requirements[CR]- highlighting color now adjusts according to text color[CR]- streamline OSD animations[CR]- add missing adjustable plot fonts[CR]- let favourites dialog behave like a normal window[CR]- add file path and name to refresh button in video info dialog[CR]- add song/album year to music player[CR]- add wide list as music view[CR]- add music OSD album art size switch[CR]- adjust widget headings to always show and adjust animations to match widget animations[CR]- add option to change widget labels[CR][CR][B]Fixed[/B][CR]- show proper game widget title when not using skinshortcuts script[CR]- highlighting is now more consistent[CR]- fix current position/time remaining and current time/end time for PVR playback[CR]- hide deprecated previous/next channel buttons in PVR playback OSD[CR]- fix background of subtitle settings window[CR]- fix layout of PVR playback dialogs[CR]- fix dialog list navigation[CR]- change font size of media tags to prevent overlap with titles/details[CR]- only offer rip CD feature when an audio CD is present</news>
+		<news>[B]New[/B][CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR][CR][B]Improved[/B][CR]- add audio information to video info dialog[CR][CR][B]Fixed[/B][CR]- only offer rip CD feature when an audio CD is present</news>
 	</extension>
 	<assets>
 		<icon>icon.png</icon>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -527,17 +527,17 @@ msgstr ""
 
 #: /16x9/Viewtype521.xml
 msgctxt "#31112"
-msgid "Wide - low"
+msgid "Wide low"
 msgstr ""
 
-#: /16x9/Viewtype533.xml
+#: /16x9/Viewtype534.xml
 msgctxt "#31113"
-msgid "Wall - low"
+msgid "Wall low"
 msgstr ""
 
 #: /16x9/Viewtype532.xml
 msgctxt "#31114"
-msgid "Wall - small"
+msgid "Wall small"
 msgstr ""
 
 #: /16x9/SkinSettings.xml
@@ -545,14 +545,14 @@ msgctxt "#31115"
 msgid "Bigger music OSD album art"
 msgstr ""
 
-#: /16x9/Viewtype531.xml
+#: /16x9/Viewtype533.xml
 msgctxt "#31116"
-msgid "Wall - info"
+msgid "Wall small info"
 msgstr ""
 
 #: /16x9/Viewtype511.xml
 msgctxt "#31117"
-msgid "List - info"
+msgid "List info"
 msgstr ""
 
 #: /16x9/SkinSettings.xml
@@ -628,4 +628,14 @@ msgstr ""
 #: /16x9/SkinSettings.xml
 msgctxt "#31132"
 msgid "Duration before playback ends (default: 10s)"
+msgstr ""
+
+#: /16x9/Viewtype531.xml
+msgctxt "#31133"
+msgid "Wall info"
+msgstr ""
+
+#: /16x9/SkinSettings.xml
+msgctxt "#31134"
+msgid "Adjust representation of video duration (default: Minutes)"
 msgstr ""


### PR DESCRIPTION
AddonBrowser.xml:
- add onload for new video duration setting

DialogAddonInfo.xml:
- fix syntax

DialogVideoInfo.xml:
- add onload and onunload for new second info screen
- fix conditional visibility of poster/actor images, info list and cast list for use with new second info screen
- fix positioning of actor image
- remove extended ratings
- add back simple rating (without votes and source)
- add audio information
- adjust plot text box and make it show plot outline (shorter and no spoilers)
- fix positioning of cast list
- fix positioning of cast list scrollbar
- add second info screen (with extended rating, audio and subtitle information and bigger plot text box)
- add conditional visiblity to only show play and return button in second info screen
- remove ratings toggle button
- add extended info button

Home.xml:
- add onload for new video duration setting

Includes.xml:
- add new include file for new view

LoginScreen.xml:
- add onload for new video duration setting

MyVideoNav.xml:
- add new view 534 and rename 531, 532 and 533
- add new scrollbar for new wall info view (old wall info is now wall small info)

SettingsCategory.xml:
- add missing onloads

SkinSettings.xml:
- add onload for new video duration setting
- add new adjust representation of video duration setting

Variables.xml:
- add new PlotInfoDialog variable (preferring plot outline over plot for video info dialog)
- add new AudioChannels.1-.4 variables for new second info dialog screen
- add new AudioCodec.1-.4 variables for new second info dialog screen
- adjust Duration variable for new video duration setting

Viewtype51.xml:
- fix alignment of plot textbox

Viewtype511.xml:
- fix alignment of plot textbox

Viewtype531.xml:
- fix alignment of plot textbox
- adjust size and amount of movie poster thumbs for new wall info view

Viewtype533.xml:
- make old wall info view new wall small info view

Viewtype534.xml:
- new viewtype file for old wall low view

strings.po:
- change view localizes (31112, 31113, 31114, 31116, 31117)
- add new localize for new wall info view (31133)
- add new localize for new video duration setting (31134)

addon.xml:
- update changelog

Changelog.md:
- update changelog