### PR TITLE
Improvements & fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,511 +1,73 @@
 **Changes**
 
 _New_
-- add new video player OSD settings (show OSD after beginning of playback and before end of playback)
-- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)
-- add new wall info view (based on wall view)
-- add new adjust representation of video duration setting
-- add new multi image (folder) background option
-- add new individual background option for home menu entries
-- add new options for music OSD to automatically show
-- add user rating to music and video library
-- add new side-menu player controls
-- add new options to hide watched indicator in video library and listened to indicator in music library
+- add 21:9 and 4:3 modes
 
 _Improved_
-- add audio information to video info dialog
-- use font type for bold, light and italic instead of label formatting (where possible)
-- prevent stacking of window/dialog text during background video playback
-- show special watched indicator icons for videos watched more than once
-- add listened to indicator for music
+- use OSMC busy spinner for widget loading
+- add Disabled option to Adjust OSD on-time during video pause button
+- rework skin structure for Transiflex localization
+- improve widget icon animations
+- rework dialog animations to prevent bright transition
 
 _Fixed_
-- only offer rip CD feature when an audio CD is present
+- don't show parts of weather widget during widget loading
+- localize all labels
 
-**Changelog v18.0.1**
+**Changelog v18.1.0**
 
-Addon.Browser.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- move skin-related onloads to include
-- clean-up window header
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-Custom_AutoMusicVis.xml:
-- add new custom dialog for new music OSD auto option
-
-Custom_Backup.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-Custom_Customization.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-Custom_Disabled_Add-on.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-Custom_Welcome.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogAddonInfo.xml:
-- fix syntax
-- replace label formatting with light font
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogAddonSettings.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogAddonSettings.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogConfirm.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-- move DialogZoomAnimation include to affect background as well
-
-DialogFavourites.xml:
-- replace label formatting with light font
-- replace old bold font
-- remove onright of list
-- add item count
-- adjust conditional visibility of submenu indicator to hide it when container is empty
-- fix top positioning of look controls
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-DialogFullScreenInfo.xml:
-- remove info dialog
-
-DialogGameControllers.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogKeyboard.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogMediaSource.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogMusicInfo.xml:
-- replace label formatting with light font
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-- add user rating button
-- add play count and last played date & time information
-
-DialogNumeric.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogPictureInfo.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogPlayerProcessInfo.xml:
-- replace label formatting with light font
-
-DialogPVRChannelGuide.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-
-DialogPVRChannelManager.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogPVRGroupManager.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogPVRGuideSearch.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogPVRInfo.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogSeekBar.xml:
-- remove PVR channel number input dialog
-
-DialogSelect.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- remove WindowFadeAnimation include
-- remove Window Background section
-- add new DialogFanart include
-
-DialogSubtitles.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- remove deprecated animations
-- add new dialog background
-
-DialogTextViewer.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-DialogVideoInfo.xml:
-- add onload and onunload for new second info screen
-- fix conditional visibility of poster/actor images, info list and cast list for use with new second info screen
-- fix positioning of actor image
-- add audio information
-- adjust plot text box and make it show plot outline (shorter and no spoilers)
-- fix positioning of cast list
-- fix positioning of cast list scrollbar
-- add second info screen (with extended rating, audio and subtitle information and bigger plot text box)
-- add conditional visiblity to only show play and return button in second info screen
-- add extended info button
-- replace label formatting with light font
-- remove deprecated onload
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-- add user rating button
-- add play count and last played date & time information
-
-EventLog.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-FileBrowser.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- remove WindowFadeAnimation include
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-FileManager.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-
-Font.xml:
-- add bold, light and italic version to each font size
-
-Home.xml:
-- move skin-related onloads to include
-- clean-up window header
-
-Includes.xml:
-- add new include file for new view
-- replace label formatting with light font
-- change background image include for new multi image (folder) background option
-- add CustomBackgroundFolderDuration include for new multi image (folder) background option
-- add new Onloads include for skin-related onloads
-- replace DialogTextBackground.png of WindowFadeBackgroundImage include by overlay image
-- fix dialogButtonBackground include (remove border and only show two horizontal lines as borders)
-- add new onload for new music OSD auto option
-- simplify WindowBackgroundImage include (remove params and animations not needed)
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-- add new SideMenuControls include for new sub-menu player controls
-- add new SideMenuControlsSpacer include for new sub-menu player controls
-
-Include_DialogSettings.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-Include_Home_OSMC.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-
-Includes_Widgets.xml:
-- replace label formatting with bold font
-
-LoginScreen.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- move skin-related onloads to include
-- clean-up window header
-
-MusicVisualisation.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-
-MyGames.xml:
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyMusicNav.xml:
-- fix width of options hidden side-menu button
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-- remove clean library option from side-menu
-- hide update library option from side-menu in add-on view
-
-MyPics.xml:
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyPlaylist.xml:
-- fix onup and ondown of sub-menu
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyPrograms.xml:
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyPVRChannels.xml:
-- fix alignment of plot textbox
-- replace label formatting with light font
-- replace label formatting with bold font
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyPVRGuide.xml:
-- fix alignment of plot textbox
-- replace label formatting with light font
-- replace label formatting with bold font
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyPVRRecordings.xml:
-- fix alignment of plot textbox
-- replace label formatting with light font
-- replace label formatting with bold font
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyPVRSearch.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
- 
-MyPVRTimers.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-MyVideoNav.xml:
-- add new view 534 and rename 531, 532 and 533
-- add new scrollbar for new wall info view (old wall info is now wall small info)
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-- remove clean library option from side-menu
-- hide update library option from side-menu in add-on view
-
-MyWeather.xml:
-- remove onclick, onup, ondown and onright
-- fix top positioning of look controls
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-script-nextup-notification-NextUpInfo.xml:
-- replace label formatting with light font
-
-script-nextup-notification-StillWatchingInfo.xml:
-- replace label formatting with light font
-
-script-skin_helper_service-ColorPicker.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-script.skinshortcuts.xml:
-- add edit background option to home menu customization dialog
-- add edit background duration option to home menu customization dialog
-- remove WindowFadeBackgroundImage include
-- move DialogZoomAnimation include to affect background as well
-- remove WindowFadeAnimation include
-- add new dialog background
-
-script.skinshortcuts-static-xml:
-- fix conditional visibility for Rip CD feature (only show for audio CDs)
-- remove background fallback of widgetBackground variable (empty value)
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-SettingsCategory.xml:
-- move skin-related onloads to include
-- clean-up window header
-- fix top positioning of look controls
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-SettingsProfile.xml:
-- fix top positioning of look controls
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-SettingsSystemInfo.xml:
-- fix top positioning of look controls
-- add animation to shift up side-menu controls when side-menu player controls are active
-- add SideMenuControlsSpacer include
-- add SideMenuControls include
-
-SkinSettings.xml:
-- add new adjust representation of video duration setting
-- replace label formatting with italic font
-- move skin-related onloads to include
-- clean-up window header
-- change IDs of skin settings categories
-- change background settings for new multi image (folder) background option
-- add skin helper backgrounds script as requirement for home menu customization
-- add skin helper backgrounds script as recommended addon
-- add new captions for video and music OSD sections
-- add new option to show music OSD after set time during playback
-- add new toggle to adjust time after which music OSD appears during playback
-- add new user rating option
-- add new option to hide new sub-menu player controls
-- add new options to hide watched indicator in video library and listened to indicator in music library
-
-SmartPlaylistEditor.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- remove deprecated animation
-- add new DialogFanart include
-
-SmartPlaylistRule.xml:
-- remove deprecated WindowFadeBackgroundImage include
-- add new DialogFanart include
-
-Variables.xml:
-- update VideoPlayerPlot, VideoPlayerTitle and VideoPlayerNext variables for new OSD settings
-- add new PlotInfoDialog variable (preferring plot outline over plot for video info dialog)
-- add new AudioChannels.1-.4 variables for new second info dialog screen
-- add new AudioCodec.1-.4 variables for new second info dialog screen
-- adjust Duration variable for new video duration setting
-- change OSMCBackgroundImage variable for new multi image (folder) background option
-- add new addon-skinhelperbackgrounds variable for new recommended addon
-- add user rating to VideoInfoLabel variable
-- add user rating to MusicInfoLabel variable
-- add user rating to Label2 variable
-- add user rating to Label2-episodes variable
-- add new LabelUserRating variable
-- add new ContentTypeFavourites variable for favourites dialog
-- update StatusOverlay and StatusOverlayWide variables with new watched indicator icons (watched more than once)
-
-VideoFullScreen.xml:
-- add onloads for OSD settings alarm
-- adjust conditional visibility of progress bar and info dialog for new OSD settings
-- add elements formerly present in fullscreen info and seekbar dialog
-- replace label formatting with bold font
-- replace label formatting with light font
-
-Viewtype50.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-
-Viewtype51.xml:
-- fix alignment of plot textbox
-- replace label formatting with light font
-- replace label formatting with bold font
-
-Viewtype511.xml:
-- fix alignment of plot textbox
-- replace label formatting with light font
-- replace label formatting with bold font
-
-Viewtype52.xml:
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype521.xml:
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype53.xml:
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype531.xml:
-- fix alignment of plot textbox
-- adjust size and amount of movie poster thumbs for new wall info view
-- add user rating
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype532.xml:
-- fix size of collection and watched/listened to indicators
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype533.xml:
-- make old wall info view new wall small info view
-- add user rating
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype534.xml:
-- new viewtype file for old wall low view
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
-
-Viewtype54.xml:
-- replace label formatting with light font
-- replace label formatting with bold font
-- add user rating
-- add back watched/listened to indicator
-
-Viewtype55.xml:
-- add back watched/listened to indicator
-
-remove Default.png file
-
-SourceSansPro-Italic.ttf:
-- add new font style file
-
-SourceSansPro-Light.ttf:
-- add new font style file
-
-SourceSansPro-Regular.ttf:
-- add new font file
-
-SourceSansPro-Semibold.ttf:
-- add new font style file
+_rename languages folder for Transiflex localization_
 
 strings.po:
-- add new localizes for extended ratings in second video info dialog screen (31120, 31121, 31122)
-- add new localizes for new OSD settings (31123, 31124, 31125, 31126, 31127, 31128, 31129, 31130, 31131, 31132)
-- change view localizes (31112, 31113, 31114, 31116, 31117)
-- add new localize for new wall info view (31133)
-- add new localize for new video duration setting (31134)
-- add new localizes for new multi image (folder) background option (31135, 31136, 31137, 31138)
-- add new localizes for reset path of new background option (31139)
-- add new localizes for new recommended addon (31140)
-- add new localizes for new music OSD options (31074, 31141, 31142, 31143, 31144, 31145)
-- add new localize for new user rating option (31146)
-- add new localize for new sub-menu player controls hide option (31147)
-- add new localizes for new hide watched indicator in video library and hide listened to indicator in music library options (31148, 31149)
+- add new localizes for not yet localized labels (31150-31169)
+- add new localizes for second video info dialog screen (31170, 31171)
+
+_move 16x9 folder contents to new xml folder and add new aspect ratio modes by moving all coordinates to seperate files_
+
+DialogPVRChannelGuide.xml:
+- add scrollbar to channel list
+
+DialogPVRChannelsOSD.xml:
+- add scrollbar to program list
+
+DialogVideoInfo.xml:
+- replace extended info button localizes
+
+Includes.xml:
+- rework dialog animations to prevent bright transition
+
+Includes_Widgets.xml:
+- add conditional visibility to first weather widget panel
+- move updating indicator down
+
+MyPVRChannels.xml:
+- remove watched status overlay
+
+MyPVRRecordings.xml:
+- adjust watched/listened to indicators for new icon file dimensions
+
+script-skinshortcuts-static.xml:
+- replace old busy-small.gif with default OSMC busy.gif
+- improve widget icon animations
+
+SkinSettings.xml:
+- add skin reload button to debug section
+- add Disabled option to Adjust OSD on-time during video pause button
+
+Variables.xml:
+- adjust StatusOverlay and StatusOverlayWide variables to show correct icon for in progress TV shows
+- change 3DMode variable for consistency (naming as per Kodi wiki) and to show more specific 3D information (HSBS, HTAB, SBS, TAB)
 
 Textures.xbt:
-- repack content of media folder after adding new sub-menu player control fullscreen toggle icon
-- repack content of media folder after adding new watched indicator icons (watched more than once)
-
-341.DATA.xml:
-- fix conditional visibility for Rip CD feature (only show for audio CDs)
-
-overrides.xml:
-- add background smartshortcuts and background browse overrides
+- repack content of media folder after fixing watched indicator icons
 
 template.xml:
-- add value to widgetbackground variable for new background option
-- remove background fallback of widgetBackground variable (empty value)
-- add conditional visibility to watched/listened to indicator background for new option to hide these indicators
+- move updating indicator up
+- replace old busy-small.gif with default OSMC busy.gif
+- improve widget icon animations
+
+_add resources folder_
 
 addon.xml:
-- bump version to 18.0.1
-- fix fanart asset
-
-fanart.jpg:
-- add new addon asset
+- rework syntax
+- bump version to 18.1.0

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="18.0.1" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="18.1.0" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.14.0"/>
 	</requires>
@@ -16,6 +16,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new video player OSD settings (show OSD after beginning of playback and before end of playback)[CR]- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)[CR]- add new wall info view (based on wall view)[CR]- add new adjust representation of video duration setting[CR]- add new multi image (folder) background option[CR]- add new individual background option for home menu entries[CR]- add new options for music OSD to automatically show[CR]- add user rating to music and video library[CR]- add new side-menu player controls[CR]- add new options to hide watched indicator in video library and listened to indicator in music library[CR][CR][B]Improved[/B][CR]- add audio information to video info dialog[CR]- use font type for bold, light and italic instead of label formatting (where possible)[CR]- prevent stacking of window/dialog text during background video playback[CR]- show special watched indicator icons for videos watched more than once[CR]- add listened to indicator for music[CR][CR][B]Fixed[/B][CR]- only offer rip CD feature when an audio CD is present</news>
+		<news>[B]New[/B][CR]- add 21:9 and 4:3 modes[CR][CR][B]Improved[/B][CR]- use OSMC busy spinner for widget loading[CR]- add Disabled option to Adjust OSD on-time during video pause button[CR]- rework skin structure for Transiflex localization[CR]- improve widget icon animations[CR]- rework dialog animations to prevent bright transition[CR][CR][B]Fixed[/B][CR]- don't show parts of weather widget during widget loading[CR]- localize all labels</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -814,3 +814,13 @@ msgstr ""
 msgctxt "#31169"
 msgid "Welcome"
 msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31170"
+msgid "More information"
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31171"
+msgid "Back"
+msgstr ""

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -198,6 +198,8 @@
 
 				<focusedlayout width="203" height="306">
 					<control type="group">
+						<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+						<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 						<control type="label">
 							<top>2</top>
 							<width>203</width>
@@ -218,8 +220,6 @@
 							<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
 						</control>
 						<control type="image">
-							<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
-							<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear" reversible="false">Unfocus</animation>
 							<left>0</left>
 							<top>35</top>
 							<width>203</width>
@@ -242,7 +242,6 @@
 							<visible>Skin.HasSetting(weatherIcons.multi)</visible>
 						</control>
 						<control type="multiimage">
-							<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 							<left>0</left>
 							<top>35</top>
 							<width>203</width>

--- a/xml/Coordinates_Home.xml
+++ b/xml/Coordinates_Home.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 
+	<include name="HomeLogo_coords">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">HomeLogo_coords_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">HomeLogo_coords_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">HomeLogo_coords_4:3</include>
+	</include>
+	<include name="HomeLogo_coords_16:9">
+		<left>120</left>
+		<top>105</top>
+		<width>50</width>
+		<height>50</height>
+	</include>
+	<include name="HomeLogo_coords_21:9">
+		<left>120</left>
+		<top>105</top>
+		<width>50</width>
+		<height>50</height>
+	</include>
+	<include name="HomeLogo_coords_4:3">
+		<left>120</left>
+		<top>105</top>
+		<width>50</width>
+		<height>50</height>
+	</include>
+
 	<include name="HomeRSS_coords">
 		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">HomeRSS_coords_16:9</include>
 		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">HomeRSS_coords_21:9</include>
@@ -20,6 +44,249 @@
 		<right>0</right>
 		<bottom>0</bottom>
 		<width>1440</width>
+	</include>
+
+	<include name="Home_coords1">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">Home_coords1_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Home_coords1_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Home_coords1_4:3</include>
+	</include>
+	<include name="Home_coords1_16:9">
+		<left>120</left>
+		<top>240</top>
+		<width>400</width>
+		<height>679</height>
+	</include>
+	<include name="Home_coords1_21:9">
+		<left>120</left>
+		<top>240</top>
+		<width>400</width>
+		<height>679</height>
+	</include>
+	<include name="Home_coords1_4:3">
+		<left>120</left>
+		<top>240</top>
+		<width>400</width>
+		<height>679</height>
+	</include>
+	
+	<include name="Home_OptionsSideMenuAnimation">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">Home_OptionsSideMenuAnimation_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Home_OptionsSideMenuAnimation_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Home_OptionsSideMenuAnimation_4:3</include>
+	</include>
+	<include name="Home_OptionsSideMenuAnimation_16:9">
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,20)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,19)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,18)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,17)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,16)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,15)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,14)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,13)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,12)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,11)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,10)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,9)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,8)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,7)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,6)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,5)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,4)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,3)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,2)">Conditional</animation>
+	</include>
+	<include name="Home_OptionsSideMenuAnimation_21:9">
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,20)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,19)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,18)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,17)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,16)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,15)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,14)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,13)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,12)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,11)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,10)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,9)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,8)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,7)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,6)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,5)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,4)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,3)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,2)">Conditional</animation>
+	</include>
+	<include name="Home_OptionsSideMenuAnimation_4:3">
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,20)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,19)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,18)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,17)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,16)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,15)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,14)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,13)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,12)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,11)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,10)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,9)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,8)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,7)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,6)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,5)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,4)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,3)">Conditional</animation>
+		<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,2)">Conditional</animation>
+	</include>
+	
+	<include name="Home_coords2">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">Home_coords2_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Home_coords2_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Home_coords2_4:3</include>
+	</include>
+	<include name="Home_coords2_16:9">
+		<itemlayout width="400" height="97">
+			<control type="label">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<label>$INFO[ListItem.Label]</label>
+				<font>Font50-light</font>
+				<textcolor>$VAR[TextColor2]</textcolor>
+			</control>
+		</itemlayout>
+	</include>
+	<include name="Home_coords2_21:9">
+		<itemlayout width="400" height="97">
+			<control type="label">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<label>$INFO[ListItem.Label]</label>
+				<font>Font50-light</font>
+				<textcolor>$VAR[TextColor2]</textcolor>
+			</control>
+		</itemlayout>
+	</include>
+	<include name="Home_coords2_4:3">
+		<itemlayout width="400" height="97">
+			<control type="label">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<label>$INFO[ListItem.Label]</label>
+				<font>Font50-light</font>
+				<textcolor>$VAR[TextColor2]</textcolor>
+			</control>
+		</itemlayout>
+	</include>
+	
+	<include name="Home_coords3">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">Home_coords3_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Home_coords3_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Home_coords3_4:3</include>
+	</include>
+	<include name="Home_coords3_16:9">
+		<focusedlayout width="400" height="97">
+			<control type="label">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<label>$INFO[ListItem.Label]</label>
+				<font>Font50-bold</font>
+				<textcolor>$VAR[TextColor1]</textcolor>
+				<scroll>True</scroll>
+				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
+			</control>
+			<control type="image">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<texture colordiffuse="$VAR[TextColor1]">$VAR[focus97]</texture>
+				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
+			</control>
+		</focusedlayout>
+	</include>
+	<include name="Home_coords3_21:9">
+		<focusedlayout width="400" height="97">
+			<control type="label">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<label>$INFO[ListItem.Label]</label>
+				<font>Font50-bold</font>
+				<textcolor>$VAR[TextColor1]</textcolor>
+				<scroll>True</scroll>
+				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
+			</control>
+			<control type="image">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<texture colordiffuse="$VAR[TextColor1]">$VAR[focus97]</texture>
+				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
+			</control>
+		</focusedlayout>
+	</include>
+	<include name="Home_coords3_4:3">
+		<focusedlayout width="400" height="97">
+			<control type="label">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<label>$INFO[ListItem.Label]</label>
+				<font>Font50-bold</font>
+				<textcolor>$VAR[TextColor1]</textcolor>
+				<scroll>True</scroll>
+				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
+			</control>
+			<control type="image">
+				<left>0</left>
+				<top>0</top>
+				<width>400</width>
+				<height>97</height>
+				<texture colordiffuse="$VAR[TextColor1]">$VAR[focus97]</texture>
+				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
+			</control>
+		</focusedlayout>
+	</include>
+	
+	<include name="Home_coords4">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">Home_coords4_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Home_coords4_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Home_coords4_4:3</include>
+	</include>
+	<include name="Home_coords4_16:9">
+		<include content="Indicators">
+			<param name="left">120</param>
+			<param name="top">200</param>
+			<param name="height">759</param>
+			<param name="container">9000</param>
+		</include>
+	</include>
+	<include name="Home_coords4_21:9">
+		<include content="Indicators">
+			<param name="left">120</param>
+			<param name="top">200</param>
+			<param name="height">759</param>
+			<param name="container">9000</param>
+		</include>
+	</include>
+	<include name="Home_coords4_4:3">
+		<include content="Indicators">
+			<param name="left">120</param>
+			<param name="top">200</param>
+			<param name="height">759</param>
+			<param name="container">9000</param>
+		</include>
 	</include>
 
 </includes>

--- a/xml/Coordinates_Includes.xml
+++ b/xml/Coordinates_Includes.xml
@@ -944,6 +944,83 @@
 		<top>7</top>
 	</include>
 
+	<include name="SideMenuAnimation">
+		<definition>
+			<include condition="String.IsEqual(Skin.AspectRatio,16:9)" content="SideMenuAnimation_16:9">
+				<param name="containerID">$PARAM[containerID]</param>
+			</include>
+			<include condition="String.IsEqual(Skin.AspectRatio,21:9)" content="SideMenuAnimation_21:9">
+				<param name="containerID">$PARAM[containerID]</param>
+			</include>
+			<include condition="String.IsEqual(Skin.AspectRatio,4:3)" content="SideMenuAnimation_4:3">
+				<param name="containerID">$PARAM[containerID]</param>
+			</include>
+		</definition>
+	</include>
+	<include name="SideMenuAnimation_16:9">
+		<animation effect="slide" end="0,26" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,19)">Conditional</animation>
+		<animation effect="slide" end="0,52" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,18)">Conditional</animation>
+		<animation effect="slide" end="0,78" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,17)">Conditional</animation>
+		<animation effect="slide" end="0,104" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,16)">Conditional</animation>
+		<animation effect="slide" end="0,130" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,15)">Conditional</animation>
+		<animation effect="slide" end="0,156" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,14)">Conditional</animation>
+		<animation effect="slide" end="0,182" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,13)">Conditional</animation>
+		<animation effect="slide" end="0,208" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,12)">Conditional</animation>
+		<animation effect="slide" end="0,234" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,11)">Conditional</animation>
+		<animation effect="slide" end="0,260" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,10)">Conditional</animation>
+		<animation effect="slide" end="0,286" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,9)">Conditional</animation>
+		<animation effect="slide" end="0,312" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,8)">Conditional</animation>
+		<animation effect="slide" end="0,338" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,7)">Conditional</animation>
+		<animation effect="slide" end="0,364" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,6)">Conditional</animation>
+		<animation effect="slide" end="0,390" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,5)">Conditional</animation>
+		<animation effect="slide" end="0,416" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,4)">Conditional</animation>
+		<animation effect="slide" end="0,442" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,3)">Conditional</animation>
+		<animation effect="slide" end="0,468" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,2)">Conditional</animation>
+		<animation effect="slide" end="0,494" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,1)">Conditional</animation>
+	</include>
+	<include name="SideMenuAnimation_21:9">
+		<animation effect="slide" end="0,26" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,19)">Conditional</animation>
+		<animation effect="slide" end="0,52" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,18)">Conditional</animation>
+		<animation effect="slide" end="0,78" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,17)">Conditional</animation>
+		<animation effect="slide" end="0,104" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,16)">Conditional</animation>
+		<animation effect="slide" end="0,130" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,15)">Conditional</animation>
+		<animation effect="slide" end="0,156" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,14)">Conditional</animation>
+		<animation effect="slide" end="0,182" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,13)">Conditional</animation>
+		<animation effect="slide" end="0,208" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,12)">Conditional</animation>
+		<animation effect="slide" end="0,234" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,11)">Conditional</animation>
+		<animation effect="slide" end="0,260" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,10)">Conditional</animation>
+		<animation effect="slide" end="0,286" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,9)">Conditional</animation>
+		<animation effect="slide" end="0,312" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,8)">Conditional</animation>
+		<animation effect="slide" end="0,338" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,7)">Conditional</animation>
+		<animation effect="slide" end="0,364" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,6)">Conditional</animation>
+		<animation effect="slide" end="0,390" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,5)">Conditional</animation>
+		<animation effect="slide" end="0,416" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,4)">Conditional</animation>
+		<animation effect="slide" end="0,442" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,3)">Conditional</animation>
+		<animation effect="slide" end="0,468" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,2)">Conditional</animation>
+		<animation effect="slide" end="0,494" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,1)">Conditional</animation>
+	</include>
+	<include name="SideMenuAnimation_4:3">
+		<animation effect="slide" end="0,26" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,19)">Conditional</animation>
+		<animation effect="slide" end="0,52" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,18)">Conditional</animation>
+		<animation effect="slide" end="0,78" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,17)">Conditional</animation>
+		<animation effect="slide" end="0,104" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,16)">Conditional</animation>
+		<animation effect="slide" end="0,130" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,15)">Conditional</animation>
+		<animation effect="slide" end="0,156" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,14)">Conditional</animation>
+		<animation effect="slide" end="0,182" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,13)">Conditional</animation>
+		<animation effect="slide" end="0,208" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,12)">Conditional</animation>
+		<animation effect="slide" end="0,234" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,11)">Conditional</animation>
+		<animation effect="slide" end="0,260" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,10)">Conditional</animation>
+		<animation effect="slide" end="0,286" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,9)">Conditional</animation>
+		<animation effect="slide" end="0,312" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,8)">Conditional</animation>
+		<animation effect="slide" end="0,338" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,7)">Conditional</animation>
+		<animation effect="slide" end="0,364" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,6)">Conditional</animation>
+		<animation effect="slide" end="0,390" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,5)">Conditional</animation>
+		<animation effect="slide" end="0,416" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,4)">Conditional</animation>
+		<animation effect="slide" end="0,442" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,3)">Conditional</animation>
+		<animation effect="slide" end="0,468" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,2)">Conditional</animation>
+		<animation effect="slide" end="0,494" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,1)">Conditional</animation>
+	</include>
+	
 	<include name="dialogButtonBackground_coords1">
 		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">dialogButtonBackground_coords1_16:9</include>
 		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords1_21:9</include>

--- a/xml/Coordinates_SkinSettings.xml
+++ b/xml/Coordinates_SkinSettings.xml
@@ -139,22 +139,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords5_4:3</include>
 	</include>
 	<include name="SkinSettings_coords5_16:9">
-		<left>500</left>
-		<top>253</top>
-		<width>30</width>
-		<height>610</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">100</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords5_21:9">
-		<left>0</left>
-		<top>228</top>
-		<width>360</width>
-		<height>660</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">100</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords5_4:3">
-		<left>0</left>
-		<top>228</top>
-		<width>360</width>
-		<height>660</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">100</param>
+		</include>
 	</include>
 	
 	<include name="SkinSettings_coords6">
@@ -163,22 +169,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords6_4:3</include>
 	</include>
 	<include name="SkinSettings_coords6_16:9">
-		<left>0</left>
-		<top>0</top>
-		<width>30</width>
-		<height>16</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">200</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords6_21:9">
-		<left>0</left>
-		<top>0</top>
-		<width>30</width>
-		<height>16</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">200</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords6_4:3">
-		<left>0</left>
-		<top>0</top>
-		<width>30</width>
-		<height>16</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">200</param>
+		</include>
 	</include>
 	
 	<include name="SkinSettings_coords7">
@@ -187,13 +199,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords7_4:3</include>
 	</include>
 	<include name="SkinSettings_coords7_16:9">
-		<left>550</left>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">300</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords7_21:9">
-		<left>550</left>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">300</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords7_4:3">
-		<left>550</left>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">300</param>
+		</include>
 	</include>
 	
 	<include name="SkinSettings_coords8">
@@ -202,22 +229,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords8_4:3</include>
 	</include>
 	<include name="SkinSettings_coords8_16:9">
-		<left>0</left>
-		<top>228</top>
-		<width>1220</width>
-		<height>660</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">400</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords8_21:9">
-		<left>0</left>
-		<top>228</top>
-		<width>1860</width>
-		<height>660</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">400</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords8_4:3">
-		<left>0</left>
-		<top>228</top>
-		<width>770</width>
-		<height>660</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">400</param>
+		</include>
 	</include>
 	
 	<include name="SkinSettings_coords9">
@@ -226,19 +259,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords9_4:3</include>
 	</include>
 	<include name="SkinSettings_coords9_16:9">
-		<width>1220</width>
-		<height>66</height>
-		<textwidth>1120</textwidth>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">500</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords9_21:9">
-		<width>1860</width>
-		<height>66</height>
-		<textwidth>1760</textwidth>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">500</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords9_4:3">
-		<width>770</width>
-		<height>66</height>
-		<textwidth>670</textwidth>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">500</param>
+		</include>
 	</include>
 	
 	<include name="SkinSettings_coords10">
@@ -247,16 +289,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords10_4:3</include>
 	</include>
 	<include name="SkinSettings_coords10_16:9">
-		<width>1220</width>
-		<height>62</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">600</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords10_21:9">
-		<width>1860</width>
-		<height>62</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">600</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords10_4:3">
-		<width>770</width>
-		<height>62</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">600</param>
+		</include>
 	</include>
 	
 	<include name="SkinSettings_coords11">
@@ -265,18 +319,186 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords11_4:3</include>
 	</include>
 	<include name="SkinSettings_coords11_16:9">
-		<left>340</left>
-		<top>894</top>
-		<width>1240</width>
-		<height>132</height>
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">700</param>
+		</include>
 	</include>
 	<include name="SkinSettings_coords11_21:9">
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">700</param>
+		</include>
+	</include>
+	<include name="SkinSettings_coords11_4:3">
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">700</param>
+		</include>
+	</include>
+	
+	<include name="SkinSettings_coords12">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords12_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords12_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords12_4:3</include>
+	</include>
+	<include name="SkinSettings_coords12_16:9">
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">800</param>
+		</include>
+	</include>
+	<include name="SkinSettings_coords12_21:9">
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">800</param>
+		</include>
+	</include>
+	<include name="SkinSettings_coords12_4:3">
+		<include content="Indicators">
+			<param name="left">500</param>
+			<param name="top">253</param>
+			<param name="height">610</param>
+			<param name="container">800</param>
+		</include>
+	</include>
+	
+	<include name="SkinSettings_coords13">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords13_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords13_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords13_4:3</include>
+	</include>
+	<include name="SkinSettings_coords13_16:9">
+		<include content="Indicators">
+			<param name="left">120</param>
+			<param name="top">210</param>
+			<param name="height">740</param>
+			<param name="container">9000</param>
+		</include>
+	</include>
+	<include name="SkinSettings_coords13_21:9">
+		<include content="Indicators">
+			<param name="left">120</param>
+			<param name="top">210</param>
+			<param name="height">740</param>
+			<param name="container">9000</param>
+		</include>
+	</include>
+	<include name="SkinSettings_coords13_4:3">
+		<include content="Indicators">
+			<param name="left">120</param>
+			<param name="top">210</param>
+			<param name="height">740</param>
+			<param name="container">9000</param>
+		</include>
+	</include>
+	
+	<include name="SkinSettings_coords14">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords14_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords14_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords14_4:3</include>
+	</include>
+	<include name="SkinSettings_coords14_16:9">
+		<left>550</left>
+	</include>
+	<include name="SkinSettings_coords14_21:9">
+		<left>550</left>
+	</include>
+	<include name="SkinSettings_coords14_4:3">
+		<left>550</left>
+	</include>
+	
+	<include name="SkinSettings_coords15">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords15_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords15_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords15_4:3</include>
+	</include>
+	<include name="SkinSettings_coords15_16:9">
+		<left>0</left>
+		<top>228</top>
+		<width>1220</width>
+		<height>660</height>
+	</include>
+	<include name="SkinSettings_coords15_21:9">
+		<left>0</left>
+		<top>228</top>
+		<width>1860</width>
+		<height>660</height>
+	</include>
+	<include name="SkinSettings_coords15_4:3">
+		<left>0</left>
+		<top>228</top>
+		<width>770</width>
+		<height>660</height>
+	</include>
+	
+	<include name="SkinSettings_coords16">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords16_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords16_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords16_4:3</include>
+	</include>
+	<include name="SkinSettings_coords16_16:9">
+		<width>1220</width>
+		<height>66</height>
+		<textwidth>1120</textwidth>
+	</include>
+	<include name="SkinSettings_coords16_21:9">
+		<width>1860</width>
+		<height>66</height>
+		<textwidth>1760</textwidth>
+	</include>
+	<include name="SkinSettings_coords16_4:3">
+		<width>770</width>
+		<height>66</height>
+		<textwidth>670</textwidth>
+	</include>
+	
+	<include name="SkinSettings_coords17">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords17_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords17_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords17_4:3</include>
+	</include>
+	<include name="SkinSettings_coords17_16:9">
+		<width>1220</width>
+		<height>62</height>
+	</include>
+	<include name="SkinSettings_coords17_21:9">
+		<width>1860</width>
+		<height>62</height>
+	</include>
+	<include name="SkinSettings_coords17_4:3">
+		<width>770</width>
+		<height>62</height>
+	</include>
+	
+	<include name="SkinSettings_coords18">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">SkinSettings_coords18_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SkinSettings_coords18_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SkinSettings_coords18_4:3</include>
+	</include>
+	<include name="SkinSettings_coords18_16:9">
 		<left>340</left>
 		<top>894</top>
 		<width>1240</width>
 		<height>132</height>
 	</include>
-	<include name="SkinSettings_coords11_4:3">
+	<include name="SkinSettings_coords18_21:9">
+		<left>340</left>
+		<top>894</top>
+		<width>1240</width>
+		<height>132</height>
+	</include>
+	<include name="SkinSettings_coords18_4:3">
 		<left>100</left>
 		<top>894</top>
 		<width>1240</width>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -579,13 +579,13 @@
 				<!-- Extended info Button -->
 				<control type="button" id="15">
 					<width>Auto</width>
-					<label>22082</label>
+					<label>31170</label>
 					<onclick>SetProperty(extended,14115,12003)</onclick>
 					<visible>String.IsEmpty(Window(12003).Property(extended)) + !String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + !Container.Content(musicvideos)</visible>
 				</control>
 				<control type="button" id="16">
 					<width>Auto</width>
-					<label>210</label>
+					<label>31171</label>
 					<onclick>ClearProperty(extended,12003)</onclick>
 					<visible>!String.IsEmpty(Window(12003).Property(extended)) + !String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + !Container.Content(musicvideos)</visible>
 				</control>

--- a/xml/Home.xml
+++ b/xml/Home.xml
@@ -38,10 +38,7 @@
 
 		<!-- Logo -->
 		<control type="image">
-			<left>120</left>
-			<top>105</top>
-			<width>50</width>
-			<height>50</height>
+			<include>HomeLogo_coords</include>
 			<texture>logo.png</texture>
 			<include>WindowFadeAnimation</include>
 		</control>

--- a/xml/Include_Home_OSMC.xml
+++ b/xml/Include_Home_OSMC.xml
@@ -7,10 +7,7 @@
 
 		<!-- Main list -->
 		<control type="list" id="9000">
-			<left>120</left>
-			<top>240</top>
-			<width>400</width>
-			<height>679</height>
+			<include>Home_coords1</include>
 			<focusposition>7</focusposition>
 			<defaultcontrol>1</defaultcontrol>
 			<onup>9000</onup>
@@ -20,39 +17,9 @@
 			<orientation>vertical</orientation>
 			<scrolltime tween="sine" easing="out">240</scrolltime>
 
-			<itemlayout width="400" height="97">
-				<control type="label">
-					<left>0</left>
-					<top>0</top>
-					<width>400</width>
-					<height>97</height>
-					<label>$INFO[ListItem.Label]</label>
-					<font>Font50-light</font>
-					<textcolor>$VAR[TextColor2]</textcolor>
-				</control>
-			</itemlayout>
+			<include>Home_coords2</include>
 
-			<focusedlayout width="400" height="97">
-				<control type="label">
-					<left>0</left>
-					<top>0</top>
-					<width>400</width>
-					<height>97</height>
-					<label>$INFO[ListItem.Label]</label>
-					<font>Font50-bold</font>
-					<textcolor>$VAR[TextColor1]</textcolor>
-					<scroll>True</scroll>
-					<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
-				</control>
-				<control type="image">
-					<left>0</left>
-					<top>0</top>
-					<width>400</width>
-					<height>97</height>
-					<texture colordiffuse="$VAR[TextColor1]">$VAR[focus97]</texture>
-					<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="!Control.HasFocus(9000)">Conditional</animation>
-				</control>
-			</focusedlayout>
+			<include>Home_coords3</include>
 
 			<content>
 				<include>skinshortcuts-mainmenu</include>
@@ -68,12 +35,7 @@
 		</control>
 
 		<!-- Indicators -->
-		<include content="Indicators">
-			<param name="left">120</param>
-			<param name="top">200</param>
-			<param name="height">759</param>
-			<param name="container">9000</param>
-		</include>
+		<include>Home_coords4</include>
 
 		<!-- Widgets -->
 		<control type="group" id="9002">
@@ -106,50 +68,23 @@
 				<top>0</top>
 				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9010).HasFocus">Conditional</animation>
 				<control type="button">
-					<left>0</left>
-					<top>0</top>
-					<width>460</width>
-					<height>1080</height>
+					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>
 				</control>
 
 				<control type="image">
-					<left>0</left>
-					<top>0</top>
-					<width>450</width>
-					<height>1080</height>
+					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
 				</control>
 
 				<control type="list" id="9001">
-					<left>20</left>
-					<top>20</top>
-					<width>410</width>
-					<height>1040</height>
+					<include>OptionsSideMenu3</include>
 					<onleft>9000</onleft>
 					<onright>9000</onright>
 					<orientation>vertical</orientation>
 					<defaultcontrol always="true">1</defaultcontrol>
 
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,20)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,19)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,18)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,17)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,16)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,15)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,14)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,13)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,12)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,11)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,10)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,9)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,8)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,7)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,6)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,5)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,4)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,3)">Conditional</animation>
-					<animation effect="slide" time="0" end="0,26" condition="Integer.IsLess(Container(9001).NumItems,2)">Conditional</animation>
+					<include>Home_OptionsSideMenuAnimation</include>
 
 					<itemlayout width="410" height="52">
 						<control type="label">

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -208,46 +208,51 @@
 	
 	<!-- Dialog fanart -->
 	<include name="DialogFanart">
-		<control type="group">
+		<!-- Single background image -->
+		<control type="image">
+			<include>FullscreenDimensions</include>
+			<texture background="true">$VAR[OSMCBackgroundImage]</texture>
+			<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
+			<aspectratio>scale</aspectratio>
+			<animation effect="fade" start="0" end="100" time="200">Visible</animation>
+			<animation effect="fade" start="100" end="0" time="150">Hidden</animation>
 			<include>WindowFadeAnimation</include>
-			<!-- Single background image -->
-			<control type="image">
-				<include>FullscreenDimensions</include>
-				<texture background="true">$VAR[OSMCBackgroundImage]</texture>
-				<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
-				<aspectratio>scale</aspectratio>
-				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
-				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
-			</control>
-			<!-- Multiple background images -->
-			<control type="multiimage">
-				<include>FullscreenDimensions</include>
-				<imagepath background="true">$VAR[OSMCBackgroundImage]</imagepath>
-				<visible>String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder)) + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
-				<aspectratio>scale</aspectratio>
-				<include>CustomBackgroundFolderDuration</include>
-				<fadetime>2000</fadetime>
-				<randomize>true</randomize>
-				<loop>yes</loop>
-				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
-				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
-			</control>
-			<!-- Fanart -->
-			<control type="image" id="10000">
-				<include>FullscreenDimensions</include>
-				<texture background="true" fallback="transparent.png">$INFO[ListItem.Art(fanart)]</texture>
-				<aspectratio>scale</aspectratio>
-				<fadetime>400</fadetime>
-				<visible>!Skin.HasSetting(HideFanart)</visible>
-				<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
-				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
-			</control>
-			<!-- Overlay -->
-			<control type="image">
-				<include>FullscreenDimensions</include>
-				<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
-				<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
-			</control>
+		</control>
+		<!-- Multiple background images -->
+		<control type="multiimage">
+			<include>FullscreenDimensions</include>
+			<imagepath background="true">$VAR[OSMCBackgroundImage]</imagepath>
+			<visible>String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder)) + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
+			<aspectratio>scale</aspectratio>
+			<include>CustomBackgroundFolderDuration</include>
+			<fadetime>2000</fadetime>
+			<randomize>true</randomize>
+			<loop>yes</loop>
+			<animation effect="fade" start="0" end="100" time="200">Visible</animation>
+			<animation effect="fade" start="100" end="0" time="150">Hidden</animation>
+			<include>WindowFadeAnimation</include>
+		</control>
+		<!-- Fanart -->
+		<control type="image" id="10000">
+			<include>FullscreenDimensions</include>
+			<texture background="true" fallback="transparent.png">$INFO[ListItem.Art(fanart)]</texture>
+			<aspectratio>scale</aspectratio>
+			<fadetime>400</fadetime>
+			<visible>!Skin.HasSetting(HideFanart)</visible>
+			<animation effect="fade" start="0" end="100" time="300">Visible</animation>
+			<animation effect="fade" start="100" end="0" time="300">Hidden</animation>
+			<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
+			<animation effect="fade" start="100" end="0" time="200" delay="100">WindowClose</animation>
+		</control>
+		<!-- Overlay -->
+		<control type="image">
+			<include>FullscreenDimensions</include>
+			<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
+			<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
+			<animation effect="fade" start="0" end="100" time="300">Visible</animation>
+			<animation effect="fade" start="100" end="0" time="300">Hidden</animation>
+			<animation effect="fade" start="0" end="100" time="150">WindowOpen</animation>
+			<animation effect="fade" start="100" end="0" time="200" delay="100">WindowClose</animation>
 		</control>
 	</include>
 
@@ -731,11 +736,11 @@
 	<include name="DialogZoomAnimation">
 		<animation type="WindowOpen">
 			<effect type="zoom" start="70" end="100" center="auto" tween="back" easing="inout" time="300" />
-			<effect type="fade" start="0" end="100" time="300" />
+			<effect type="fade" start="0" end="100" time="50" delay="50" />
 		</animation>
 		<animation type="WindowClose">
 			<effect type="zoom" start="100" end="70" center="auto" time="300" />
-			<effect type="fade" start="100" end="0" time="300" />
+			<effect type="fade" start="100" end="0" time="150" delay="150" />
 		</animation>
 	</include>
 
@@ -743,11 +748,11 @@
 	<include name="OptionsAnimation">
 		<animation type="Visible">
 			<effect type="zoom" start="70" end="100" center="auto" tween="back" easing="inout" time="300" />
-			<effect type="fade" start="0" end="100" time="300" />
+			<effect type="fade" start="0" end="100" time="150" delay="150" />
 		</animation>
 		<animation type="Hidden">
-			<effect type="zoom" start="100" end="70" center="auto" time="100" />
-			<effect type="fade" start="100" end="0" time="100" />
+			<effect type="zoom" start="100" end="70" center="auto" time="300" />
+			<effect type="fade" start="100" end="0" time="150" delay="150" />
 		</animation>
 	</include>
 
@@ -1231,29 +1236,6 @@
 				<visible>!ListItem.IsFolder + ![String.IsEqual(ListItem.Size,0 B) | String.IsEqual(ListItem.Size,0.000000 B)]</visible>
 			</control>
 		</control>
-	</include>
-
-	<!-- Side menu animation -->
-	<include name="SideMenuAnimation">
-		<animation effect="slide" end="0,26" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,19)">Conditional</animation>
-		<animation effect="slide" end="0,52" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,18)">Conditional</animation>
-		<animation effect="slide" end="0,78" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,17)">Conditional</animation>
-		<animation effect="slide" end="0,104" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,16)">Conditional</animation>
-		<animation effect="slide" end="0,130" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,15)">Conditional</animation>
-		<animation effect="slide" end="0,156" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,14)">Conditional</animation>
-		<animation effect="slide" end="0,182" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,13)">Conditional</animation>
-		<animation effect="slide" end="0,208" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,12)">Conditional</animation>
-		<animation effect="slide" end="0,234" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,11)">Conditional</animation>
-		<animation effect="slide" end="0,260" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,10)">Conditional</animation>
-		<animation effect="slide" end="0,286" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,9)">Conditional</animation>
-		<animation effect="slide" end="0,312" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,8)">Conditional</animation>
-		<animation effect="slide" end="0,338" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,7)">Conditional</animation>
-		<animation effect="slide" end="0,364" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,6)">Conditional</animation>
-		<animation effect="slide" end="0,390" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,5)">Conditional</animation>
-		<animation effect="slide" end="0,416" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,4)">Conditional</animation>
-		<animation effect="slide" end="0,442" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,3)">Conditional</animation>
-		<animation effect="slide" end="0,468" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,2)">Conditional</animation>
-		<animation effect="slide" end="0,494" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,1)">Conditional</animation>
 	</include>
 
 	<include name="Indicators">

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -85,45 +85,46 @@
 		<!-- Indicators -->
 		<control type="group">
 			<include>SkinSettings_coords5</include>
-			<control type="image">
-				<include>SkinSettings_coords6</include>
-				<colordiffuse>$VAR[TextColor2]</colordiffuse>
-				<texture colordiffuse="$VAR[DialogColor2]">up.png</texture>
-
-				<visible>Container(300).HasPrevious + Container(9000).HasFocus(3) | Container(700).HasPrevious + Container(9000).HasFocus(7) | Container(400).HasPrevious + Container(9000).HasFocus(4)</visible>
-
-				<animation type="Visible">
-					<effect type="Fade" start="0" end="100" time="200"/>
-					<effect type="slide" start="0,10" end="0,0" time="200"/>
-				</animation>
-				<animation type="Hidden">
-					<effect type="Fade" start="100" end="0" time="200"/>
-					<effect type="slide" start="0,0" end="0,-10" time="200"/>
-				</animation>
-
-			</control>
-			<control type="image">
-				<include>SkinSettings_coords6</include>
-				<texture colordiffuse="$VAR[DialogColor2]">down.png</texture>
-
-				<visible>Container(300).HasNext + Container(9000).HasFocus(3) | Container(700).HasNext + Container(9000).HasFocus(7) | Container(400).HasNext + Container(9000).HasFocus(4)</visible>
-
-				<animation type="Visible">
-					<effect type="Fade" start="0" end="100" time="200"/>
-					<effect type="slide" start="0,-10" end="0,0" time="200"/>
-				</animation>
-				<animation type="Hidden">
-					<effect type="Fade" start="100" end="0" time="200"/>
-					<effect type="slide" start="0,0" end="0,10" time="200"/>
-				</animation>
-			</control>
+			<visible>Container(9000).HasFocus(1)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords6</include>
+			<visible>Container(9000).HasFocus(2)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords7</include>
+			<visible>Container(9000).HasFocus(3)</visible>
+		</control>
+			<control type="group">
+			<include>SkinSettings_coords8</include>
+			<visible>Container(9000).HasFocus(4)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords9</include>
+			<visible>Container(9000).HasFocus(5)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords10</include>
+			<visible>Container(9000).HasFocus(6)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords11</include>
+			<visible>Container(9000).HasFocus(7)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords12</include>
+			<visible>Container(9000).HasFocus(8)</visible>
+		</control>
+		<control type="group">
+			<include>SkinSettings_coords13</include>
+			<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(10000).HasFocus">Conditional</animation>
 		</control>
 		
 		<!-- Home items -->
 		<control type="group" id="10000">
-			<include>SkinSettings_coords7</include>
+			<include>SkinSettings_coords14</include>
 			<control type="grouplist" id="100">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -135,7 +136,7 @@
 				<visible>Container(9000).HasFocus(1)</visible>
 				<!-- Edit menu-->
 				<control type="button" id="101">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label>31049</label>
 					<font>Font33</font>
 					<onclick>RunScript(script.skinshortcuts,type=manage&amp;group=mainmenu)</onclick>
@@ -144,7 +145,7 @@
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
 				<control type="button" id="102">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label>$LOCALIZE[31030]</label>
 					<font>Font33</font>
 					<onclick>InstallAddon(script.skinshortcuts)</onclick>
@@ -156,7 +157,7 @@
 				</control>
 				<!-- Always show settings link -->
 				<control type="radiobutton" id="103">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31096]</label>
 					<onclick>Skin.ToggleSetting(AlwaysShowSettingsLink)</onclick>
@@ -165,7 +166,7 @@
 				</control>
 				<!-- Show date above system time -->
 				<control type="radiobutton" id="104">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31101</label>
 					<onclick>Skin.ToggleSetting(Dateaboveclock)</onclick>
@@ -175,7 +176,7 @@
 
 			<!-- Background -->
 			<control type="grouplist" id="200">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -187,14 +188,14 @@
 				<visible>Container(9000).HasFocus(2)</visible>
 				<!-- Default background image -->
 				<control type="radiobutton" id="201">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[13278]</label>
 					<onclick>Skin.SetString(BackgroundDefaultImage,yes)</onclick>
 					<selected>String.IsEqual(Skin.String(BackgroundDefaultImage),yes)</selected>
 				</control>
 				<control type="button" id="202">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[33068]</label>
 					<label2>$INFO[Skin.String(BackgroundImage)]</label2>
@@ -208,7 +209,7 @@
 				</control>
 				<!-- Custom background image -->
 				<control type="radiobutton" id="203">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[636]</label>
 					<onclick>Skin.SetString(BackgroundDefaultImage,no)</onclick>
@@ -216,7 +217,7 @@
 				</control>
 				<!-- Single custom background image -->
 				<control type="radiobutton" id="204">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31135]</label>
 					<onclick>Skin.SetString(BackgroundSingleImage,yes)</onclick>
@@ -224,7 +225,7 @@
 					<selected>String.IsEqual(Skin.String(BackgroundSingleImage),yes)</selected>
 				</control>
 				<control type="button" id="205">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>    - $LOCALIZE[1024]</label>
 					<label2>$INFO[Skin.String(CustomBackground)]</label2>
@@ -234,7 +235,7 @@
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
 				<control type="button" id="206">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>    - $LOCALIZE[31139]</label>
 					<onclick>Skin.Reset(CustomBackground)</onclick>
@@ -243,7 +244,7 @@
 				</control>
 				<!-- Multiple custom background images -->
 				<control type="radiobutton" id="207">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31136]</label>
 					<onclick>Skin.SetString(BackgroundSingleImage,no)</onclick>
@@ -251,7 +252,7 @@
 					<selected>String.IsEqual(Skin.String(BackgroundSingleImage),no)</selected>
 				</control>
 				<control type="button" id="208">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>    - $LOCALIZE[1024]</label>
 					<label2>$INFO[Skin.String(CustomBackgroundFolder)]</label2>
@@ -261,7 +262,7 @@
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
 				<control type="button" id="209">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>    - $LOCALIZE[31139]</label>
 					<onclick>Skin.Reset(CustomBackgroundFolder)</onclick>
@@ -269,7 +270,7 @@
 					<visible>String.IsEqual(Skin.String(BackgroundDefaultImage),no) + String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder))</visible>
 				</control>
 				<control type="button" id="210">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>    - $LOCALIZE[31137]</label>
 					<label2>$INFO[Skin.String(CustomBackgroundFolderDuration)]</label2>
@@ -287,7 +288,7 @@
 				</control>
 				<!-- Display fanart -->
 				<control type="radiobutton" id="211">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31099]</label>
 					<onclick>Skin.ToggleSetting(HideFanart)</onclick>
@@ -295,7 +296,7 @@
 				</control>
 				<!-- Background video -->
 				<control type="radiobutton" id="212">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31027</label>
 					<onclick>Skin.ToggleSetting(BackgroundVideo)</onclick>
@@ -303,7 +304,7 @@
 				</control>
 				<!-- Background visualisation -->
 				<control type="radiobutton" id="213">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31028</label>
 					<onclick>Skin.ToggleSetting(BackgroundVisualisation)</onclick>
@@ -311,7 +312,7 @@
 				</control>
 				<!-- Enable artist slideshow -->
 				<control type="radiobutton" id="214">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31034</label>
 					<onclick>Skin.ToggleSetting(EnableArtistFanart)</onclick>
@@ -321,7 +322,7 @@
 			
 			<!-- Colors -->
 			<control type="grouplist" id="300">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -333,7 +334,7 @@
 				<visible>Container(9000).HasFocus(3)</visible>
 				<!-- Default colors -->
 				<control type="radiobutton" id="301">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[13278]</label>
 					<onclick>Skin.SetString(DefaultColors,yes)</onclick>
@@ -341,7 +342,7 @@
 				</control>
 				<!-- Default color sets -->
 				<control type="button" id="302">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31108]</label>
 					<label2>$INFO[Skin.String(DefaultColorSet)]</label2>
@@ -360,7 +361,7 @@
 				</control>
 				<!-- Background opacity -->
 				<control type="button" id="303">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31109]</label>
 					<label2>$INFO[Skin.String(DefaultBackgroundOpacity)]</label2>
@@ -374,7 +375,7 @@
 				</control>
 				<!-- Overlay opacity -->
 				<control type="button" id="304">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31110]</label>
 					<label2>$INFO[Skin.String(DefaultOverlayOpacity)]</label2>
@@ -388,7 +389,7 @@
 				</control>
 				<!-- Background color gradient -->
 				<control type="button" id="305">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31111]</label>
 					<label2>$VAR[OSMCBackgroundOverlayName]</label2>
@@ -402,7 +403,7 @@
 				</control>
 				<!-- Custom colors -->
 				<control type="radiobutton" id="306">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[636]</label>
 					<onclick>Skin.SetString(DefaultColors,no)</onclick>
@@ -410,7 +411,7 @@
 				</control>
 				<!-- Custom background color -->
 				<control type="button" id="307">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31162]</label>
 					<label2>$VAR[BackgroundColor-Name]</label2>
@@ -422,7 +423,7 @@
 				</control>
 				<!-- Custom overlay color -->
 				<control type="button" id="308">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31062]</label>
 					<label2>$VAR[OverlayColor-Name]</label2>
@@ -434,7 +435,7 @@
 				</control>
 				<!-- Custom focus text color -->
 				<control type="button" id="309">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31163]</label>
 					<label2>$VAR[TextColor1-Name]</label2>
@@ -446,7 +447,7 @@
 				</control>
 				<!-- Custom non-focus text color -->
 				<control type="button" id="310">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31164]</label>
 					<label2>$VAR[TextColor2-Name]</label2>
@@ -458,7 +459,7 @@
 				</control>
 				<!-- Custom selected text color -->
 				<control type="button" id="311">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31165]</label>
 					<label2>$VAR[SelectedColor-Name]</label2>
@@ -470,7 +471,7 @@
 				</control>
 				<!-- Custom disabled text color -->
 				<control type="button" id="312">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31166]</label>
 					<label2>$VAR[TextColor4-Name]</label2>
@@ -484,7 +485,7 @@
 			
 			<!-- OSD -->
 			<control type="grouplist" id="400">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -496,7 +497,7 @@
 				<visible>Container(9000).HasFocus(4)</visible>
 				<!-- Video OSD -->
 				<control type="label" id="401">
-					<include>SkinSettings_coords10</include>
+					<include>SkinSettings_coords17</include>
 					<font>Font33-italic</font>
 					<align>left</align>
 					<label>$LOCALIZE[31144]</label>
@@ -504,7 +505,7 @@
 				</control>
 				<!-- OSD info video start -->
 				<control type="radiobutton" id="402">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31123</label>
 					<onclick>Skin.ToggleSetting(videoinfostart)</onclick>
@@ -512,7 +513,7 @@
 				</control>
 				<!-- Movies -->
 				<control type="radiobutton" id="403">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31124]</label>
 					<onclick>Skin.ToggleSetting(videoinfostartmovies)</onclick>
@@ -521,7 +522,7 @@
 				</control>
 				<!-- TV shows -->
 				<control type="radiobutton" id="404">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31125]</label>
 					<onclick>Skin.ToggleSetting(videoinfostarttvshow)</onclick>
@@ -530,7 +531,7 @@
 				</control>
 				<!-- Live TV -->
 				<control type="radiobutton" id="405">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31126]</label>
 					<onclick>Skin.ToggleSetting(videoinfostartlivetv)</onclick>
@@ -539,7 +540,7 @@
 				</control>
 				<!-- Music videos -->
 				<control type="radiobutton" id="406">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31127]</label>
 					<onclick>Skin.ToggleSetting(videoinfostartmusicvideo)</onclick>
@@ -548,7 +549,7 @@
 				</control>
 				<!-- Other videos -->
 				<control type="radiobutton" id="407">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31128]</label>
 					<onclick>Skin.ToggleSetting(videoinfostartfiles)</onclick>
@@ -557,7 +558,7 @@
 				</control>
 				<!-- OSD info video start duration -->
 				<control type="button" id="408">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31129]</label>
 					<label2>$INFO[Skin.String(videoinfostartduration)]</label2>
@@ -571,7 +572,7 @@
 				</control>
 				<!-- OSD info PVR channel switch -->
 				<control type="radiobutton" id="409">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31130]</label>
 					<onclick>Skin.ToggleSetting(videoinfolivetvswitch)</onclick>
@@ -579,7 +580,7 @@
 				</control>
 				<!-- OSD info video end -->
 				<control type="radiobutton" id="410">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31131</label>
 					<onclick>Skin.ToggleSetting(videoinfoend)</onclick>
@@ -587,7 +588,7 @@
 				</control>
 				<!-- Movies -->
 				<control type="radiobutton" id="411">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31124]</label>
 					<onclick>Skin.ToggleSetting(videoinfoendmovie)</onclick>
@@ -596,7 +597,7 @@
 				</control>
 				<!-- TV shows -->
 				<control type="radiobutton" id="412">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31125]</label>
 					<onclick>Skin.ToggleSetting(videoinfoendtvshow)</onclick>
@@ -605,7 +606,7 @@
 				</control>
 				<!-- Music videos -->
 				<control type="radiobutton" id="413">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31127]</label>
 					<onclick>Skin.ToggleSetting(videoinfoendmusicvideo)</onclick>
@@ -614,7 +615,7 @@
 				</control>
 				<!-- Other videos -->
 				<control type="radiobutton" id="414">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31128]</label>
 					<onclick>Skin.ToggleSetting(videoinfoendfiles)</onclick>
@@ -623,7 +624,7 @@
 				</control>
 				<!-- OSD info video start duration -->
 				<control type="button" id="415">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31132]</label>
 					<label2>$INFO[Skin.String(videoinfoendduration)]</label2>
@@ -637,7 +638,7 @@
 				</control>
 				<!-- Adjust OSD on-time during video pause -->
 				<control type="button" id="416">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31102]</label>
 					<label2>$INFO[Skin.String(HideOSD)]</label2>
@@ -656,7 +657,7 @@
 				</control>
 				<!-- Music OSD -->
 				<control type="label" id="417">
-					<include>SkinSettings_coords10</include>
+					<include>SkinSettings_coords17</include>
 					<font>Font33-italic</font>
 					<align>left</align>
 					<label>$LOCALIZE[31145]</label>
@@ -664,14 +665,14 @@
 				</control>
 				<!-- Automatically show music OSD during playback -->
 				<control type="radiobutton" id="418">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31142]</label>
 					<onclick>Skin.ToggleSetting(AutoMusicVisPlayback)</onclick>
 					<selected>Skin.HasSetting(AutoMusicVisPlayback)</selected>
 				</control>
 				<control type="button" id="419">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31143]</label>
 					<label2>$INFO[Skin.String(AutoMusicVisPlaybackDuration)]</label2>
@@ -686,7 +687,7 @@
 				</control>
 				<!-- Adjust music OSD album art size -->
 				<control type="radiobutton" id="420">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31115</label>
 					<onclick>Skin.ToggleSetting(MusicOSDSize)</onclick>
@@ -696,7 +697,7 @@
 
 			<!-- Weather -->
 			<control type="grouplist" id="500">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -708,7 +709,7 @@
 				<visible>Container(9000).HasFocus(5)</visible>
 				<!-- Weather icons-->
 				<control type="button" id="501">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31067]</label>
 					<label2>$VAR[weather-icons]</label2>
@@ -719,7 +720,7 @@
 				</control>
 				<!-- Weather fanart -->
 				<control type="button" id="502">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<onclick condition="System.HasAddon(script.image.resource.select)">RunScript(script.image.resource.select,property=weatherFanart&amp;type=resource.images.weatherfanart)</onclick>
 					<onclick condition="!System.HasAddon(script.image.resource.select)">InstallAddon(script.image.resource.select)</onclick>
@@ -730,7 +731,7 @@
 				</control>
 				<!-- Warning label for multi-image fanart -->
 				<control type="label" id="503">
-					<include>SkinSettings_coords10</include>
+					<include>SkinSettings_coords17</include>
 					<font>Font33</font>
 					<label> - $LOCALIZE[31094]</label>
 					<visible>Skin.HasSetting(weatherFanart.multi)</visible>
@@ -740,7 +741,7 @@
 
 			<!-- Advanced -->
 			<control type="grouplist" id="600">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -752,7 +753,7 @@
 				<visible>Container(9000).HasFocus(6)</visible>
 				<!-- Hide additional text highlighting -->
 				<control type="radiobutton" id="601">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31105</label>
 					<onclick>Skin.ToggleSetting(TextHighlight)</onclick>
@@ -760,7 +761,7 @@
 				</control>
 				<!-- Hide video watched status in library -->
 				<control type="radiobutton" id="602">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31148</label>
 					<onclick>Skin.ToggleSetting(VideoWatchedStatus)</onclick>
@@ -768,7 +769,7 @@
 				</control>
 				<!-- Hide music listened to status in library -->
 				<control type="radiobutton" id="603">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31149</label>
 					<onclick>Skin.ToggleSetting(MusicListenedToStatus)</onclick>
@@ -776,7 +777,7 @@
 				</control>
 				<!-- Hide sub-menu player controls -->
 				<control type="radiobutton" id="604">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31147</label>
 					<onclick>Skin.ToggleSetting(SubMenuControls)</onclick>
@@ -784,7 +785,7 @@
 				</control>
 				<!-- Show user rating -->
 				<control type="radiobutton" id="605">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31146</label>
 					<onclick>Skin.ToggleSetting(UserRating)</onclick>
@@ -792,7 +793,7 @@
 				</control>
 				<!-- Adjust non-focus dim opacity -->
 				<control type="button" id="606">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31104]</label>
 					<label2>$INFO[Skin.String(NFDimOpac),,%]</label2>
@@ -807,7 +808,7 @@
 				</control>
 				<!-- Adjust plot/description text font size -->
 				<control type="button" id="607">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31100]</label>
 					<label2>$INFO[Skin.String(PlotFont),Size ,]</label2>
@@ -824,7 +825,7 @@
 				</control>
 				<!-- Adjust representation of video duration -->
 				<control type="button" id="608">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31134]</label>
 					<label2>$INFO[Skin.String(videodurationformat)]</label2>
@@ -835,7 +836,7 @@
 				</control>
 				<!-- Kiosk mode -->
 				<control type="radiobutton" id="609">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31057</label>
 					<onclick>Skin.ToggleSetting(KioskMode)</onclick>
@@ -845,7 +846,7 @@
 
 			<!-- Addons -->
 			<control type="grouplist" id="700">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -857,14 +858,14 @@
 				<visible>Container(9000).HasFocus(7)</visible>
 				<!-- Recommended -->
 				<control type="label" id="701">
-					<include>SkinSettings_coords10</include>
+					<include>SkinSettings_coords17</include>
 					<font>Font33-italic</font>
 					<align>left</align>
 					<label>$LOCALIZE[31080]</label>
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
 				<control type="button" id="702">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31079]</label>
 					<label2>$VAR[addon-skinshortcuts]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skinshortcuts)) + !System.HasAddon(script.skinshortcuts)">InstallAddon(script.skinshortcuts)</onclick>
@@ -872,7 +873,7 @@
 					<onclick condition="System.HasAddon(script.skinshortcuts)">Addon.OpenSettings(script.skinshortcuts)</onclick>
 				</control>
 				<control type="button" id="703">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31081]</label>
 					<label2>$VAR[addon-skinhelper]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.service)) + !System.HasAddon(script.skin.helper.service)">InstallAddon(script.skin.helper.service)</onclick>
@@ -880,7 +881,7 @@
 					<onclick condition="System.HasAddon(script.skin.helper.service)">Addon.OpenSettings(script.skin.helper.service)</onclick>
 				</control>
 				<control type="button" id="704">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31140]</label>
 					<label2>$VAR[addon-skinhelperbackgrounds]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.backgrounds)) + !System.HasAddon(script.skin.helper.backgrounds)">InstallAddon(script.skin.helper.backgrounds)</onclick>
@@ -888,7 +889,7 @@
 					<onclick condition="System.HasAddon(script.skin.helper.backgrounds)">Addon.OpenSettings(script.skin.helper.backgrounds)</onclick>
 				</control>
 				<control type="button" id="705">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31106]</label>
 					<label2>$VAR[addon-skinhelperwidgets]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.widgets)) + !System.HasAddon(script.skin.helper.widgets)">InstallAddon(script.skin.helper.widgets)</onclick>
@@ -896,7 +897,7 @@
 					<onclick condition="System.HasAddon(script.skin.helper.widgets)">Addon.OpenSettings(script.skin.helper.widgets)</onclick>
 				</control>
 				<control type="button" id="706">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31097]</label>
 					<label2>$VAR[addon-skinhelperbackup]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.skinbackup)) + !System.HasAddon(script.skin.helper.skinbackup)">InstallAddon(script.skin.helper.skinbackup)</onclick>
@@ -905,14 +906,14 @@
 				</control>
 				<!-- Supported -->
 				<control type="label" id="707">
-					<include>SkinSettings_coords10</include>
+					<include>SkinSettings_coords17</include>
 					<font>Font33-italic</font>
 					<align>left</align>
 					<label>$LOCALIZE[31084]</label>
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
 				<control type="button" id="708">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31082]</label>
 					<label2>$VAR[addon-autocompletion]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(plugin.program.autocompletion)) + !System.HasAddon(plugin.program.autocompletion)">InstallAddon(plugin.program.autocompletion)</onclick>
@@ -920,7 +921,7 @@
 					<onclick condition="System.HasAddon(plugin.program.autocompletion)">Addon.OpenSettings(plugin.program.autocompletion)</onclick>
 				</control>
 				<control type="button" id="709">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31083]</label>
 					<label2>$VAR[addon-imageselect]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.image.resource.select)) + !System.HasAddon(script.image.resource.select)">InstallAddon(script.image.resource.select)</onclick>
@@ -928,7 +929,7 @@
 					<onclick condition="System.HasAddon(script.image.resource.select)">Addon.OpenSettings(script.image.resource.select)</onclick>
 				</control>
 				<!-- <control type="button" id="710">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31085]</label>
 					<label2>$VAR[addon-nextup]</label2>
 					<onclick condition="!String.IsEmpty(System.AddonVersion(service.nextup.notification)) + System.HasAddon(service.nextup.notification)">InstallAddon(service.nextup.notification)</onclick>
@@ -936,7 +937,7 @@
 					<onclick condition="System.HasAddon(service.nextup.notification)">Addon.OpenSettings(service.nextup.notification)</onclick>
 				</control> -->
 				<control type="button" id="711">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label> - $LOCALIZE[31086]</label>
 					<label2>$VAR[addon-artistslideshow]</label2>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.artistslideshow)) + !System.HasAddon(script.artistslideshow)">InstallAddon(script.artistslideshow)</onclick>
@@ -947,7 +948,7 @@
 
 			<!-- Reset/Debug -->
 			<control type="grouplist" id="800">
-				<include>SkinSettings_coords8</include>
+				<include>SkinSettings_coords15</include>
 				<itemgap>0</itemgap>
 				<onleft>9000</onleft>
 				<onright>noop</onright>
@@ -959,7 +960,7 @@
 				<visible>Container(9000).HasFocus(8)</visible>
 				<!-- Backup -->
 				<control type="button" id="801">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<onclick condition="String.IsEmpty(System.AddonVersion(script.skin.helper.skinbackup)) + !System.HasAddon(script.skin.helper.skinbackup)">InstallAddon(script.skin.helper.skinbackup)</onclick>
 					<onclick condition="!String.IsEmpty(System.AddonVersion(script.skin.helper.skinbackup)) + !System.HasAddon(script.skin.helper.skinbackup)">ActivateWindow(1104)</onclick>
 					<onclick condition="System.HasAddon(script.skin.helper.skinbackup)">RunScript(script.skin.helper.skinbackup)</onclick>
@@ -969,7 +970,7 @@
 				</control>
 				<!-- Reset all -->
 				<control type="button" id="802">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<onclick>RunScript(script.skinshortcuts,type=resetall)</onclick>
 					<label>$ADDON[script.skinshortcuts 32037]</label>
 					<visible>System.HasAddon(script.skinshortcuts)</visible>
@@ -978,7 +979,7 @@
 				</control>
 				<!-- Reset skin settings -->
 				<control type="button" id="803">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<label>31058</label>
 					<onclick>Skin.ResetSettings</onclick>
 					<onclick>ReloadSkin()</onclick>
@@ -987,7 +988,7 @@
 				</control>
 				<!-- Lock PVR guide view -->
 				<control type="radiobutton" id="804">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31098]</label>
 					<onclick>Skin.ToggleSetting(GuideLocked)</onclick>
@@ -995,7 +996,7 @@
 				</control>
 				<!-- Enable Debug Grid -->
 				<control type="radiobutton" id="805">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31041</label>
 					<onclick>Skin.ToggleSetting(DebugGrid)</onclick>
@@ -1003,7 +1004,7 @@
 				</control>
 				<!-- Disable Debug Info -->
 				<control type="radiobutton" id="806">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31042</label>
 					<onclick>Skin.ToggleSetting(DebugInfo)</onclick>
@@ -1011,7 +1012,7 @@
 				</control>
 				<!-- Reload skin -->
 				<control type="button" id="807">
-					<include>SkinSettings_coords9</include>
+					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>20183</label>
 					<onclick>ReloadSkin()</onclick>
@@ -1023,7 +1024,7 @@
 
 		<!-- Hide settings warning -->
 		<control type="textbox">
-			<include>SkinSettings_coords11</include>
+			<include>SkinSettings_coords18</include>
 			<label>31051</label>
 			<textcolor>$VAR[TextColor1]</textcolor>
 			<visible>Container(9000).HasFocus(1) + Skin.HasSetting(AlwaysShowSettingsLink) + System.HasAddon(script.skinshortcuts)</visible>

--- a/xml/script-skinshortcuts-static.xml
+++ b/xml/script-skinshortcuts-static.xml
@@ -1672,7 +1672,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>
@@ -1867,7 +1868,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>
@@ -2060,7 +2062,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>
@@ -2253,7 +2256,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>
@@ -2446,7 +2450,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>
@@ -2769,7 +2774,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>
@@ -2962,7 +2968,8 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="90" end="100" center="102,326" time="300" tween="back" easing="out" reversible="false">Focus</animation>
+					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out">Focus</animation>
+					<animation effect="zoom" start="100" end="80" center="auto" time="30" tween="linear">Unfocus</animation>
 					<include content="widget-image">
 						<description>Primary art</description>
 						<param name="left">0</param>


### PR DESCRIPTION
strings.po:
- add new localizes for second video info dialog screen (31170, 31171)

Coordinates_Home.xml:
- add missing coordinates

Coordinates_Includes.xml:
- add missing coordinates

Coordinates_SkinSettings.xml:
- add missing coordinates

DialogVideoInfo.xml:
- replace extended info button localizes

Home.xml:
- move remaining coordinates to corresponding coordinates file 

Include_Home_OSMC.xml:
- move remaining coordinates to corresponding coordinates file 

Includes.xml:
- rework dialog animations to prevent bright transition

script-skinshortcuts-static.xml:
- improve widget icon animations

SkinSettings.xml:
- move remaining coordinates to corresponding coordinates file

addon.xml:
- update changelog

Changelog.md:
- update changelog