### PR TITLE
Horizontal view improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,11 +9,12 @@ _Improved_
 - improve sort by and sort order toggles
 - improve video info dialog (animations and buttons)
 - improve alignment and positioning of item count and media flags
-- smooth transitions between views
+- show view toggle only when more than one view is available
 
 _Fixed_
 - move hide scrollbars setting to skin settings window
 - hide MyOSMC home menu entry and widget on non-OSMC systems
+- fix overlapping in views with big horizontal titles
 
 **Changelog v18.2.0**
 
@@ -38,6 +39,28 @@ Coordinates_Includes.xml:
 - add SideMenuControlsSpacer_coords13 include for only one item in side/context menu
 - change positioning of media flags (aligned with item count)
 
+Coordinates_MyVideoNav.xml:
+- move year and genre label slightly up to match media flags and item count positioning
+
+Coordinates_Viewtype52.xml:
+- move whole view down to match title/scrollbar positioning of other horizontal views
+- fix width of title and year/genre label control
+
+Coordinates_Viewtype53.xml:
+- fix width of title and year/genre label control
+
+Coordinates_Viewtype55.xml:
+- fix width of title and year/genre label control
+
+Coordinates_Viewtype521.xml:
+- fix width of title and year/genre label control
+
+Coordinates_Viewtype532.xml:
+- fix width of title and year/genre label control
+
+Coordinates_Viewtype534.xml:
+- fix width of title and year/genre label control
+
 DialogFavourites.xml:
 - change conditional onleft of scrollbar (submenu is only present during playback with active side-menu controls)
 - change conditional visibility of submenu indicator (submenu is only present during playback with active side-menu controls)
@@ -57,35 +80,34 @@ Includes.xml:
 - fix alignment of item count and media flags
 - add new hide media flags functionality
 - change seperator of duration/size label
+- rework media flags and item count to add scrolling
 
 MyGames.xml:
 - add new "View: " localize to view toggle
 - remove hide scrollbar toggle
 - add new "Sort order" localize to sort order toggle
-- add animation for view change
+- hide view submenu button with containers that only support one viewtype
 
 MyMusicNav.xml:
 - add new "View: " localize to view toggle
 - remove hide scrollbar toggle
 - add new "Sort order" localize to sort order toggle
-- add animation for view change
+- hide view submenu button with containers that only support one viewtype
 
 MyPics.xml:
 - remove hide scrollbar toggle
 - add new "Sort order" localize to sort order toggle
-- add animation for view change
+- remove view submenu button
 
 MyPlaylist.xml:
 - fix side-menu coordinates
 - remove hide scrollbar toggle
 - add new "Sort order" localize to sort order toggle
-- add animation for view change
 
 MyPrograms.xml:
 - add new "View: " localize to view toggle
 - remove hide scrollbar toggle
 - add new "Sort order" localize to sort order toggle
-- add animation for view change
 
 MyPVRChannels.xml:
 - fix side-menu coordinates
@@ -115,7 +137,7 @@ MyVideoNav.xml:
 - add new "View: " localize to view toggle
 - remove hide scrollbar toggle
 - add new "Sort order" localize to sort order toggle
-- add animation for view change
+- hide view submenu button with containers that only support one viewtype
 
 script-skinshortcuts-static.xml:
 - add conditional visibility to MyOSMC home menu entry

--- a/addon.xml
+++ b/addon.xml
@@ -16,6 +16,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new pre-defined widgets[CR]- add setting to hide media flags[CR][CR][B]Improved[/B][CR]- rework of home menu customization dialogs[CR]- improve sort by and sort order toggles[CR]- improve video info dialog (animations and buttons)[CR]- improve alignment and positioning of item count and media flags[CR]- smooth transitions between views[CR][CR][B]Fixed[/B][CR]- move hide scrollbars setting to skin settings window[CR]- hide MyOSMC home menu entry and widget on non-OSMC systems</news>
+		<news>[B]New[/B][CR]- add new pre-defined widgets[CR]- add setting to hide media flags[CR][CR][B]Improved[/B][CR]- rework of home menu customization dialogs[CR]- improve sort by and sort order toggles[CR]- improve video info dialog (animations and buttons)[CR]- improve alignment and positioning of item count and media flags[CR]- show view toggle only when more than one view is available[CR][CR][B]Fixed[/B][CR]- move hide scrollbars setting to skin settings window[CR]- hide MyOSMC home menu entry and widget on non-OSMC systems[CR]- fix overlapping in views with big horizontal titles</news>
 	</extension>
 </addon>

--- a/xml/Coordinates_Includes.xml
+++ b/xml/Coordinates_Includes.xml
@@ -293,30 +293,6 @@
 		<height>60</height>
 	</include>
 	
-	<include name="ItemCount_coords">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">ItemCount_coords_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">ItemCount_coords_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">ItemCount_coords_4:3</include>
-	</include>
-	<include name="ItemCount_coords_16:9">
-		<right>120</right>
-		<bottom>120</bottom>
-		<width>800</width>
-		<height>40</height>
-	</include>
-	<include name="ItemCount_coords_21:9">
-		<right>120</right>
-		<bottom>120</bottom>
-		<width>800</width>
-		<height>40</height>
-	</include>
-	<include name="ItemCount_coords_4:3">
-		<right>120</right>
-		<bottom>120</bottom>
-		<width>600</width>
-		<height>40</height>
-	</include>
-	
 	<include name="MediaFlags_coords1">
 		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">MediaFlags_coords1_16:9</include>
 		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">MediaFlags_coords1_21:9</include>
@@ -324,21 +300,21 @@
 	</include>
 	<include name="MediaFlags_coords1_16:9">
 		<left>120</left>
-		<bottom>160</bottom>
-		<width>480</width>
-		<height>40</height>
+		<bottom>120</bottom>
+		<width>400</width>
+		<height>90</height>
 	</include>
 	<include name="MediaFlags_coords1_21:9">
 		<left>120</left>
-		<bottom>160</bottom>
-		<width>480</width>
-		<height>40</height>
+		<bottom>120</bottom>
+		<width>400</width>
+		<height>90</height>
 	</include>
 	<include name="MediaFlags_coords1_4:3">
 		<left>120</left>
-		<bottom>160</bottom>
-		<width>480</width>
-		<height>40</height>
+		<bottom>120</bottom>
+		<width>400</width>
+		<height>90</height>
 	</include>
 	
 	<include name="MediaFlags_coords2">
@@ -348,18 +324,18 @@
 	</include>
 	<include name="MediaFlags_coords2_16:9">
 		<top>2</top>
-		<width>40</width>
-		<height>36</height>
+		<width>30</width>
+		<height>26</height>
 	</include>
 	<include name="MediaFlags_coords2_21:9">
 		<top>2</top>
-		<width>40</width>
-		<height>36</height>
+		<width>30</width>
+		<height>26</height>
 	</include>
 	<include name="MediaFlags_coords2_4:3">
 		<top>2</top>
-		<width>40</width>
-		<height>36</height>
+		<width>30</width>
+		<height>26</height>
 	</include>
 	
 	<include name="MediaFlags_coords3">
@@ -368,22 +344,19 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MediaFlags_coords3_4:3</include>
 	</include>
 	<include name="MediaFlags_coords3_16:9">
-		<left>120</left>
-		<bottom>120</bottom>
-		<width>480</width>
-		<height>40</height>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
 	</include>
 	<include name="MediaFlags_coords3_21:9">
-		<left>120</left>
-		<bottom>120</bottom>
-		<width>480</width>
-		<height>40</height>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
 	</include>
 	<include name="MediaFlags_coords3_4:3">
-		<left>120</left>
-		<bottom>120</bottom>
-		<width>480</width>
-		<height>40</height>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
 	</include>
 	
 	<include name="MediaFlags_coords4">
@@ -392,22 +365,112 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MediaFlags_coords4_4:3</include>
 	</include>
 	<include name="MediaFlags_coords4_16:9">
-		<left>120</left>
-		<bottom>80</bottom>
-		<width>800</width>
-		<height>40</height>
+		<top>32</top>
+		<width>30</width>
+		<height>26</height>
 	</include>
 	<include name="MediaFlags_coords4_21:9">
-		<left>120</left>
-		<bottom>80</bottom>
-		<width>800</width>
-		<height>40</height>
+		<top>32</top>
+		<width>30</width>
+		<height>26</height>
 	</include>
 	<include name="MediaFlags_coords4_4:3">
-		<left>120</left>
-		<bottom>80</bottom>
-		<width>800</width>
-		<height>40</height>
+		<top>32</top>
+		<width>30</width>
+		<height>26</height>
+	</include>
+	
+	<include name="MediaFlags_coords5">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">MediaFlags_coords5_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">MediaFlags_coords5_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MediaFlags_coords5_4:3</include>
+	</include>
+	<include name="MediaFlags_coords5_16:9">
+		<top>30</top>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
+	</include>
+	<include name="MediaFlags_coords5_21:9">
+		<top>30</top>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
+	</include>
+	<include name="MediaFlags_coords5_4:3">
+		<top>30</top>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
+	</include>
+	
+	<include name="MediaFlags_coords6">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">MediaFlags_coords6_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">MediaFlags_coords6_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MediaFlags_coords6_4:3</include>
+	</include>
+	<include name="MediaFlags_coords6_16:9">
+		<top>62</top>
+		<width>30</width>
+		<height>26</height>
+	</include>
+	<include name="MediaFlags_coords6_21:9">
+		<top>62</top>
+		<width>30</width>
+		<height>26</height>
+	</include>
+	<include name="MediaFlags_coords6_4:3">
+		<top>62</top>
+		<width>30</width>
+		<height>26</height>
+	</include>
+	
+	<include name="MediaFlags_coords7">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">MediaFlags_coords7_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">MediaFlags_coords7_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MediaFlags_coords7_4:3</include>
+	</include>
+	<include name="MediaFlags_coords7_16:9">
+		<top>60</top>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
+	</include>
+	<include name="MediaFlags_coords7_21:9">
+		<top>60</top>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
+	</include>
+	<include name="MediaFlags_coords7_4:3">
+		<top>60</top>
+		<left>30</left>
+		<width>372</width>
+		<height>30</height>
+	</include>
+	
+	<include name="ItemCount_coords">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">ItemCount_coords_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">ItemCount_coords_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">ItemCount_coords_4:3</include>
+	</include>
+	<include name="ItemCount_coords_16:9">
+		<right>120</right>
+		<bottom>120</bottom>
+		<width>400</width>
+		<height>30</height>
+	</include>
+	<include name="ItemCount_coords_21:9">
+		<right>120</right>
+		<bottom>120</bottom>
+		<width>400</width>
+		<height>30</height>
+	</include>
+	<include name="ItemCount_coords_4:3">
+		<right>120</right>
+		<bottom>120</bottom>
+		<width>400</width>
+		<height>30</height>
 	</include>
 	
 	<include name="KeyboardButtons_coords">

--- a/xml/Coordinates_MyVideoNav.xml
+++ b/xml/Coordinates_MyVideoNav.xml
@@ -32,19 +32,19 @@
 	</include>
 	<include name="MyVideoNav_coords2_16:9">
 		<centerleft>50%</centerleft>
-		<top>766</top>
+		<top>812</top>
 		<width>1680</width>
 		<height>20</height>
 	</include>
 	<include name="MyVideoNav_coords2_21:9">
 		<centerleft>50%</centerleft>
-		<top>766</top>
+		<top>812</top>
 		<width>2320</width>
 		<height>20</height>
 	</include>
 	<include name="MyVideoNav_coords2_4:3">
 		<centerleft>50%</centerleft>
-		<top>766</top>
+		<top>812</top>
 		<width>1200</width>
 		<height>20</height>
 	</include>
@@ -79,22 +79,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MyVideoNav_coords4_4:3</include>
 	</include>
 	<include name="MyVideoNav_coords4_16:9">
-		<centerleft>50%</centerleft>
-		<top>812</top>
-		<width>1680</width>
-		<height>20</height>
+		<left>120</left>
+		<top>442</top>
+		<width>20</width>
+		<height>362</height>
 	</include>
 	<include name="MyVideoNav_coords4_21:9">
-		<centerleft>50%</centerleft>
-		<top>812</top>
-		<width>2320</width>
-		<height>20</height>
+		<left>120</left>
+		<top>442</top>
+		<width>20</width>
+		<height>362</height>
 	</include>
 	<include name="MyVideoNav_coords4_4:3">
-		<centerleft>50%</centerleft>
-		<top>812</top>
-		<width>1200</width>
-		<height>20</height>
+		<left>120</left>
+		<top>442</top>
+		<width>20</width>
+		<height>362</height>
 	</include>
 	
 	<include name="MyVideoNav_coords5">
@@ -104,21 +104,21 @@
 	</include>
 	<include name="MyVideoNav_coords5_16:9">
 		<left>120</left>
-		<top>442</top>
+		<top>242</top>
 		<width>20</width>
-		<height>362</height>
+		<height>562</height>
 	</include>
 	<include name="MyVideoNav_coords5_21:9">
 		<left>120</left>
-		<top>442</top>
+		<top>242</top>
 		<width>20</width>
-		<height>362</height>
+		<height>562</height>
 	</include>
 	<include name="MyVideoNav_coords5_4:3">
 		<left>120</left>
-		<top>442</top>
+		<top>242</top>
 		<width>20</width>
-		<height>362</height>
+		<height>562</height>
 	</include>
 	
 	<include name="MyVideoNav_coords6">
@@ -127,42 +127,18 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MyVideoNav_coords6_4:3</include>
 	</include>
 	<include name="MyVideoNav_coords6_16:9">
-		<left>120</left>
-		<top>242</top>
+		<left>690</left>
+		<top>192</top>
 		<width>20</width>
-		<height>562</height>
+		<height>633</height>
 	</include>
 	<include name="MyVideoNav_coords6_21:9">
-		<left>120</left>
-		<top>242</top>
+		<left>690</left>
+		<top>192</top>
 		<width>20</width>
-		<height>562</height>
+		<height>633</height>
 	</include>
 	<include name="MyVideoNav_coords6_4:3">
-		<left>120</left>
-		<top>242</top>
-		<width>20</width>
-		<height>562</height>
-	</include>
-	
-	<include name="MyVideoNav_coords7">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">MyVideoNav_coords7_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">MyVideoNav_coords7_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MyVideoNav_coords7_4:3</include>
-	</include>
-	<include name="MyVideoNav_coords7_16:9">
-		<left>690</left>
-		<top>192</top>
-		<width>20</width>
-		<height>633</height>
-	</include>
-	<include name="MyVideoNav_coords7_21:9">
-		<left>690</left>
-		<top>192</top>
-		<width>20</width>
-		<height>633</height>
-	</include>
-	<include name="MyVideoNav_coords7_4:3">
 		<left>690</left>
 		<top>192</top>
 		<width>20</width>

--- a/xml/Coordinates_Viewtype52.xml
+++ b/xml/Coordinates_Viewtype52.xml
@@ -8,7 +8,7 @@
 	</include>
 	<include name="Viewtype52_coords1_16:9">
 		<left>0</left>
-		<top>120</top>
+		<top>170</top>
 		<width>1920</width>
 		<height>750</height>
 		<preloaditems>4</preloaditems>
@@ -16,7 +16,7 @@
 	</include>
 	<include name="Viewtype52_coords1_21:9">
 		<left>0</left>
-		<top>120</top>
+		<top>170</top>
 		<width>2560</width>
 		<height>750</height>
 		<preloaditems>5</preloaditems>
@@ -24,7 +24,7 @@
 	</include>
 	<include name="Viewtype52_coords1_4:3">
 		<left>0</left>
-		<top>120</top>
+		<top>170</top>
 		<width>1440</width>
 		<height>750</height>
 		<preloaditems>4</preloaditems>
@@ -401,21 +401,21 @@
 	</include>
 	<include name="Viewtype52_coords4_16:9">
 		<centerleft>50%</centerleft>
-		<top>800</top>
-		<width>1920</width>
-		<height>100</height>
+		<top>850</top>
+		<width>1680</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype52_coords4_21:9">
 		<centerleft>50%</centerleft>
-		<top>800</top>
-		<width>2560</width>
-		<height>100</height>
+		<top>850</top>
+		<width>2320</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype52_coords4_4:3">
 		<centerleft>50%</centerleft>
-		<top>800</top>
-		<width>1440</width>
-		<height>100</height>
+		<top>850</top>
+		<width>1200</width>
+		<height>142</height>
 	</include>
 	
 	<include name="Viewtype52_coords5">
@@ -424,19 +424,19 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype52_coords5_4:3</include>
 	</include>
 	<include name="Viewtype52_coords5_16:9">
-		<left>120</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
 		<width>1680</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype52_coords5_21:9">
-		<left>120</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
 		<width>2320</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype52_coords5_4:3">
-		<left>120</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
 		<width>1200</width>
 		<height>72</height>
@@ -448,21 +448,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype52_coords6_4:3</include>
 	</include>
 	<include name="Viewtype52_coords6_16:9">
-		<left>500</left>
-		<top>88</top>
-		<width>920</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>800</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype52_coords6_21:9">
-		<left>500</left>
-		<top>88</top>
-		<width>1560</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>1440</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype52_coords6_4:3">
-		<left>500</left>
-		<top>88</top>
-		<width>440</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>320</width>
 		<height>54</height>
 	</include>
 	

--- a/xml/Coordinates_Viewtype521.xml
+++ b/xml/Coordinates_Viewtype521.xml
@@ -340,22 +340,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype521_coords4_4:3</include>
 	</include>
 	<include name="Viewtype521_coords4_16:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>1680</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype521_coords4_21:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>2320</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype521_coords4_4:3">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>440</width>
-		<height>100</height>
+		<width>1200</width>
+		<height>142</height>
 	</include>
 	
 	<include name="Viewtype521_coords5">
@@ -364,21 +364,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype521_coords5_4:3</include>
 	</include>
 	<include name="Viewtype521_coords5_16:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>920</width>
+		<width>1680</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype521_coords5_21:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>1560</width>
+		<width>2320</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype521_coords5_4:3">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>440</width>
+		<width>1200</width>
 		<height>72</height>
 	</include>
 	
@@ -388,21 +388,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype521_coords6_4:3</include>
 	</include>
 	<include name="Viewtype521_coords6_16:9">
-		<left>90</left>
-		<top>88</top>
-		<width>920</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>800</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype521_coords6_21:9">
-		<left>90</left>
-		<top>88</top>
-		<width>1560</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>1440</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype521_coords6_4:3">
-		<left>130</left>
-		<top>88</top>
-		<width>360</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>320</width>
 		<height>54</height>
 	</include>
 	

--- a/xml/Coordinates_Viewtype53.xml
+++ b/xml/Coordinates_Viewtype53.xml
@@ -334,22 +334,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype53_coords4_4:3</include>
 	</include>
 	<include name="Viewtype53_coords4_16:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>1680</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype53_coords4_21:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>2320</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype53_coords4_4:3">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>620</width>
-		<height>100</height>
+		<width>1200</width>
+		<height>142</height>
 	</include>
 	
 	<include name="Viewtype53_coords5">
@@ -358,21 +358,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype53_coords5_4:3</include>
 	</include>
 	<include name="Viewtype53_coords5_16:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>920</width>
+		<width>1680</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype53_coords5_21:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>1560</width>
+		<width>2320</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype53_coords5_4:3">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>620</width>
+		<width>1200</width>
 		<height>72</height>
 	</include>
 	
@@ -382,21 +382,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype53_coords6_4:3</include>
 	</include>
 	<include name="Viewtype53_coords6_16:9">
-		<left>90</left>
-		<top>88</top>
-		<width>920</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>800</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype53_coords6_21:9">
-		<left>90</left>
-		<top>88</top>
-		<width>1560</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>1440</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype53_coords6_4:3">
-		<left>90</left>
-		<top>88</top>
-		<width>620</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>320</width>
 		<height>54</height>
 	</include>
 	

--- a/xml/Coordinates_Viewtype532.xml
+++ b/xml/Coordinates_Viewtype532.xml
@@ -334,22 +334,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype532_coords4_4:3</include>
 	</include>
 	<include name="Viewtype532_coords4_16:9">
-		<left>410</left>
+			<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>1680</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype532_coords4_21:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>2320</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype532_coords4_4:3">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>440</width>
-		<height>100</height>
+		<width>1200</width>
+		<height>142</height>
 	</include>
 	
 	<include name="Viewtype532_coords5">
@@ -358,21 +358,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype532_coords5_4:3</include>
 	</include>
 	<include name="Viewtype532_coords5_16:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>920</width>
+		<width>1680</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype532_coords5_21:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>1560</width>
+		<width>2320</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype532_coords5_4:3">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>440</width>
+		<width>1200</width>
 		<height>72</height>
 	</include>
 	
@@ -382,21 +382,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype532_coords6_4:3</include>
 	</include>
 	<include name="Viewtype532_coords6_16:9">
-		<left>90</left>
-		<top>88</top>
-		<width>920</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>800</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype532_coords6_21:9">
-		<left>90</left>
-		<top>88</top>
-		<width>1560</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>1440</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype532_coords6_4:3">
-		<left>130</left>
-		<top>88</top>
-		<width>360</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>320</width>
 		<height>54</height>
 	</include>
 	

--- a/xml/Coordinates_Viewtype534.xml
+++ b/xml/Coordinates_Viewtype534.xml
@@ -334,22 +334,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype534_coords4_4:3</include>
 	</include>
 	<include name="Viewtype534_coords4_16:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>1680</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype534_coords4_21:9">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>1560</width>
-		<height>100</height>
+		<width>2320</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype534_coords4_4:3">
-		<left>410</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>440</width>
-		<height>100</height>
+		<width>1200</width>
+		<height>142</height>
 	</include>
 	
 	<include name="Viewtype534_coords5">
@@ -358,21 +358,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype534_coords5_4:3</include>
 	</include>
 	<include name="Viewtype534_coords5_16:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>920</width>
+		<width>1680</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype534_coords5_21:9">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>1560</width>
+		<width>2320</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype534_coords5_4:3">
-		<left>90</left>
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>440</width>
+		<width>1200</width>
 		<height>72</height>
 	</include>
 	
@@ -382,21 +382,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype534_coords6_4:3</include>
 	</include>
 	<include name="Viewtype534_coords6_16:9">
-		<left>90</left>
-		<top>88</top>
-		<width>920</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>800</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype534_coords6_21:9">
-		<left>90</left>
-		<top>88</top>
-		<width>1560</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>1440</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype534_coords6_4:3">
-		<left>130</left>
-		<top>88</top>
-		<width>360</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>320</width>
 		<height>54</height>
 	</include>
 	

--- a/xml/Coordinates_Viewtype55.xml
+++ b/xml/Coordinates_Viewtype55.xml
@@ -358,22 +358,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype55_coords4_4:3</include>
 	</include>
 	<include name="Viewtype55_coords4_16:9">
-		<left>150</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>1680</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype55_coords4_21:9">
-		<left>150</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>920</width>
-		<height>100</height>
+		<width>2320</width>
+		<height>142</height>
 	</include>
 	<include name="Viewtype55_coords4_4:3">
-		<left>150</left>
+		<centerleft>50%</centerleft>
 		<top>850</top>
-		<width>1140</width>
-		<height>100</height>
+		<width>1200</width>
+		<height>142</height>
 	</include>
 	
 	<include name="Viewtype55_coords5">
@@ -382,18 +382,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype55_coords5_4:3</include>
 	</include>
 	<include name="Viewtype55_coords5_16:9">
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>1620</width>
+		<width>1680</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype55_coords5_21:9">
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>2260</width>
+		<width>2320</width>
 		<height>72</height>
 	</include>
 	<include name="Viewtype55_coords5_4:3">
+		<centerleft>50%</centerleft>
 		<top>0</top>
-		<width>1140</width>
+		<width>1200</width>
 		<height>72</height>
 	</include>
 	
@@ -403,21 +406,21 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype55_coords6_4:3</include>
 	</include>
 	<include name="Viewtype55_coords6_16:9">
-		<left>110</left>
-		<top>88</top>
-		<width>1400</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>800</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype55_coords6_21:9">
-		<left>350</left>
-		<top>88</top>
-		<width>1560</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>1440</width>
 		<height>54</height>
 	</include>
 	<include name="Viewtype55_coords6_4:3">
-		<left>110</left>
-		<top>88</top>
-		<width>920</width>
+		<centerleft>50%</centerleft>
+		<top>82</top>
+		<width>320</width>
 		<height>54</height>
 	</include>
 	

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -163,11 +163,6 @@
 		<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 	</include>
 	
-	<include name="VisibleFadeAnimationLong">
-		<animation effect="fade" start="0" end="100" time="400">Visible</animation>
-		<animation effect="fade" start="100" end="0" time="400">Hidden</animation>
-	</include>
-
 	<!-- Dialog animation -->
 	<include name="DialogZoomAnimation">
 		<animation type="WindowOpen">
@@ -309,8 +304,7 @@
 			<texture background="true">common/white.png</texture>
 			<colordiffuse>FF000000</colordiffuse>
 			<aspectratio>scale</aspectratio>
-			<animation effect="fade" start="0" end="100" time="0" delay="300">WindowOpen</animation>
-			<animation effect="fade" start="100" end="0" time="0">WindowClose</animation>
+			<include>DialogZoomAnimation</include>
 		</control>
 		<!-- Single background image -->
 		<control type="image">
@@ -683,140 +677,84 @@
 
 	<!-- Media Flags -->
 	<include name="MediaFlags">
-		<!-- Video flags -->
-		<control type="grouplist">
+		<control type="group">
 			<include>MediaFlags_coords1</include>
-			<itemgap>0</itemgap>
-			<align>left</align>
-			<aligny>bottom</aligny>
-			<orientation>horizontal</orientation>
-			<usecontrolcoords>true</usecontrolcoords>
-			<visible>Integer.IsGreater(Container.NumItems,0) + !Skin.HasSetting(HideMediaFlags)</visible>
+			<visible>Integer.IsGreater(Container.NumItems,0) + !ListItem.IsFolder</visible>
+			<animation effect="slide" time="0" start="0,0" end="0,60" condition="!Skin.HasSetting(HideMediaFlags) + [Control.IsVisible(52) | Control.IsVisible(521) | Control.IsVisible(53) | Control.IsVisible(532) | Control.IsVisible(534) | Control.IsVisible(55)]">Conditional</animation>
+		
+			<!-- Video -->
 			<control type="image">
 				<include>MediaFlags_coords2</include>
 				<colordiffuse>$VAR[TextColor2]</colordiffuse>
 				<texture>Video.png</texture>
 				<aspectratio align="left" aligny="bottom">keep</aspectratio>
-				<visible>!String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
+				<visible>!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
 			</control>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
+			<control type="fadelabel">
+				<include>MediaFlags_coords3</include>
 				<label>$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]</label>
-				<font>Font33</font>
+				<font>Font30</font>
 				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
+				<pauseatend>5000</pauseatend>
+				<visible>!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
 			</control>
-		</control>
-
-		<!-- Audio flags -->
-		<control type="grouplist">
-			<include>MediaFlags_coords3</include>
-			<itemgap>0</itemgap>
-			<align>left</align>
-			<aligny>bottom</aligny>
-			<orientation>horizontal</orientation>
-			<usecontrolcoords>true</usecontrolcoords>
-			<visible>Integer.IsGreater(Container.NumItems,0) + !Skin.HasSetting(HideMediaFlags)</visible>
+			
+			<!-- Audio -->
 			<control type="image">
-				<include>MediaFlags_coords2</include>
+				<include>MediaFlags_coords4</include>
 				<colordiffuse>$VAR[TextColor2]</colordiffuse>
 				<texture>AudioTrack.png</texture>
 				<aspectratio align="left" aligny="bottom">keep</aspectratio>
-				<visible>!String.IsEmpty(ListItem.AudioCodec)</visible>
+				<visible>!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.AudioCodec)</visible>
 			</control>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
+			<control type="fadelabel">
+				<include>MediaFlags_coords5</include>
 				<label>$VAR[Audio]</label>
-				<font>Font33</font>
+				<font>Font30</font>
 				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!String.IsEmpty(ListItem.AudioCodec)</visible>
+				<pauseatend>5000</pauseatend>
+				<visible>!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.AudioCodec)</visible>
 			</control>
-		</control>
-		
-		<!-- Duration -->
-		<control type="grouplist">
-			<include>MediaFlags_coords4</include>
-			<itemgap>0</itemgap>
-			<align>left</align>
-			<aligny>bottom</aligny>
-			<orientation>horizontal</orientation>
-			<usecontrolcoords>true</usecontrolcoords>
-			<visible>Integer.IsGreater(Container.NumItems,0)</visible>
-			<animation effect="slide" time="0" start="0,0" end="0,-40" condition="Skin.HasSetting(HideMediaFlags) | String.IsEmpty(ListItem.VideoCodec) + String.IsEmpty(ListItem.VideoResolution) + String.IsEmpty(ListItem.AudioCodec)">Conditional</animation>
+			
+			<!-- Duration -->
 			<control type="image">
-				<include>MediaFlags_coords2</include>
+				<include>MediaFlags_coords6</include>
 				<colordiffuse>$VAR[TextColor2]</colordiffuse>
 				<texture>Duration.png</texture>
 				<aspectratio align="left" aligny="bottom">keep</aspectratio>
 				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons)</visible>
 			</control>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
+			<control type="fadelabel">
+				<include>MediaFlags_coords7</include>
 				<label>$VAR[Duration]</label>
-				<font>Font33</font>
+				<font>Font30</font>
 				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons)</visible>
+				<pauseatend>5000</pauseatend>
+				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons) + [String.IsEqual(ListItem.Size,0 B) | String.IsEqual(ListItem.Size,0.000000 B)]</visible>
 			</control>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
-				<label> &#8226; </label>
-				<font>Font33</font>
+			<control type="fadelabel">
+				<include>MediaFlags_coords7</include>
+				<label>$VAR[Duration]$INFO[ListItem.Size, &#8226; $LOCALIZE[289]: ,]</label>
+				<font>Font30</font>
 				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons) + !ListItem.IsFolder + ![String.IsEqual(ListItem.Size,0 B) | String.IsEqual(ListItem.Size,0.000000 B)]</visible>
+				<pauseatend>5000</pauseatend>
+				<visible>!String.IsEmpty(ListItem.Duration) + !Container.Content(tvshows) + !Container.Content(seasons) + ![String.IsEqual(ListItem.Size,0 B) | String.IsEqual(ListItem.Size,0.000000 B)]</visible>
 			</control>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
-				<label>$INFO[ListItem.Size,$LOCALIZE[289]: ,]</label>
-				<font>Font33</font>
-				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!ListItem.IsFolder + ![String.IsEqual(ListItem.Size,0 B) | String.IsEqual(ListItem.Size,0.000000 B)]</visible>
-			</control>
+		
 		</control>
+
 	</include>
 
 	<!-- Item count -->
 	<include name="ItemCount">
-		<control type="grouplist">
+		<control type="fadelabel">
 			<include>ItemCount_coords</include>
-			<itemgap>6</itemgap>
+			<label>$INFO[Container.NumItems]$VAR[ContentType, ,]</label>
+			<font>Font30</font>
+			<textcolor>$VAR[TextColor2]</textcolor>
 			<align>right</align>
-			<aligny>bottom</aligny>
-			<orientation>horizontal</orientation>
-			<usecontrolcoords>true</usecontrolcoords>
+			<pauseatend>5000</pauseatend>
 			<visible>Integer.IsGreater(Container.NumItems,0)</visible>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
-				<label>$INFO[Container.NumItems]</label>
-				<font>Font33</font>
-				<textcolor>$VAR[TextColor2]</textcolor>
-			</control>
-			<control type="label">
-				<width>auto</width>
-				<height>36</height>
-				<align>right</align>
-				<aligny>bottom</aligny>
-				<label>$VAR[ContentType]</label>
-				<font>Font33</font>
-				<textcolor>$VAR[TextColor2]</textcolor>
-			</control>
 		</control>
 	</include>
 

--- a/xml/MyGames.xml
+++ b/xml/MyGames.xml
@@ -32,7 +32,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(50)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Scrollbar (wall) -->
@@ -49,7 +48,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(55)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Item count -->
@@ -105,6 +103,7 @@
 						<label>$LOCALIZE[31233]$INFO[Container.ViewMode]</label>
 						<height>52</height>
 						<onclick>Container.NextViewMode</onclick>
+						<visible>Container.Content(addons) | Container.Content(games)</visible>
 					</control>
 
 
@@ -114,6 +113,7 @@
 						<width>410</width>
 						<height>10</height>
 						<texture>transparent.png</texture>
+						<visible>Container.Content(addons) | Container.Content(games)</visible>
 					</control>
 
 

--- a/xml/MyMusicNav.xml
+++ b/xml/MyMusicNav.xml
@@ -44,10 +44,9 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + [Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(54)]</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 			
-			<!-- Scrollbar (poster) -->
+			<!-- Scrollbar (wide) -->
 			<control type="scrollbar" id="61">
 				<include>MyMusicNav_coords2</include>
 				<onup>50</onup>
@@ -61,7 +60,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(52)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Scrollbar (wall) -->
@@ -78,7 +76,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(55)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Media flags -->
@@ -136,6 +133,7 @@
 						<height>52</height>
 						<label>$LOCALIZE[31233]$INFO[Container.ViewMode]</label>
 						<onclick>Container.NextViewMode</onclick>
+						<visible>Container.Content(albums) | Container.Content(artists)</visible>
 					</control>
 
 
@@ -145,6 +143,7 @@
 						<width>410</width>
 						<height>10</height>
 						<texture>transparent.png</texture>
+						<visible>Container.Content(albums) | Container.Content(artists)</visible>
 					</control>
 
 

--- a/xml/MyPics.xml
+++ b/xml/MyPics.xml
@@ -41,7 +41,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + [Control.IsVisible(50) | Control.IsVisible(54)]</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Item count -->
@@ -79,7 +78,7 @@
 
 				<!-- Look controls -->
 				<control type="grouplist" id="3001">
-					<include>OptionsSideMenu2</include>
+					<include>OptionsSideMenu3</include>
 					<onleft>50</onleft>
 					<onright>50</onright>
 					<scrolltime>200</scrolltime>
@@ -90,23 +89,6 @@
 					<include content="SideMenuAnimation">
 						<param name="containerID">3001</param>
 					</include>
-
-					<!-- View -->
-					<control type="button" id="99">
-						<height>52</height>
-						<label>$LOCALIZE[31233]$INFO[Container.ViewMode]</label>
-						<onclick>Container.NextViewMode</onclick>
-					</control>
-
-
-					<control type="image" id="80">
-						<left>0</left>
-						<top>0</top>
-						<width>410</width>
-						<height>10</height>
-						<texture>transparent.png</texture>
-					</control>
-
 
 					<!-- Sort by -->
 					<control type="button" id="3">

--- a/xml/MyPlaylist.xml
+++ b/xml/MyPlaylist.xml
@@ -31,7 +31,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(50)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Item count -->

--- a/xml/MyPrograms.xml
+++ b/xml/MyPrograms.xml
@@ -32,7 +32,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(50)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Scrollbar (wall) -->
@@ -49,7 +48,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(55)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Item count -->

--- a/xml/MyVideoNav.xml
+++ b/xml/MyVideoNav.xml
@@ -41,10 +41,9 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + [Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(511) | Control.IsVisible(533)]</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
-			<!-- Scrollbar (poster) -->
+			<!-- Scrollbar (wide) -->
 			<control type="scrollbar" id="61">
 				<include>MyVideoNav_coords2</include>
 				<onup>50</onup>
@@ -57,8 +56,7 @@
 				<texturesliderbarfocus border="1,12,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripHorizontalFO.png</texturesliderbarfocus>
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
-				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(52)</visible>
-				<include>VisibleFadeAnimationLong</include>
+				<visible>!Skin.HasSetting(Scrollbars) + [Control.IsVisible(52) | Control.IsVisible(521)]</visible>
 			</control>
 
 			<!-- Scrollbar (wall) -->
@@ -75,29 +73,11 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(53)</visible>
-				<include>VisibleFadeAnimationLong</include>
-			</control>
-			
-			<!-- Scrollbar (poster low) -->
-			<control type="scrollbar" id="66">
-				<include>MyVideoNav_coords4</include>
-				<onup>50</onup>
-				<ondown condition="!Skin.HasSetting(KioskMode)">3001</ondown>
-				<showonepage>false</showonepage>
-				<orientation>horizontal</orientation>
-				<colordiffuse>$VAR[OverlayColorNF]</colordiffuse>
-				<texturesliderbackground border="1,12,1,1">common/ScrollBackgroundHorizontal.png</texturesliderbackground>
-				<texturesliderbar border="1,12,1,1">common/ScrollbarGripHorizontalNF.png</texturesliderbar>
-				<texturesliderbarfocus border="1,12,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripHorizontalFO.png</texturesliderbarfocus>
-				<textureslidernib></textureslidernib>
-				<textureslidernibfocus></textureslidernibfocus>
-				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(521)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 			
 			<!-- Scrollbar (wall low) -->
 			<control type="scrollbar" id="67">
-				<include>MyVideoNav_coords5</include>
+				<include>MyVideoNav_coords4</include>
 				<onleft condition="!Skin.HasSetting(KioskMode)">3001</onleft>
 				<onright>50</onright>
 				<showonepage>false</showonepage>
@@ -109,12 +89,11 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(534)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 			
 			<!-- Scrollbar (wall small) -->
 			<control type="scrollbar" id="68">
-				<include>MyVideoNav_coords6</include>
+				<include>MyVideoNav_coords5</include>
 				<onleft condition="!Skin.HasSetting(KioskMode)">3001</onleft>
 				<onright>50</onright>
 				<showonepage>false</showonepage>
@@ -126,12 +105,11 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(532)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 			
 			<!-- Scrollbar (wall info) -->
 			<control type="scrollbar" id="69">
-				<include>MyVideoNav_coords7</include>
+				<include>MyVideoNav_coords6</include>
 				<onleft condition="!Skin.HasSetting(KioskMode)">3001</onleft>
 				<onright>50</onright>
 				<showonepage>false</showonepage>
@@ -143,7 +121,6 @@
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars) + Control.IsVisible(531)</visible>
-				<include>VisibleFadeAnimationLong</include>
 			</control>
 
 			<!-- Media flags -->
@@ -202,6 +179,7 @@
 						<label>$LOCALIZE[31233]$INFO[Container.ViewMode]</label>
 						<height>52</height>
 						<onclick>Container.NextViewMode</onclick>
+						<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 					</control>
 
 
@@ -211,6 +189,7 @@
 						<width>410</width>
 						<height>10</height>
 						<texture>transparent.png</texture>
+						<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 					</control>
 
 

--- a/xml/Viewtype50.xml
+++ b/xml/Viewtype50.xml
@@ -6,7 +6,6 @@
 		<!-- List (songs & files) -->
 		<control type="group">
 			<visible>Control.IsVisible(50)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<!-- Image -->
 			<include content="image-50">

--- a/xml/Viewtype51.xml
+++ b/xml/Viewtype51.xml
@@ -6,7 +6,6 @@
 		<!-- List -->
 		<control type="group">
 			<visible>Control.IsVisible(51)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<!-- Media image - not episodes -->
 			<control type="group">

--- a/xml/Viewtype511.xml
+++ b/xml/Viewtype511.xml
@@ -6,7 +6,6 @@
 		<!-- List info -->
 		<control type="group">
 			<visible>Control.IsVisible(511)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<!-- Media image -->
 			<control type="group">

--- a/xml/Viewtype52.xml
+++ b/xml/Viewtype52.xml
@@ -6,7 +6,6 @@
 		<!-- Wide -->
 		<control type="group">
 			<visible>Control.IsVisible(52)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<control type="fixedlist" id="52">
 				<include>Viewtype52_coords1</include>

--- a/xml/Viewtype521.xml
+++ b/xml/Viewtype521.xml
@@ -6,14 +6,13 @@
 		<!-- Wide low -->
 		<control type="group">
 			<visible>Control.IsVisible(521)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<control type="fixedlist" id="521">
 				<include>Viewtype521_coords1</include>
-				<ondown>66</ondown>
+				<ondown>61</ondown>
 				<onleft>521</onleft>
 				<onright>521</onright>
-				<pagecontrol>66</pagecontrol>
+				<pagecontrol>61</pagecontrol>
 				<preloaditems>6</preloaditems>
 				<focusposition>5</focusposition>
 				<orientation>horizontal</orientation>

--- a/xml/Viewtype53.xml
+++ b/xml/Viewtype53.xml
@@ -6,7 +6,6 @@
 		<!-- Wall -->
 		<control type="group">
 			<visible>Control.IsVisible(53)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<control type="panel" id="53">
 				<include>Viewtype53_coords1</include>

--- a/xml/Viewtype531.xml
+++ b/xml/Viewtype531.xml
@@ -6,7 +6,6 @@
 		<!-- Wall info -->
 		<control type="group">
 			<visible>Control.IsVisible(531)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<!-- Movie/TV show info -->
 			<control type="group">

--- a/xml/Viewtype532.xml
+++ b/xml/Viewtype532.xml
@@ -6,7 +6,6 @@
 		<!-- Wall small -->
 		<control type="group">
 			<visible>Control.IsVisible(532)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<control type="panel" id="532">
 				<include>Viewtype532_coords1</include>

--- a/xml/Viewtype533.xml
+++ b/xml/Viewtype533.xml
@@ -6,7 +6,6 @@
 		<!-- Wall small info -->
 		<control type="group">
 			<visible>Control.IsVisible(533)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<!-- Movie/TV show info -->
 			<control type="group">

--- a/xml/Viewtype534.xml
+++ b/xml/Viewtype534.xml
@@ -6,7 +6,6 @@
 		<!-- Wall low -->
 		<control type="group">
 			<visible>Control.IsVisible(534)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<control type="panel" id="534">
 				<include>Viewtype534_coords1</include>

--- a/xml/Viewtype54.xml
+++ b/xml/Viewtype54.xml
@@ -6,7 +6,6 @@
 		<!-- List (music/pictures) -->
 		<control type="group">
 			<visible>Control.IsVisible(54)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<!-- Image - Songs -->
 			<include content="image-54">

--- a/xml/Viewtype55.xml
+++ b/xml/Viewtype55.xml
@@ -6,7 +6,6 @@
 		<!-- Wall (music) -->
 		<control type="group">
 			<visible>Control.IsVisible(55)</visible>
-			<include>VisibleFadeAnimationLong</include>
 
 			<control type="panel" id="55">
 				<include>Viewtype55_coords1</include>


### PR DESCRIPTION
Coordinates_Includes.xml:
- fix MediaFlags position and dimensions

Coordinates_MyVideoNav.xml:
- move year and genre label slightly up to match media flags and item count positioning

Coordinates_Viewtype52.xml:
- move whole view down to match title/scrollbar positioning of other horizontal views
- fix width of title and year/genre label control

Coordinates_Viewtype53.xml:
- fix width of title and year/genre label control

Coordinates_Viewtype55.xml:
- fix width of title and year/genre label control

Coordinates_Viewtype521.xml:
- fix width of title and year/genre label control

Coordinates_Viewtype532.xml:
- fix width of title and year/genre label control

Coordinates_Viewtype534.xml:
- fix width of title and year/genre label control

Includes.xml:
- rework media flags and item count to add scrolling

MyGames.xml:
- hide view submenu button with containers that only support one viewtype

MyMusicNav.xml:
- hide view submenu button with containers that only support one viewtype

MyPics.xml:
- remove view submenu button

MyVideoNav.xml:
- remove poster low scrollbar
- hide view submenu button with containers that only support one viewtype

Viewtype521.xml:
- change ondown and pagecontrol

addon.xml:
- update changelog

Changelog.md:
- update changelog