### PR TITLE
Add individual background option to customizable home menu

### DIFF
--- a/16x9/Include_Home_OSMC.xml
+++ b/16x9/Include_Home_OSMC.xml
@@ -82,22 +82,20 @@
 
 		<!-- Sub Menu -->
 		<control type="group" id="9010">
-			<animation effect="slide" time="200" end="-200,0" condition="Integer.IsEqual(Container(9001).NumItems,0)">Conditional</animation>
-			<animation effect="slide" time="200" start="-200,0" end="0,0" condition="Integer.IsGreater(Container(9001).NumItems,0)">WindowOpen</animation>
-			<animation effect="slide" time="200" start="0,0" end="-200,0" condition="Integer.IsGreater(Container(9001).NumItems,0)">WindowClose</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>
-				<width>2120</width>
+				<width>1920</width>
 				<height>1080</height>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
-				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
-				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9010).HasFocus</visible>
 			</control>
 			<control type="group">
 				<visible>Control.HasFocus(9000)</visible>
 				<animation effect="fade" start="0" end="100" time="200">VisibleChange</animation>
+				<animation effect="slide" time="200" start="0,0" end="-200,0" condition="Integer.IsEqual(Container(9001).NumItems,0)">Conditional</animation>
+				<animation effect="slide" time="200" start="-200,0" end="0,0" condition="Integer.IsGreater(Container(9001).NumItems,0)">WindowOpen</animation>
+				<animation effect="slide" time="200" start="0,0" end="-200,0" condition="Integer.IsGreater(Container(9001).NumItems,0)">WindowClose</animation>
 				<control type="image">
 					<left>10</left>
 					<centertop>50%</centertop>

--- a/16x9/Includes.xml
+++ b/16x9/Includes.xml
@@ -44,7 +44,7 @@
 				<include>FullscreenDimensions</include>
 				<texture background="true">$VAR[OSMCBackgroundImage]</texture>
 				<visible>![Player.HasVideo + Skin.HasSetting(BackgroundVideo)]</visible>
-				<visible>String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))</visible>
+				<visible>[String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
 				<visible>!$PARAM[animate]</visible>
 				<aspectratio>keep</aspectratio>
 				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
@@ -55,7 +55,7 @@
 				<include>FullscreenDimensions</include>
 				<imagepath background="true">$VAR[OSMCBackgroundImage]</imagepath>
 				<visible>![Player.HasVideo + Skin.HasSetting(BackgroundVideo)]</visible>
-				<visible>String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder))</visible>
+				<visible>String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder)) + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
 				<visible>!$PARAM[animate]</visible>
 				<aspectratio>keep</aspectratio>
 				<include>CustomBackgroundFolderDuration</include>
@@ -64,6 +64,37 @@
 				<loop>yes</loop>
 				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+			</control>
+			
+			<!-- Single individual background image -->
+			<control type="image">
+				<include>FullscreenDimensions</include>
+				<texture background="true">$INFO[Container(9000).ListItem.Property(background)]</texture>
+				<visible>![Player.HasVideo + Skin.HasSetting(BackgroundVideo)]</visible>
+				<visible>!String.IsEmpty(Container(9000).ListItem.Property(background)) + !String.EndsWith(Container(9000).ListItem.Property(background),\)</visible>
+				<visible>!$PARAM[animate]</visible>
+				<aspectratio>keep</aspectratio>
+				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
+				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+				<animation effect="fade" start="0" end="100" time="200" delay="70" condition="$PARAM[animate]">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+			</control>
+			<!-- Multiple individual background images -->
+			<control type="multiimage">
+				<include>FullscreenDimensions</include>
+				<imagepath background="true">$INFO[Container(9000).ListItem.Property(background)]</imagepath>
+				<visible>![Player.HasVideo + Skin.HasSetting(BackgroundVideo)]</visible>
+				<visible>!String.IsEmpty(Container(9000).ListItem.Property(background)) + String.EndsWith(Container(9000).ListItem.Property(background),\)</visible>
+				<visible>!$PARAM[animate]</visible>
+				<aspectratio>keep</aspectratio>
+				<include>CustomBackgroundFolderDuration</include>
+				<fadetime>2000</fadetime>
+				<randomize>true</randomize>
+				<loop>yes</loop>
+				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
+				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+				<animation effect="fade" start="0" end="100" time="200" delay="70" condition="$PARAM[animate]">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 			</control>
 			
 			<!-- Fanart -->
@@ -139,6 +170,43 @@
 			<texture border="20">dialogs/OptionsBackground.png</texture>
 		</control>
 	</include>
+	
+	<!-- Multi image custom background duration -->
+	<include name="IndividualBackgroundFolderDuration">
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),5s)">IndividualBackgroundFolderDuration5</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),6s)">IndividualBackgroundFolderDuration6</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),8s)">IndividualBackgroundFolderDuration8</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),10s)">IndividualBackgroundFolderDuration10</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),15s)">IndividualBackgroundFolderDuration15</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),20s)">IndividualBackgroundFolderDuration20</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),30s)">IndividualBackgroundFolderDuration30</include>
+		<include condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),1 min)">IndividualBackgroundFolderDuration60</include>
+    </include>
+	
+	<include name="IndividualBackgroundFolderDuration5">
+		<timeperimage>5000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration6">
+		<timeperimage>6000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration8">
+		<timeperimage>8000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration10">
+		<timeperimage>10000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration15">
+		<timeperimage>15000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration20">
+		<timeperimage>20000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration30">
+		<timeperimage>30000</timeperimage>
+    </include>
+    <include name="IndividualBackgroundFolderDuration60">
+		<timeperimage>60000</timeperimage>
+    </include>
 	
 	<!-- Multi image custom background duration -->
 	<include name="CustomBackgroundFolderDuration">
@@ -1052,10 +1120,14 @@
 		<onload condition="String.IsEmpty(Skin.String(HideOSD))">Skin.SetString(HideOSD,Always)</onload>
 		<onload condition="String.IsEqual(Skin.String(HideOSD),Off)">Skin.SetString(HideOSD,Always)</onload>
 		<onload condition="String.IsEmpty(Skin.String(NFDimOpac))">Skin.SetString(NFDimOpac,100)</onload>
-		<onload condition="String.IsEqual(Skin.String(BackgroundImage),custom)">Skin.SetString(BackgroundImage,1)</onload>
-		<onload condition="String.IsEqual(Skin.String(BackgroundImage),custom)">Skin.SetString(BackgroundSingleImage,yes)</onload>
+		<onload condition="String.IsEqual(Skin.String(BackgroundImage),custom) + !String.IsEmpty(Skin.String(CustomBackground))">Skin.SetString(BackgroundDefaultImage,no)</onload>
+		<onload condition="String.IsEqual(Skin.String(BackgroundImage),custom) + String.IsEmpty(Skin.String(CustomBackground))">Skin.SetString(BackgroundDefaultImage,yes)</onload>
+		<onload condition="String.IsEmpty(Skin.String(BackgroundSingleImage))">Skin.SetString(BackgroundSingleImage,yes)</onload>
+		<onload condition="String.IsEmpty(Skin.String(BackgroundImage))">Skin.SetString(BackgroundDefaultImage,yes)</onload>
 		<onload condition="String.IsEmpty(Skin.String(BackgroundImage))">Skin.SetString(BackgroundImage,1)</onload>
-		<onload condition="String.IsEmpty(Skin.String(BackgroundDefaultImage))">Skin.SetString(BackgroundDefaultImage,yes)</onload>
+		<onload condition="String.IsEqual(Skin.String(BackgroundImage),custom)">Skin.SetString(BackgroundImage,1)</onload>
+		<onload condition="String.IsEqual(Skin.String(BackgroundDefaultImage),no) + String.IsEqual(Skin.String(BackgroundSingleImage),yes) + String.IsEmpty(Skin.String(CustomBackground))">Skin.SetString(BackgroundDefaultImage,yes)</onload>
+		<onload condition="String.IsEqual(Skin.String(BackgroundDefaultImage),no) + String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))">Skin.SetString(BackgroundDefaultImage,yes)</onload>
 		<onload condition="String.IsEmpty(Skin.String(color.text1))">Skin.SetString(color.text1,None)</onload>
 		<onload condition="String.IsEmpty(Skin.String(color.text2))">Skin.SetString(color.text2,None)</onload>
 		<onload condition="String.IsEmpty(Skin.String(color.text3))">Skin.SetString(color.text3,None)</onload>
@@ -1084,6 +1156,7 @@
 		<onload condition="String.IsEmpty(Skin.String(videoinfoendduration))">Skin.SetString(videoinfoendduration,10s)</onload>
 		<onload condition="String.IsEmpty(Skin.String(videodurationformat))">Skin.SetString(videodurationformat,Minutes)</onload>
 		<onload condition="String.IsEmpty(Skin.String(CustomBackgroundFolderDuration))">Skin.SetString(CustomBackgroundFolderDuration,30s)</onload>
+		<onload condition="String.IsEmpty(Skin.String(IndividualBackgroundFolderDuration))">Skin.SetString(IndividualBackgroundFolderDuration,30s)</onload>
 	</include>
 
 </includes>

--- a/16x9/SkinSettings.xml
+++ b/16x9/SkinSettings.xml
@@ -172,7 +172,7 @@
 					<label>31049</label>
 					<font>Font33</font>
 					<onclick>RunScript(script.skinshortcuts,type=manage&amp;group=mainmenu)</onclick>
-					<visible>System.HasAddon(script.skinshortcuts) + System.HasAddon(script.skin.helper.service)</visible>
+					<visible>System.HasAddon(script.skinshortcuts) + System.HasAddon(script.skin.helper.service) + System.HasAddon(script.skin.helper.backgrounds)</visible>
 					<focusedcolor>$VAR[TextColor1]</focusedcolor>
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
@@ -184,8 +184,9 @@
 					<font>Font33</font>
 					<onclick>InstallAddon(script.skinshortcuts)</onclick>
 					<onclick>InstallAddon(script.skin.helper.service)</onclick>
-					<onclick condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.service)) + !System.HasAddon(script.skin.helper.service)">ActivateWindow(1103)</onclick>
-					<visible>!System.HasAddon(script.skinshortcuts) | !System.HasAddon(script.skin.helper.service)</visible>
+					<onclick>InstallAddon(script.skin.helper.backgrounds)</onclick>
+					<onclick condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.service)) + !System.HasAddon(script.skin.helper.service) + !System.HasAddon(script.skin.helper.backgrounds)">ActivateWindow(1103)</onclick>
+					<visible>!System.HasAddon(script.skinshortcuts) | !System.HasAddon(script.skin.helper.service) | !System.HasAddon(script.skin.helper.backgrounds)</visible>
 					<focusedcolor>$VAR[TextColor1]</focusedcolor>
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
@@ -973,13 +974,23 @@
 					<width>1200</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>
+					<label> - $LOCALIZE[31140]</label>
+					<label2>$VAR[addon-skinhelperbackgrounds]</label2>
+					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.backgrounds)) + !System.HasAddon(script.skin.helper.backgrounds)">InstallAddon(script.skin.helper.backgrounds)</onclick>
+					<onclick condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.backgrounds)) + !System.HasAddon(script.skin.helper.backgrounds)">ActivateWindow(1102)</onclick>
+					<onclick condition="System.HasAddon(script.skin.helper.backgrounds)">Addon.OpenSettings(script.skin.helper.backgrounds)</onclick>
+				</control>
+				<control type="button" id="705">
+					<width>1200</width>
+					<height>66</height>
+					<textwidth>1120</textwidth>
 					<label> - $LOCALIZE[31106]</label>
 					<label2>$VAR[addon-skinhelperwidgets]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.widgets)) + !System.HasAddon(script.skin.helper.widgets)">InstallAddon(script.skin.helper.widgets)</onclick>
 					<onclick condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.widgets)) + !System.HasAddon(script.skin.helper.widgets)">ActivateWindow(1102)</onclick>
 					<onclick condition="System.HasAddon(script.skin.helper.widgets)">Addon.OpenSettings(script.skin.helper.widgets)</onclick>
 				</control>
-				<control type="button" id="705">
+				<control type="button" id="706">
 					<width>1200</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>
@@ -990,7 +1001,7 @@
 					<onclick condition="System.HasAddon(script.skin.helper.skinbackup)">Addon.OpenSettings(script.skin.helper.skinbackup)</onclick>
 				</control>
 				<!-- Supported -->
-				<control type="label" id="706">
+				<control type="label" id="707">
 					<width>1220</width>
 					<height>62</height>
 					<font>Font33-italic</font>
@@ -998,7 +1009,7 @@
 					<label>$LOCALIZE[31084]</label>
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
-				<control type="button" id="707">
+				<control type="button" id="708">
 					<width>1200</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>
@@ -1008,7 +1019,7 @@
 					<onclick condition="!String.IsEmpty(System.AddonVersion(plugin.program.autocompletion)) + !System.HasAddon(plugin.program.autocompletion)">ActivateWindow(1102)</onclick>
 					<onclick condition="System.HasAddon(plugin.program.autocompletion)">Addon.OpenSettings(plugin.program.autocompletion)</onclick>
 				</control>
-				<control type="button" id="708">
+				<control type="button" id="709">
 					<width>1200</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>
@@ -1018,7 +1029,7 @@
 					<onclick condition="!String.IsEmpty(System.AddonVersion(script.image.resource.select)) + !System.HasAddon(script.image.resource.select)">ActivateWindow(1102)</onclick>
 					<onclick condition="System.HasAddon(script.image.resource.select)">Addon.OpenSettings(script.image.resource.select)</onclick>
 				</control>
-				<!-- <control type="button" id="709">
+				<!-- <control type="button" id="710">
 					<width>1200</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>
@@ -1028,7 +1039,7 @@
 					<onclick condition="String.IsEmpty(System.AddonVersion(service.nextup.notification)) + System.HasAddon(service.nextup.notification)">ActivateWindow(1102)</onclick>
 					<onclick condition="System.HasAddon(service.nextup.notification)">Addon.OpenSettings(service.nextup.notification)</onclick>
 				</control> -->
-				<control type="button" id="710">
+				<control type="button" id="711">
 					<width>1200</width>
 					<height>66</height>
 					<textwidth>1120</textwidth>

--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -1437,6 +1437,11 @@
 		<value condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.service)) + !System.HasAddon(script.skin.helper.service)">[COLOR orange]$LOCALIZE[31119][/COLOR]</value>
 		<value>[COLOR red]$LOCALIZE[31092][/COLOR]</value>
 	</variable>
+	<variable name="addon-skinhelperbackgrounds">
+		<value condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.backgrounds)) + System.HasAddon(script.skin.helper.backgrounds)">[COLOR lightgreen]v$INFO[System.AddonVersion(script.skin.helper.backgrounds)] $LOCALIZE[31093][/COLOR]</value>
+		<value condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.backgrounds)) + !System.HasAddon(script.skin.helper.backgrounds)">[COLOR orange]$LOCALIZE[31119][/COLOR]</value>
+		<value>[COLOR red]$LOCALIZE[31092][/COLOR]</value>
+	</variable>
 	<variable name="addon-skinhelperwidgets">
 		<value condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.widgets)) + System.HasAddon(script.skin.helper.widgets)">[COLOR lightgreen]v$INFO[System.AddonVersion(script.skin.helper.widgets)] $LOCALIZE[31093][/COLOR]</value>
 		<value condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.widgets)) + !System.HasAddon(script.skin.helper.widgets)">[COLOR orange]$LOCALIZE[31119][/COLOR]</value>

--- a/16x9/script-skinshortcuts.xml
+++ b/16x9/script-skinshortcuts.xml
@@ -166,6 +166,35 @@
 					<label2>$INFO[Container(211).ListItem.Property(displaypath)]</label2>
 					<visible>!String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
+				
+				<!-- Edit background -->
+				<control type="button" id="310">
+					<width>1220</width>
+					<height>40</height>
+					<label>  -  $ADDON[script.skinshortcuts 32045]</label>
+					<label2>$INFO[Container(211).ListItem.Property(background)]</label2>
+					<disabledcolor>$VAR[TextColor4]</disabledcolor>
+					<visible>String.IsEqual(Window.Property(groupname),mainmenu)</visible>
+				</control>
+				
+				<!-- Edit background duration -->
+				<control type="button" id="210">
+					<width>1220</width>
+					<height>40</height>
+					<font>Font33</font>
+					<label>  -  $LOCALIZE[31137]</label>
+					<label2>$INFO[Skin.String(IndividualBackgroundFolderDuration)]</label2>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),1 min)">Skin.SetString(IndividualBackgroundFolderDuration,5s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),5s)">Skin.SetString(IndividualBackgroundFolderDuration,6s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),6s)">Skin.SetString(IndividualBackgroundFolderDuration,8s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),8s)">Skin.SetString(IndividualBackgroundFolderDuration,10s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),10s)">Skin.SetString(IndividualBackgroundFolderDuration,15s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),15s)">Skin.SetString(IndividualBackgroundFolderDuration,20s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),20s)">Skin.SetString(IndividualBackgroundFolderDuration,30s)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),30s)">Skin.SetString(IndividualBackgroundFolderDuration,1 min)</onclick>
+					<disabledcolor>$VAR[TextColor4]</disabledcolor>
+					<visible>String.IsEqual(Window.Property(groupname),mainmenu)</visible>
+				</control>
 
 				<!-- Edit submenu -->
 				<control type="button" id="405">

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ _New_
 - add new wall info view (based on wall view)
 - add new adjust representation of video duration setting
 - add new multi image (folder) background option
+- add new individual background option for home menu entries
 
 _Improved_
 - add audio information to video info dialog
@@ -92,6 +93,7 @@ Includes.xml:
 - change background image include for new multi image (folder) background option
 - add CustomBackgroundFolderDuration include for new multi image (folder) background option
 - add new Onloads include for skin-related onloads
+- change fanart image control to multi image control
 
 Includes_Widgets.xml:
 - replace label formatting with bold font
@@ -143,6 +145,10 @@ script-nextup-notification-NextUpInfo.xml:
 script-nextup-notification-StillWatchingInfo.xml:
 - replace label formatting with light font
 
+script.skinshortcuts.xml:
+- add edit background option to home menu customization dialog
+- add edit background duration option to home menu customization dialog
+
 script.skinshortcuts-static-xml:
 - fix conditional visibility for Rip CD feature (only show for audio CDs)
 
@@ -157,6 +163,8 @@ SkinSettings.xml:
 - clean-up window header
 - change IDs of skin settings categories
 - change background settings for new multi image (folder) background option
+- add skin helper backgrounds script as requirement for home menu customization
+- add skin helper backgrounds script as recommended addon
 
 Variables.xml:
 - update VideoPlayerPlot, VideoPlayerTitle and VideoPlayerNext variables for new OSD settings
@@ -165,6 +173,7 @@ Variables.xml:
 - add new AudioCodec.1-.4 variables for new second info dialog screen
 - adjust Duration variable for new video duration setting
 - change OSMCBackgroundImage variable for new multi image (folder) background option
+- add new addon-skinhelperbackgrounds variable for new recommended addon
 
 VideoFullScreen.xml:
 - add onloads for OSD settings alarm
@@ -220,9 +229,17 @@ strings.po:
 - add new localize for new wall info view (31133)
 - add new localize for new video duration setting (31134)
 - add new localizes for new multi image (folder) background option (31135, 31136, 31137, 31138)
+- add new localizes for reset path of new background option (31139)
+- add new localizes for new recommended addon (31140)
 
 341.DATA.xml:
 - fix conditional visibility for Rip CD feature (only show for audio CDs)
+
+overrides.xml:
+- add background smartshortcuts and background browse overrides
+
+template.xml:
+- add value to widgetbackground variable for new background option
 
 addon.xml:
 - bump version to 18.0.1

--- a/addon.xml
+++ b/addon.xml
@@ -14,7 +14,7 @@
 		<platform>all</platform>
 		<summary lang="en">The default skin for OSMC</summary>
 		<description lang="en">Original skin: Andy Morton[CR]Original design: Simon Brunton[CR]Skinner: Julian Michel</description>
-		<news>[B]New[/B][CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR]- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)[CR]- add new wall info view (based on wall view)[CR]- add new adjust representation of video duration setting[CR]- add new multi image (folder) background option[CR][CR][B]Improved[/B][CR]- add audio information to video info dialog[CR]- use font type for bold, light and italic instead of label formatting (where possible)[CR][CR][B]Fixed[/B][CR]- only offer rip CD feature when an audio CD is present</news>
+		<news>[B]New[/B][CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR]- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)[CR]- add new wall info view (based on wall view)[CR]- add new adjust representation of video duration setting[CR]- add new multi image (folder) background option[CR]- add new individual background option for home menu entries[CR][CR][B]Improved[/B][CR]- add audio information to video info dialog[CR]- use font type for bold, light and italic instead of label formatting (where possible)[CR][CR][B]Fixed[/B][CR]- only offer rip CD feature when an audio CD is present</news>
 	</extension>
 	<assets>
 		<icon>icon.png</icon>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -664,3 +664,8 @@ msgstr ""
 msgctxt "#31139"
 msgid "Reset path"
 msgstr ""
+
+#: /16x9/SkinSettings.xml
+msgctxt "#31140"
+msgid "Skin Helper Service Backgrounds"
+msgstr ""

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -66,6 +66,9 @@
 	<property property="widgetArt" condition="[!String.IsEmpty(Container(8000).ListItem.Art(fanart)) | !String.IsEmpty(Container(8000).ListItem(2).Art(fanart))] + [!String.IsEmpty(Container(8000).ListItem.Art(clearlogo)) | !String.IsEmpty(Container(8000).ListItem(2).Art(clearlogo))]" label="Fake Landscape">FAKELANDSCAPE</property>
 	<property property="widgetArt" condition="[!String.IsEmpty(Container(8000).ListItem.Art(fanart)) | !String.IsEmpty(Container(8000).ListItem(2).Art(fanart))] + [!String.IsEmpty(Container(8000).ListItem.Art(tvshow.clearlogo)) | !String.IsEmpty(Container(8000).ListItem(2).Art(tvshow.clearlogo))]" label="Fake TV Show Landscape">FAKETVLANDSCAPE</property>
 
+	<background label="smartshortcuts">||BROWSE||plugin://script.skin.helper.service/?action=backgrounds</background>
+	<backgroundBrowse>True</backgroundBrowse>
+
 	<!-- Fallback Artwork -->
 	<propertySettings property="widgetFallbackArt" buttonID="603" templateonly="True" showNone="False" title="Fallback Artwork" />
 	<propertyfallback property="widgetFallbackArt">Icon</propertyfallback>

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -660,6 +660,7 @@
 				<value condition="Window.Is(Home) + Control.IsVisible(1000$SKINSHORTCUTS[auto-rootID]) + [Control.HasFocus(10$SKINSHORTCUTS[auto-rootID]0$SKINSHORTCUTS[id]) | String.IsEqual(Skin.String(menuStyle),lumos)] + [$SKINSHORTCUTS[isWeather] + Skin.HasSetting(weatherFanart.multi)]">$INFO[Skin.String(weatherFanart.path)]$INFO[Container(10$SKINSHORTCUTS[auto-rootID]0$SKINSHORTCUTS[id]).ListItem.Property(weatherFanart)]/</value>
 				<value condition="!Window.Is(Home) + !String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
 				<value condition="[Window.IsActive(visualisation) | Skin.HasSetting(BackgroundVisualisation)] + !String.IsEmpty(MusicPlayer.Property(Fanart_Image))">$INFO[MusicPlayer.Property(Fanart_Image)]</value>
+				<value condition="!String.IsEmpty(Container(9000).ListItem.Property(background)) + !Control.HasFocus(10$SKINSHORTCUTS[auto-rootID]0$SKINSHORTCUTS[id])"></value>
 				<value>$VAR[OtherBackgroundImage]</value>
 			</variable>
 			<variable name="SeasonContainerArgs">


### PR DESCRIPTION
Includes.xml:
- change fanart image control to multi image control
- add new onload for individual background option

script.skinshortcuts.xml:
- add edit background option to home menu customization dialog
- add edit background duration option to home menu customization dialog

SkinSettings.xml:
- add skin helper backgrounds script as requirement for home menu customization
- add skin helper backgrounds script as recommended addon

Variables.xml:
- add new addon-skinhelperbackgrounds variable for new recommended addon

strings.po:
- add new localizes for new recommended addon (31140)

overrides.xml:
- add background smartshortcuts and background browse overrides

template.xml:
- add value to widgetbackground variable for new background option

addon.xml:
- update changelog

Changelog.md:
- update changelog