### PR TITLE
Add setting to show original movie title in video info dialog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 _New_
 - add new pre-defined widgets
 - add setting to hide media flags
+- add setting to show original movie title in video info dialog
 
 _Improved_
 - rework home menu customization dialogs
@@ -10,11 +11,13 @@ _Improved_
 - improve video info dialog (animations and buttons)
 - improve alignment and positioning of item count and media flags
 - show view toggle only when more than one view is available
+- improve info dialogs (size and positioning of plot/description textbox and details list)
 
 _Fixed_
 - move hide scrollbars setting to skin settings window
 - hide MyOSMC home menu entry and widget on non-OSMC systems
 - fix overlapping in views with big horizontal titles
+- add scrollbar to music album info dialog (if details list is too long)
 
 **Changelog v18.2.0**
 
@@ -28,12 +31,27 @@ strings.po:
 - add new localizes for additional widgets per script (31235, 31236)
 - add new localize hide media flags setting (31237)
 - add new localizes for Transiflex translation (31238-31266)
+- add new localize for show original movie title setting (31267)
 
 AddonBrowser.xml:
 - remove deprecated view toggle
 - remove hide scrollbar toggle
 - fix side-menu coordinates
 - add new "Sort order" localize to sort order toggle
+
+Coordinates_DialogAddonInfo.xml:
+- adjust hight of details list
+- adjust position and hight of description textbox
+
+Coordinates_DialogMusicInfo.xml:
+- adjust hight of details list
+- adjust position and hight of plot textbox
+- add coordinates for scrollbar
+
+Coordinates_DialogVideoInfo.xml:
+- adjust hight of details list
+- adjust position and hight of plot textbox
+- add additional coordinates for new show original movie title setting
 
 Coordinates_Includes.xml:
 - add SideMenuControlsSpacer_coords13 include for only one item in side/context menu
@@ -66,10 +84,15 @@ DialogFavourites.xml:
 - change conditional visibility of submenu indicator (submenu is only present during playback with active side-menu controls)
 - remove hide scrollbar toggle
 
+DialogMusicInfo.xml:
+- add new scrollbar for artist info dialog
+- add button indicator include
+
 DialogVideoInfo.xml:
 - add fade animation to togglable dialog elements (plot, cast, extended info)
 - show all buttons all the time
 - improve extended info button to keep focus
+- add original movie title to details list
 
 EventLog.xml:
 - add new "Sort order" localize to sort order toggle
@@ -150,6 +173,7 @@ script-skinshortcuts.xml:
 SkinSettings.xml:
 - add hide scrollbars setting formerly found in other windows
 - add new hide media flags setting
+- add new show original movie title in video info dialog setting
 
 Variables.xml:
 - add new WidgetSortByLabel, WidgetSortDirectionLabel and WidgetLimitLabel variables for new widget sort by, widget sort direction and widget limit options

--- a/addon.xml
+++ b/addon.xml
@@ -16,6 +16,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new pre-defined widgets[CR]- add setting to hide media flags[CR][CR][B]Improved[/B][CR]- rework of home menu customization dialogs[CR]- improve sort by and sort order toggles[CR]- improve video info dialog (animations and buttons)[CR]- improve alignment and positioning of item count and media flags[CR]- show view toggle only when more than one view is available[CR][CR][B]Fixed[/B][CR]- move hide scrollbars setting to skin settings window[CR]- hide MyOSMC home menu entry and widget on non-OSMC systems[CR]- fix overlapping in views with big horizontal titles</news>
+		<news>[B]New[/B][CR]- add new pre-defined widgets[CR]- add setting to hide media flags[CR]- add setting to show original movie title in video info dialog[CR][CR][B]Improved[/B][CR]- rework of home menu customization dialogs[CR]- improve sort by and sort order toggles[CR]- improve video info dialog (animations and buttons)[CR]- improve alignment and positioning of item count and media flags[CR]- show view toggle only when more than one view is available[CR]- improve info dialogs (size and positioning of plot/description textbox and details list)[CR][CR][B]Fixed[/B][CR]- move hide scrollbars setting to skin settings window[CR]- hide MyOSMC home menu entry and widget on non-OSMC systems[CR]- fix overlapping in views with big horizontal titles[CR]- add scrollbar to music album info dialog (if details list is too long)</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1299,3 +1299,8 @@ msgstr ""
 msgctxt "#31266"
 msgid "Plain color"
 msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31267"
+msgid "Show original movie title in video info dialog"
+msgstr ""

--- a/xml/Coordinates_DialogAddonInfo.xml
+++ b/xml/Coordinates_DialogAddonInfo.xml
@@ -50,15 +50,15 @@
 	</include>
 	<include name="DialogAddonInfodetails_coords3_16:9">
 		<width>1170</width>
-		<height>336</height>
+		<height>180</height>
 	</include>
 	<include name="DialogAddonInfodetails_coords3_21:9">
 		<width>1810</width>
-		<height>336</height>
+		<height>180</height>
 	</include>
 	<include name="DialogAddonInfodetails_coords3_4:3">
 		<width>690</width>
-		<height>336</height>
+		<height>180</height>
 	</include>
 	
 	<include name="DialogAddonInfodetails_coords4">
@@ -166,19 +166,19 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonInfodetails_coords9_4:3</include>
 	</include>
 	<include name="DialogAddonInfodetails_coords9_16:9">
-		<top>230</top>
+		<top>192</top>
 		<width>1170</width>
-		<height>360</height>
+		<height>388</height>
 	</include>
 	<include name="DialogAddonInfodetails_coords9_21:9">
-		<top>230</top>
+		<top>192</top>
 		<width>1810</width>
-		<height>360</height>
+		<height>388</height>
 	</include>
 	<include name="DialogAddonInfodetails_coords9_4:3">
-		<top>230</top>
+		<top>192</top>
 		<width>690</width>
-		<height>360</height>
+		<height>388</height>
 	</include>
 
 </includes>

--- a/xml/Coordinates_DialogMusicInfo.xml
+++ b/xml/Coordinates_DialogMusicInfo.xml
@@ -74,15 +74,15 @@
 	</include>
 	<include name="DialogMusicInfo_coords4_16:9">
 		<width>1170</width>
-		<height>336</height>
+		<height>324</height>
 	</include>
 	<include name="DialogMusicInfo_coords4_21:9">
 		<width>1810</width>
-		<height>336</height>
+		<height>324</height>
 	</include>
 	<include name="DialogMusicInfo_coords4_4:3">
 		<width>690</width>
-		<height>336</height>
+		<height>324</height>
 	</include>
 	
 	<include name="DialogMusicInfo_coords5">
@@ -148,19 +148,43 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogMusicInfo_coords8_4:3</include>
 	</include>
 	<include name="DialogMusicInfo_coords8_16:9">
-		<top>370</top>
+		<top>336</top>
 		<width>1170</width>
-		<height>210</height>
+		<height>244</height>
 	</include>
 	<include name="DialogMusicInfo_coords8_21:9">
-		<top>370</top>
+		<top>336</top>
 		<width>1810</width>
-		<height>210</height>
+		<height>244</height>
 	</include>
 	<include name="DialogMusicInfo_coords8_4:3">
-		<top>370</top>
+		<top>336</top>
 		<width>690</width>
-		<height>210</height>
+		<height>244</height>
+	</include>
+	
+	<include name="DialogMusicInfo_coords9">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">DialogMusicInfo_coords9_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogMusicInfo_coords9_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogMusicInfo_coords9_4:3</include>
+	</include>
+	<include name="DialogMusicInfo_coords9_16:9">
+		<left>580</left>
+		<top>235</top>
+		<width>20</width>
+		<height>324</height>
+	</include>
+	<include name="DialogMusicInfo_coords9_21:9">
+		<left>580</left>
+		<top>235</top>
+		<width>20</width>
+		<height>324</height>
+	</include>
+	<include name="DialogMusicInfo_coords9_4:3">
+		<left>580</left>
+		<top>235</top>
+		<width>20</width>
+		<height>324</height>
 	</include>
 
 </includes>

--- a/xml/Coordinates_DialogVideoInfo.xml
+++ b/xml/Coordinates_DialogVideoInfo.xml
@@ -74,15 +74,15 @@
 	</include>
 	<include name="DialogVideoInfo_coords4_16:9">
 		<width>1170</width>
-		<height>456</height>
+		<height>420</height>
 	</include>
 	<include name="DialogVideoInfo_coords4_21:9">
 		<width>1810</width>
-		<height>456</height>
+		<height>420</height>
 	</include>
 	<include name="DialogVideoInfo_coords4_4:3">
 		<width>690</width>
-		<height>456</height>
+		<height>420</height>
 	</include>
 	
 	<include name="DialogVideoInfo_coords5">
@@ -143,24 +143,42 @@
 	</include>
 	
 	<include name="DialogVideoInfo_coords8">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9)">DialogVideoInfo_coords8_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogVideoInfo_coords8_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogVideoInfo_coords8_4:3</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + Skin.HasSetting(ShowOriginalTitle)">DialogVideoInfo_coords8_ShowOriginalTitle_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9) + Skin.HasSetting(ShowOriginalTitle)">DialogVideoInfo_coords8_ShowOriginalTitle_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3) + Skin.HasSetting(ShowOriginalTitle)">DialogVideoInfo_coords8_ShowOriginalTitle_4:3</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + !Skin.HasSetting(ShowOriginalTitle)">DialogVideoInfo_coords8_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9) + !Skin.HasSetting(ShowOriginalTitle)">DialogVideoInfo_coords8_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3) + !Skin.HasSetting(ShowOriginalTitle)">DialogVideoInfo_coords8_4:3</include>
+	</include>
+	<include name="DialogVideoInfo_coords8_ShowOriginalTitle_16:9">
+		<top>432</top>
+		<width>1170</width>
+		<height>148</height>
+	</include>
+	<include name="DialogVideoInfo_coords8_ShowOriginalTitle_21:9">
+		<top>432</top>
+		<width>1810</width>
+		<height>148</height>
+	</include>
+	<include name="DialogVideoInfo_coords8_ShowOriginalTitle_4:3">
+		<top>432</top>
+		<width>690</width>
+		<height>148</height>
 	</include>
 	<include name="DialogVideoInfo_coords8_16:9">
-		<top>394</top>
+		<top>384</top>
 		<width>1170</width>
-		<height>186</height>
+		<height>196</height>
 	</include>
 	<include name="DialogVideoInfo_coords8_21:9">
-		<top>394</top>
+		<top>384</top>
 		<width>1810</width>
-		<height>186</height>
+		<height>196</height>
 	</include>
 	<include name="DialogVideoInfo_coords8_4:3">
-		<top>394</top>
+		<top>384</top>
 		<width>690</width>
-		<height>186</height>
+		<height>196</height>
 	</include>
 	
 	<include name="DialogVideoInfo_coords9">

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -42,503 +42,505 @@
 				<include>DialogMusicInfo_coords3</include>
 				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[21887]) + !String.IsEqual(Control.GetLabel(5),$LOCALIZE[183])</visible>
 
-				<!-- Details -->
-				<control type="grouplist">
+				<!-- Details (song) -->
+				<control type="grouplist" id="100">
 					<include>DialogMusicInfo_coords4</include>
 					<itemgap>12</itemgap>
 					<orientation>vertical</orientation>
 					<usecontrolcoords>true</usecontrolcoords>
-						<visible>Window.Is(songinformation)</visible>
+					<visible>Window.Is(songinformation)</visible>
 
-						<!-- Artist -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Artist)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>557</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Artist]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
+					<!-- Artist -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Artist)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>557</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
 						</control>
-
-						<!-- Album -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Album)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>558</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Album]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Artist]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
 						</control>
-
-						<!-- Year -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Year)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>562</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Year]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Genre -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Genre)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>515</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Genre]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Track Number -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.TrackNumber)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>554</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.TrackNumber]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-						
-						<!-- Duration -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Duration)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>180</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$VAR[Duration]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>						
-
-						<!-- Rating -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>String.IsEqual(ListItem.StarRating,rating0.png) | String.IsEqual(ListItem.StarRating,rating1.png) | String.IsEqual(ListItem.StarRating,rating2.png) | String.IsEqual(ListItem.StarRating,rating3.png) | String.IsEqual(ListItem.StarRating,rating4.png) | String.IsEqual(ListItem.StarRating,rating5.png)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>563</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="image">
-								<include>DialogMusicInfo_coords7</include>
-								<aspectratio align="left">keep</aspectratio>
-								<texture>$INFO[ListItem.StarRating]</texture>
-							</control>
-						</control>
-
 					</control>
 
-				<control type="grouplist">
-					<width>1170</width>
-					<height>336</height>
+					<!-- Album -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Album)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>558</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Album]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Year -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Year)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>562</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Year]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Genre -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Genre)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>515</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Genre]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Track Number -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.TrackNumber)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>554</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.TrackNumber]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+					
+					<!-- Duration -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Duration)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>180</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$VAR[Duration]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>						
+
+					<!-- Rating -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>String.IsEqual(ListItem.StarRating,rating0.png) | String.IsEqual(ListItem.StarRating,rating1.png) | String.IsEqual(ListItem.StarRating,rating2.png) | String.IsEqual(ListItem.StarRating,rating3.png) | String.IsEqual(ListItem.StarRating,rating4.png) | String.IsEqual(ListItem.StarRating,rating5.png)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>563</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="image">
+							<include>DialogMusicInfo_coords7</include>
+							<aspectratio align="left">keep</aspectratio>
+							<texture>$INFO[ListItem.StarRating]</texture>
+						</control>
+					</control>
+
+				</control>
+
+				<!-- Details (album/artist) -->
+				<control type="grouplist" id="101">
+					<include>DialogMusicInfo_coords4</include>
 					<itemgap>12</itemgap>
 					<orientation>vertical</orientation>
 					<usecontrolcoords>true</usecontrolcoords>
-						<visible>!Window.Is(songinformation)</visible>
-						<!-- Artist -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>Container.Content(Albums) + !String.IsEmpty(ListItem.Artist)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>557</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Artist]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Year -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Year)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>562</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Year]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Genre -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Genre)</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>515</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Genre]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
+					<pagecontrol>50</pagecontrol>
+					<visible>!Window.Is(songinformation)</visible>
 						
-						<!-- Type -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Album_Type))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>146</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Album_Type)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
+					<!-- Artist -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>Container.Content(Albums) + !String.IsEmpty(ListItem.Artist)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>557</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
 						</control>
-
-						<!-- Label -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Album_Label))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>21899</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Album_Label)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Artist]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
 						</control>
-
-						<!-- Rating -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>Container.Content(albums) + [String.IsEqual(ListItem.StarRating,rating0.png) | String.IsEqual(ListItem.StarRating,rating1.png) | String.IsEqual(ListItem.StarRating,rating2.png) | String.IsEqual(ListItem.StarRating,rating3.png) | String.IsEqual(ListItem.StarRating,rating4.png) | String.IsEqual(ListItem.StarRating,rating5.png)]</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>563</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="image" id="99">
-								<include>DialogMusicInfo_coords7</include>
-								<aspectratio align="left">keep</aspectratio>
-								<texture>$INFO[ListItem.StarRating]</texture>
-							</control>
-						</control>
-
-						<!-- Mood -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Album_Mood))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>175</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Album_Mood)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Style -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Album_Style))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>176</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Album_Style)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Theme -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Album_Theme))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>21895</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Album_Theme)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Born -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_Born))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>21893</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_Born)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Formed -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_Formed))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>21894</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_Formed)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Mood -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_Mood))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>175</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_Mood)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Style -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_Style))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>176</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_Style)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Instrument -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_Instrument))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>21892</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_Instrument)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Died -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_Died))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>21897</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_Died)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
-						<!-- Years active -->
-						<control type="group">
-							<include>DialogMusicInfo_coords5</include>
-							<visible>!String.IsEmpty(ListItem.Property(Artist_YearsActive))</visible>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords6</include>
-								<align>right</align>
-								<font>Font36</font>
-								<label>652</label>
-								<textcolor>$VAR[TextColor2]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-							<control type="fadelabel">
-								<include>DialogMusicInfo_coords7</include>
-								<font>Font36</font>
-								<label>$INFO[ListItem.Property(Artist_YearsActive)]</label>
-								<textcolor>$VAR[TextColor1]</textcolor>
-								<pauseatend>5000</pauseatend>
-							</control>
-						</control>
-
 					</control>
+
+					<!-- Year -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Year)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>562</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Year]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Genre -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Genre)</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>515</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Genre]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+					
+					<!-- Type -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Album_Type))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>146</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Album_Type)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Label -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Album_Label))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>21899</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Album_Label)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Rating -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>Container.Content(albums) + [String.IsEqual(ListItem.StarRating,rating0.png) | String.IsEqual(ListItem.StarRating,rating1.png) | String.IsEqual(ListItem.StarRating,rating2.png) | String.IsEqual(ListItem.StarRating,rating3.png) | String.IsEqual(ListItem.StarRating,rating4.png) | String.IsEqual(ListItem.StarRating,rating5.png)]</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>563</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="image" id="99">
+							<include>DialogMusicInfo_coords7</include>
+							<aspectratio align="left">keep</aspectratio>
+							<texture>$INFO[ListItem.StarRating]</texture>
+						</control>
+					</control>
+
+					<!-- Mood -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Album_Mood))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>175</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Album_Mood)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Style -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Album_Style))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>176</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Album_Style)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Theme -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Album_Theme))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>21895</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Album_Theme)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Born -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_Born))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>21893</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_Born)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+					
+					<!-- Died -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_Died))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>21897</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_Died)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+					
+					<!-- Formed -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_Formed))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>21894</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_Formed)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Years active -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_YearsActive))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>652</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_YearsActive)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Mood -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_Mood))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>175</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_Mood)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Style -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_Style))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>176</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_Style)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+					<!-- Instrument -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Artist_Instrument))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>21892</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Artist_Instrument)]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
+				</control>
 
 				<!-- Plot -->
 				<control type="group">
@@ -610,6 +612,23 @@
 				</control>
 			</control>
 
+			<!-- Scrollbar -->
+			<control type="scrollbar" id="50">
+				<include>DialogMusicInfo_coords9</include>
+				<onleft>9000</onleft>
+				<onright>9000</onright>
+				<showonepage>false</showonepage>
+				<orientation>vertical</orientation>
+				<colordiffuse>$VAR[OverlayColorNF]</colordiffuse>
+				<texturesliderbackground border="11,1,1,1">common/ScrollBackground.png</texturesliderbackground>
+				<texturesliderbar border="11,1,1,1">common/ScrollbarGripNF.png</texturesliderbar>
+				<texturesliderbarfocus border="11,1,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripFO.png</texturesliderbarfocus>
+				<textureslidernib></textureslidernib>
+				<textureslidernibfocus></textureslidernibfocus>
+				<visible>!Window.Is(songinformation)</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+
 			<!-- Button grouplist background -->
 			<include content="dialogButtonBackground">
 				<param name="id">9000</param>
@@ -621,6 +640,7 @@
 				<orientation>horizontal</orientation>
 				<align>center</align>
 				<itemgap>30</itemgap>
+				<onup>50</onup>
 				
 				<!-- User rating Button -->
 				<control type="button" id="7">
@@ -648,6 +668,11 @@
 				</control>
 
 			</control>
+
+			<!-- Button grouplist indicator -->
+			<include content="dialogButtonIndicator">
+				<param name="visibility">!ControlGroup(9000).HasFocus</param>
+			</include>
 
 		</control>
 

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -126,6 +126,27 @@
 						</control>
 					</control>
 
+					<!-- Original Title -->
+					<control type="group">
+						<include>DialogVideoInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.OriginalTitle) + !String.IsEqual(ListItem.OriginalTitle,ListItem.Title) + Skin.HasSetting(ShowOriginalTitle)</visible>
+						<control type="fadelabel">
+							<include>DialogVideoInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>20376</label>
+							<textcolor>$VAR[TextColor2]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+						<control type="fadelabel">
+							<include>DialogVideoInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.OriginalTitle]</label>
+							<textcolor>$VAR[TextColor1]</textcolor>
+							<pauseatend>5000</pauseatend>
+						</control>
+					</control>
+
 					<!-- Genre -->
 					<control type="group">
 						<include>DialogVideoInfo_coords5</include>

--- a/xml/FileBrowser.xml
+++ b/xml/FileBrowser.xml
@@ -57,6 +57,7 @@
 			<!-- Scrollbar -->
 			<control type="scrollbar" id="60">
 				<include>FileBrowser_coords2</include>
+				<onleft>9000</onleft>
 				<onright condition="Control.IsVisible(450)">450</onright>
 				<onright condition="Control.IsVisible(451)">451</onright>
 				<showonepage>false</showonepage>

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -881,8 +881,16 @@
 					<onclick>Skin.ToggleSetting(HideMediaFlags)</onclick>
 					<selected>Skin.HasSetting(HideMediaFlags)</selected>
 				</control>
+				<!-- Show original movie titles -->
+				<control type="radiobutton" id="611">
+					<include>SkinSettings_coords16</include>
+					<font>Font33</font>
+					<label>31267</label>
+					<onclick>Skin.ToggleSetting(ShowOriginalTitle)</onclick>
+					<selected>Skin.HasSetting(ShowOriginalTitle)</selected>
+				</control>
 				<!-- Mixed -->
-				<control type="label" id="611">
+				<control type="label" id="612">
 					<include>SkinSettings_coords17</include>
 					<font>Font33-italic</font>
 					<align>left</align>
@@ -890,7 +898,7 @@
 					<textcolor>$VAR[TextColor2]</textcolor>
 				</control>
 				<!-- Hide sub-menu player controls -->
-				<control type="radiobutton" id="612">
+				<control type="radiobutton" id="613">
 					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31147</label>
@@ -898,7 +906,7 @@
 					<selected>Skin.HasSetting(SubMenuControls)</selected>
 				</control>
 				<!-- Show lock icon for encrypted PVR channels -->
-				<control type="radiobutton" id="613">
+				<control type="radiobutton" id="614">
 					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>$LOCALIZE[31174]</label>
@@ -906,7 +914,7 @@
 					<selected>Skin.HasSetting(PVRShowLock)</selected>
 				</control>
 				<!-- Hide scrollbars -->
-				<control type="radiobutton" id="614">
+				<control type="radiobutton" id="615">
 					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31005</label>
@@ -914,7 +922,7 @@
 					<selected>Skin.HasSetting(Scrollbars)</selected>
 				</control>
 				<!-- Kiosk mode -->
-				<control type="radiobutton" id="615">
+				<control type="radiobutton" id="616">
 					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31057</label>


### PR DESCRIPTION
strings.po:
- add new localize for show original movie title setting (31267)

Coordinates_DialogAddonInfo.xml:
- adjust hight of details list
- adjust position and hight of description textbox

Coordinates_DialogMusicInfo.xml:
- adjust hight of details list
- adjust position and hight of plot textbox
- add coordinates for scrollbar

Coordinates_DialogVideoInfo.xml:
- adjust hight of details list
- adjust position and hight of plot textbox
- add additional coordinates for new show original movie title setting

DialogMusicInfo.xml:
- add new scrollbar for artist info dialog
- add button indicator include

DialogVideoInfo.xml:
- add original movie title to details list

FileBrowser.xml:
- add missing onleft to scrollbar

SkinSettings.xml:
- add new show original movie title in video info dialog setting

addon.xml:
- update changelog

Changelog.md:
- update changelog