### PR TITLE
Media flag improvements

### DIFF
--- a/xml/Coordinates_Includes.xml
+++ b/xml/Coordinates_Includes.xml
@@ -300,19 +300,19 @@
 	</include>
 	<include name="MediaFlags_coords1_16:9">
 		<left>120</left>
-		<bottom>120</bottom>
+		<bottom>86</bottom>
 		<width>400</width>
 		<height>90</height>
 	</include>
 	<include name="MediaFlags_coords1_21:9">
 		<left>120</left>
-		<bottom>120</bottom>
+		<bottom>86</bottom>
 		<width>400</width>
 		<height>90</height>
 	</include>
 	<include name="MediaFlags_coords1_4:3">
 		<left>120</left>
-		<bottom>120</bottom>
+		<bottom>86</bottom>
 		<width>400</width>
 		<height>90</height>
 	</include>
@@ -456,19 +456,19 @@
 	</include>
 	<include name="ItemCount_coords_16:9">
 		<right>120</right>
-		<bottom>120</bottom>
+		<bottom>116</bottom>
 		<width>400</width>
 		<height>30</height>
 	</include>
 	<include name="ItemCount_coords_21:9">
 		<right>120</right>
-		<bottom>120</bottom>
+		<bottom>116</bottom>
 		<width>400</width>
 		<height>30</height>
 	</include>
 	<include name="ItemCount_coords_4:3">
 		<right>120</right>
-		<bottom>120</bottom>
+		<bottom>116</bottom>
 		<width>400</width>
 		<height>30</height>
 	</include>

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -680,7 +680,9 @@
 		<control type="group">
 			<include>MediaFlags_coords1</include>
 			<visible>Integer.IsGreater(Container.NumItems,0) + !ListItem.IsFolder</visible>
-			<animation effect="slide" time="0" start="0,0" end="0,60" condition="!Skin.HasSetting(HideMediaFlags) + [Control.IsVisible(52) | Control.IsVisible(521) | Control.IsVisible(53) | Control.IsVisible(532) | Control.IsVisible(534) | Control.IsVisible(55)]">Conditional</animation>
+			<animation effect="slide" time="0" start="0,0" end="0,30" condition="!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.AudioCodec) + [Control.IsVisible(52) | Control.IsVisible(521) | Control.IsVisible(53) | Control.IsVisible(532) | Control.IsVisible(534) | Control.IsVisible(55)]">Conditional</animation>
+			<animation effect="slide" time="0" start="0,0" end="0,-15" condition="String.IsEmpty(ListItem.AudioCodec) + !String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution) + ![Control.IsVisible(52) | Control.IsVisible(521) | Control.IsVisible(53) | Control.IsVisible(532) | Control.IsVisible(534) | Control.IsVisible(55)]">Conditional</animation>
+			<animation effect="slide" time="0" start="0,0" end="0,-30" condition="String.IsEmpty(ListItem.AudioCodec) + String.IsEmpty(ListItem.VideoCodec) + String.IsEmpty(ListItem.VideoResolution) + !String.IsEmpty(ListItem.Duration)">Conditional</animation>
 		
 			<!-- Video -->
 			<control type="image">
@@ -689,6 +691,7 @@
 				<texture>Video.png</texture>
 				<aspectratio align="left" aligny="bottom">keep</aspectratio>
 				<visible>!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
+				<animation effect="slide" time="0" start="0,0" end="0,30" condition="String.IsEmpty(ListItem.AudioCodec)">Conditional</animation>
 			</control>
 			<control type="fadelabel">
 				<include>MediaFlags_coords3</include>
@@ -697,6 +700,7 @@
 				<textcolor>$VAR[TextColor2]</textcolor>
 				<pauseatend>5000</pauseatend>
 				<visible>!Skin.HasSetting(HideMediaFlags) + !String.IsEmpty(ListItem.VideoCodec) + !String.IsEmpty(ListItem.VideoResolution)</visible>
+				<animation effect="slide" time="0" start="0,0" end="0,30" condition="String.IsEmpty(ListItem.AudioCodec)">Conditional</animation>
 			</control>
 			
 			<!-- Audio -->


### PR DESCRIPTION
Coordinates_Includes.xml:
- move media flags group control down
- move item count slightly down to align with horizontal view year/genre label

Includes.xml:
- change and add animations to media flags to fix alignment in all situations (horizontal title views, normal views, video without audio, music)