### PR TITLE
Fix music visualisation

### DIFF
--- a/16x9/Includes.xml
+++ b/16x9/Includes.xml
@@ -123,7 +123,7 @@
 			<!-- Visualisation -->
 			<control type="visualisation">
 				<include>FullscreenDimensions</include>
-				<visible>Player.HasAudio + Skin.HasSetting(BackgroundVisualisation) + !String.Contains(Window(Videos).Property(TvTunesIsAlive),True)</visible>
+				<visible>Player.HasAudio + Skin.HasSetting(BackgroundVisualisation) | Window.IsVisible(visualisation)</visible>
 			</control>
 
 			<!-- Overlay -->

--- a/16x9/MusicVisualisation.xml
+++ b/16x9/MusicVisualisation.xml
@@ -9,12 +9,6 @@
 		<!-- Background -->
 		<include>WindowBackgroundImage</include>
 
-		<!-- Visualisation -->
-		<control type="visualisation" id="2">
-			<include>FullscreenDimensions</include>
-			<visible>Player.HasAudio</visible>
-		</control>
-
 		<!-- Now Playing Information -->
 		<control type="group">
 			<visible>Player.ShowInfo</visible>


### PR DESCRIPTION
Includes.xml:
- remove deprecated conditional visibility of visualisation overlay
- add new conditional visibility to visualisation overlay

MusicVisualisation.xml:
- remove visualisation control (already present in WindowBackgroundImage include - this will prevent crashes occuring when actiavting a visualisation addon and activating the "show background visualisation" setting)