### PR TITLE
Add 3D depth information to GUI elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ _New_
 - add new Wide low info view
 - add support for Up Next addon
 - add playlist button to video OSD
+- add 3D depth information to GUI elements
 
 _Improved_
 - make Wide low view accessible for music views
@@ -38,6 +39,12 @@ template.xml:
 
 AddonBrowser.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+Coordinates_Includes.xml:
+- reorder dialog button coordinates
 
 Coordinates_MyMusicNav.xml:
 - fix Wide view scrollbar coordinates
@@ -60,23 +67,117 @@ Custom_Disabled_Add-on.xml:
 Custom_Overlay_Debug.xml:
 - remove deprecated and add missing window fadelabels
 
+Defaults.xml:
+- add depth includes
+
+DialogAddonInfo.xml:
+- add depth include
+
+DialogAddonSettings.xml:
+- add depth include
+
+DialogBusy.xml:
+- add depth include
+
+DialogButtonMenu.xml:
+- add depth include
+
+DialogConfirm.xml:
+- add depth include
+
+DialogContextMenu.xml:
+- add depth include
+
+DialogExtendedProgressBar.xml:
+- add depth include
+
 DialogFavourites.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+DialogGameControllers.xml:
+- add depth include
+
+DialogKeyboard.xml:
+- add depth include
+
+DialogMediaSource.xml:
+- add depth include
+
+DialogMusicInfo.xml:
+- add depth include
+
+DialogNotification.xml:
+- add depth include
+
+DialogNumeric.xml:
+- add depth include
+
+DialogPictureInfo.xml:
+- add depth include
 
 DialogPlayerProcessInfo.xml:
 - rework information label formatting
+- add depth include
+
+DialogPVRChannelGuide.xml:
+- add depth include
+
+DialogPVRChannelManager.xml:
+- add depth include
+
+DialogPVRChannelsOSD.xml:
+- add depth include
+
+DialogPVRGroupManager.xml:
+- add depth include
+
+DialogPVRGuideSearch.xml:
+- add depth include
+
+DialogPVRInfo.xml:
+- add depth include
+
+DialogSeekBar.xml:
+- add depth include
+
+DialogSelect.xml:
+- add depth includes
+- adjust game settings animations
+
+DialogSlider.xml:
+- add depth include
 
 DialogSubtitles.xml:
 - add new right list scrollbar
+- replace overlay image
+- add depth include
+
+DialogTextViewer.xml:
+- add depth include
 
 DialogVideoInfox.xml:
 - add new music video information controls (similar to music info dialog)
 
+DialogVolumeBar.xml:
+- add depth include
+
 EventLog.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+FileBrowser.xml:
+- add depth include
 
 Home.xml: 
 - add SidemenuMenucontrol include
+
+GameOSD.xml:
+- add depth includes
 
 Includes.xml:
 - add new SidemenuMenucontrol include
@@ -85,96 +186,187 @@ Includes.xml:
 - adjust conditional visibility of Context/Side menu indicator include for new Wide low info view
 - update conditional visibility to hide time while Up Next notification is visible
 - add new onload and onunload
+- move dialog buttons includes to different include file
+- add depth includes to masking bars
 
 Include_DialogSettings.xml:
 - update conditional visibility to hide OSD settings while Up Next notification is visible
+- add depth includes
+
+Includes_Home.xml:
+- add depth include to side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 Includes_Time_NowPlaying.xml:
 - rework now playing formatting
 - add new information for music video playback
 
+Includes_Windows_Dialogs.xml:
+- replace FullscreenDimensions include of background images by new FullscreenOverlayDimensions include
+- add depth includes to background images
+- add new depth includes
+- move dialog button includes from other include file
+
+MusicOSD.xml:
+- add depth include
+
 MusicVisualisation.xml:
 - adjust music information label formatting to match overall representation
+- add depth include
 
 MyGames.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyMusicNav.xml:
 - add SidemenuMenucontrol include
 - add Wide low view
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyMusicPlaylistEditor.xml:
 - rework broken music playlist editor window
 
 MyPics.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPlaylist.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPrograms.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPVRChannels.xml:
 - add SidemenuMenucontrol include
 - fix onleft of scrollbar while kiosk mode is active
 - add hidden label (ID 30) for improved window title
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPVRGuide.xml:
 - add SidemenuMenucontrol include
 - fix visibility of submenu indicator while kiosk mode is active
 - add hidden label (ID 30) for improved window title
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPVRRecordings.xml:
 - add SidemenuMenucontrol include
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPVRSearch.xml:
 - add SidemenuMenucontrol include
 - fix onleft and onright of scrollbar while kiosk mode is active
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyPVRTimers.xml:
 - add SidemenuMenucontrol include
 - fix onleft and onright of scrollbar while kiosk mode is active
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyVideoNav.xml:
 - add SidemenuMenucontrol include
 - add Wide low info view
 - add new scrollbar for Wide low info view
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 MyWeather.xml: 
 - add SidemenuMenucontrol include
 - add conditional visibility to hide window content, visible animation and busy dialog imitation while weather data is being loaded
+- add depth include to options side menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+PlayerControls.xml:
+- add depth include
+
+Pointer.xml:
+- add depth include
 
 script-skin_helper_service-Color-Picker.xml:
 - add new onload and onunload for improved debug dialog
-
-script-skinshortcuts.xml:
-- add new onload and onunload for improved debug dialog
+- add depth include
 
 script-skin_helper_service-Color-Picker.xml:
 - add new onload and onunload for improved debug dialog
 - change heading control to reflect currently selected colour name
 
+script-skinshortcuts.xml:
+- add new onload and onunload for improved debug dialog
+- replace FullscreenDimensions include of background images by new FullscreenOverlayDimensions include
+- add depth includes
+
 script-upnext-stillwatching-simple.xml:
 - add new onload and onunload for improved debug dialog
+- add depth include
 
 script-upnext-stillwatching.xml:
 - add new onload and onunload for improved debug dialog
+- add depth include
 
 script-upnext-upnext-simple.xml:
 - add new onload and onunload for improved debug dialog
+- add depth include
 
 script-upnext-upnext.xml:
 - add new onload and onunload for improved debug dialog
+- add depth include
 
 SettingsCategory.xml: 
 - add menucontrol
 - adjust buttons not adapting to different aspect ratio modes
+- add depth include to settings quick-nav menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+SettingsProfile.xml:
+- add depth include to settings quick-nav menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+SettingsCategory.xml:
+- add depth include to settings quick-nav menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
+
+SettingsSystemInfo.xml:
+- add depth include to settings quick-nav menu
+- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
+- move options menu slightly left to avoid it being inactively visible during 3D mode
 
 SkinSettings.xml:
 - rework Next Up supported addon button for new Up Next addon
 - change window heading to use global heading variable
 - change skin setting reset button to first open confirmation dialog
+
+SmartPlaylistEditor.xml:
+- add depth include
+
+SmartPlaylistRule.xml:
+- add depth include
 
 Variables.xml:
 - adjust colour values of DisabledColor variable
@@ -190,10 +382,15 @@ Variables.xml:
 VideoFullScreen.xml:
 - update conditional visibility to hide OSD elements while Up Next notification is visible
 - adjust music video info dialog information to match representation in other music video windows/dialogs
+- add depth include
 
 VideoOSD.xml:
 - update conditional visibility to hide OSD elements while Up Next notification is visible
 - add new playlist button (like with MusicOSD)
+- add depth includes
+
+VideoOSDBookmarks.xml:
+- add depth includes
 
 Viewtype50.xml:
 - add new image for songs and videos while playlist window is visible

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add standard Kodi 'Menu' key functionality to access side menu in all windows[CR]- add new Wide low info view[CR]- add support for Up Next addon[CR]- add playlist button to video OSD[CR][CR][B]Improved[/B][CR]- make Wide low view accessible for music views[CR]- make disabled text colour more readable[CR]- improve widget details and window headings[CR]- improve debug overlay[CR]- improve overall handling of music videos[CR]- improve playlist window[CR]- add scrollbar to subtitle dialog[CR][CR][B]Fixed[/B][CR]- fix settings button labels for 21:9 and 4:3 modes[CR]- fix music playlist editor window</news>
+		<news>[B]New[/B][CR]- add standard Kodi 'Menu' key functionality to access side menu in all windows[CR]- add new Wide low info view[CR]- add support for Up Next addon[CR]- add playlist button to video OSD[CR]- add 3D depth information to GUI elements[CR][CR][B]Improved[/B][CR]- make Wide low view accessible for music views[CR]- make disabled text colour more readable[CR]- improve widget details and window headings[CR]- improve debug overlay[CR]- improve overall handling of music videos[CR]- improve playlist window[CR]- add scrollbar to subtitle dialog[CR][CR][B]Fixed[/B][CR]- fix settings button labels for 21:9 and 4:3 modes[CR]- fix music playlist editor window</news>
 	</extension>
 </addon>

--- a/xml/AddonBrowser.xml
+++ b/xml/AddonBrowser.xml
@@ -95,18 +95,19 @@
 
 			<!-- Options -->
 			<control type="group" id="9002">
+				<include>NotificationDepth</include>
 				<visible>!Skin.HasSetting(KioskMode)</visible>
 				<control type="image">
-					<include>FullscreenDimensions</include>
+					<include>FullscreenOverlayDimensions</include>
 					<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 					<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 					<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 					<visible>ControlGroup(9002).HasFocus</visible>
 				</control>
 				<control type="group">
-					<left>-450</left>
+					<left>-460</left>
 					<top>0</top>
-					<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+					<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 					<control type="button">
 						<include>OptionsSideMenu1</include>
 						<texturefocus>noop</texturefocus>

--- a/xml/Coordinates_Includes.xml
+++ b/xml/Coordinates_Includes.xml
@@ -420,99 +420,6 @@
 		<animation effect="slide" end="0,494" time="0" condition="String.IsEqual(Container($PARAM[containerID]).NumItems,1)">Conditional</animation>
 	</include>
 	
-	<include name="dialogButtonBackground_coords1">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">dialogButtonBackground_coords1_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords1_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">dialogButtonBackground_coords1_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">dialogButtonBackground_coords1_4:3</include>
-	</include>
-	<include name="dialogButtonBackground_coords1_16:9">
-		<left>0</left>
-		<bottom>174</bottom>
-		<width>1920</width>
-		<height>2</height>
-	</include>
-	<include name="dialogButtonBackground_coords1_21:9">
-		<left>0</left>
-		<bottom>174</bottom>
-		<width>2560</width>
-		<height>2</height>
-	</include>
-	<include name="dialogButtonBackground_coords1_21:9_masked">
-		<left>0</left>
-		<bottom>354</bottom>
-		<width>2560</width>
-		<height>2</height>
-	</include>
-	<include name="dialogButtonBackground_coords1_4:3">
-		<left>0</left>
-		<bottom>174</bottom>
-		<width>1440</width>
-		<height>2</height>
-	</include>
-	
-	<include name="dialogButtonBackground_coords2">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">dialogButtonBackground_coords2_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords2_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">dialogButtonBackground_coords2_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">dialogButtonBackground_coords2_4:3</include>
-	</include>
-	<include name="dialogButtonBackground_coords2_16:9">
-		<left>0</left>
-		<bottom>90</bottom>
-		<width>1920</width>
-		<height>2</height>
-	</include>
-	<include name="dialogButtonBackground_coords2_21:9">
-		<left>0</left>
-		<bottom>90</bottom>
-		<width>2560</width>
-		<height>2</height>
-	</include>
-	<include name="dialogButtonBackground_coords2_21:9_masked">
-		<left>0</left>
-		<bottom>270</bottom>
-		<width>2560</width>
-		<height>2</height>
-	</include>
-	<include name="dialogButtonBackground_coords2_4:3">
-		<left>0</left>
-		<bottom>90</bottom>
-		<width>1440</width>
-		<height>2</height>
-	</include>
-	
-	<include name="dialogButtonBackground_coords3">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">dialogButtonBackground_coords3_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords3_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">dialogButtonBackground_coords3_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">dialogButtonBackground_coords3_4:3</include>
-	</include>
-	<include name="dialogButtonBackground_coords3_16:9">
-		<left>0</left>
-		<bottom>90</bottom>
-		<width>1920</width>
-		<height>86</height>
-	</include>
-	<include name="dialogButtonBackground_coords3_21:9">
-		<left>0</left>
-		<bottom>90</bottom>
-		<width>2560</width>
-		<height>86</height>
-	</include>
-	<include name="dialogButtonBackground_coords3_21:9_masked">
-		<left>0</left>
-		<bottom>270</bottom>
-		<width>2560</width>
-		<height>86</height>
-	</include>
-	<include name="dialogButtonBackground_coords3_4:3">
-		<left>0</left>
-		<bottom>90</bottom>
-		<width>1440</width>
-		<height>86</height>
-	</include>
-	
 	<include name="MaskingBars_coords1">
 		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">MaskingBars_coords1_16:9</include>
 		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">MaskingBars_coords1_21:9</include>
@@ -1432,6 +1339,130 @@
 		<top>0</top>
 		<width>1440</width>
 		<height>1080</height>
+	</include>
+	
+	<include name="FullscreenOverlayDimensions">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">FullscreenDimensions_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">FullscreenDimensions_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">FullscreenDimensions_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">FullscreenDimensions_4:3</include>
+	</include>
+	<include name="FullscreenDimensions_16:9">
+		<left>-10</left>
+		<top>-10</top>
+		<width>1940</width>
+		<height>1100</height>
+	</include>
+	<include name="FullscreenDimensions_21:9">
+		<left>-10</left>
+		<top>-10</top>
+		<width>2580</width>
+		<height>1100</height>
+	</include>
+	<include name="FullscreenDimensions_21:9_masked">
+		<left>-10</left>
+		<top>-10</top>
+		<width>2580</width>
+		<height>1460</height>
+	</include>
+	<include name="FullscreenDimensions_4:3">
+		<left>-10</left>
+		<top>-10</top>
+		<width>1460</width>
+		<height>1100</height>
+	</include>
+	
+	<include name="dialogButtonBackground_coords1">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">dialogButtonBackground_coords1_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords1_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">dialogButtonBackground_coords1_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">dialogButtonBackground_coords1_4:3</include>
+	</include>
+	<include name="dialogButtonBackground_coords1_16:9">
+		<left>-10</left>
+		<bottom>174</bottom>
+		<width>1940</width>
+		<height>2</height>
+	</include>
+	<include name="dialogButtonBackground_coords1_21:9">
+		<left>-10</left>
+		<bottom>174</bottom>
+		<width>2580</width>
+		<height>2</height>
+	</include>
+	<include name="dialogButtonBackground_coords1_21:9_masked">
+		<left>-10</left>
+		<bottom>354</bottom>
+		<width>2580</width>
+		<height>2</height>
+	</include>
+	<include name="dialogButtonBackground_coords1_4:3">
+		<left>-10</left>
+		<bottom>174</bottom>
+		<width>1460</width>
+		<height>2</height>
+	</include>
+	
+	<include name="dialogButtonBackground_coords2">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">dialogButtonBackground_coords2_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords2_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">dialogButtonBackground_coords2_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">dialogButtonBackground_coords2_4:3</include>
+	</include>
+	<include name="dialogButtonBackground_coords2_16:9">
+		<left>-10</left>
+		<bottom>90</bottom>
+		<width>1940</width>
+		<height>2</height>
+	</include>
+	<include name="dialogButtonBackground_coords2_21:9">
+		<left>-10</left>
+		<bottom>90</bottom>
+		<width>2580</width>
+		<height>2</height>
+	</include>
+	<include name="dialogButtonBackground_coords2_21:9_masked">
+		<left>10</left>
+		<bottom>270</bottom>
+		<width>2580</width>
+		<height>2</height>
+	</include>
+	<include name="dialogButtonBackground_coords2_4:3">
+		<left>-10</left>
+		<bottom>90</bottom>
+		<width>1460</width>
+		<height>2</height>
+	</include>
+	
+	<include name="dialogButtonBackground_coords3">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">dialogButtonBackground_coords3_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">dialogButtonBackground_coords3_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">dialogButtonBackground_coords3_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">dialogButtonBackground_coords3_4:3</include>
+	</include>
+	<include name="dialogButtonBackground_coords3_16:9">
+		<left>-10</left>
+		<bottom>90</bottom>
+		<width>1940</width>
+		<height>86</height>
+	</include>
+	<include name="dialogButtonBackground_coords3_21:9">
+		<left>-10</left>
+		<bottom>90</bottom>
+		<width>2580</width>
+		<height>86</height>
+	</include>
+	<include name="dialogButtonBackground_coords3_21:9_masked">
+		<left>-10</left>
+		<bottom>270</bottom>
+		<width>2580</width>
+		<height>86</height>
+	</include>
+	<include name="dialogButtonBackground_coords3_4:3">
+		<left>-10</left>
+		<bottom>90</bottom>
+		<width>1460</width>
+		<height>86</height>
 	</include>
 	
 </includes>

--- a/xml/Defaults.xml
+++ b/xml/Defaults.xml
@@ -10,6 +10,7 @@
 		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
 		<selectedcolor>$VAR[SelectedColor]</selectedcolor>
 		<scroll>False</scroll>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="fadelabel">
@@ -21,6 +22,7 @@
 		<scroll>True</scroll>
 		<scrollout>False</scrollout>
 		<pauseatend>5000</pauseatend>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="button">
@@ -38,6 +40,7 @@
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
 		<texturenofocus></texturenofocus>
 		<pulseonselect>False</pulseonselect>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="togglebutton">
@@ -56,6 +59,7 @@
 		<alttexturenofocus></alttexturenofocus>
 		<alttexturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</alttexturefocus>
 		<pulseonselect>False</pulseonselect>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="radiobutton">
@@ -78,6 +82,7 @@
 		<textureradiooffnofocus colordiffuse="$VAR[DialogColor1]">common/RadioOff.png</textureradiooffnofocus>
 		<textoffsetx>0</textoffsetx>
 		<pulseonselect>False</pulseonselect>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="spincontrolex">
@@ -100,6 +105,7 @@
 		<reverse>yes</reverse>
 		<pulseonselect>False</pulseonselect>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="spincontrol">
@@ -121,6 +127,7 @@
 		<reverse>yes</reverse>
 		<pulseonselect>False</pulseonselect>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="sliderex">
@@ -140,6 +147,7 @@
 		<textoffsetx>5</textoffsetx>
 		<orientation>horizontal</orientation>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="slider">
@@ -150,6 +158,7 @@
 		<textureslidernibfocus border="10,0,10,0" colordiffuse="$VAR[TextColor1]">osd/OSDSliderNib.png</textureslidernibfocus>
 		<orientation>horizontal</orientation>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="progress">
@@ -158,6 +167,7 @@
 		<lefttexture></lefttexture>
 		<righttexture></righttexture>
 		<overlaytexture></overlaytexture>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="textbox">
@@ -165,6 +175,7 @@
 		<font>Font27</font>
 		<textcolor>$VAR[TextColor2]</textcolor>
 		<autoscroll delay="8000" time="4000" repeat="12000">True</autoscroll>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="edit">
@@ -179,10 +190,56 @@
 		<invalidcolor>$VAR[InvalidColor]</invalidcolor>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
 		<pulseonselect>no</pulseonselect>
+		<include>WindowDepth</include>
 	</default>
 
 	<default type="fixedlist">
 		<preloaditems>2</preloaditems>
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="epggrid">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="mover">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="resize">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="grouplist">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="image">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="multiimage">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="list">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="wraplist">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="fixedlist">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="panel">
+		<include>WindowDepth</include>
+	</default>
+	
+	<default type="group">
+		<include>WindowDepth</include>
 	</default>
 
 </includes>

--- a/xml/DialogAddonInfo.xml
+++ b/xml/DialogAddonInfo.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogAddonSettings.xml
+++ b/xml/DialogAddonSettings.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogBusy.xml
+++ b/xml/DialogBusy.xml
@@ -3,23 +3,28 @@
 	<!-- busydialog -->
 
 	<controls>
-
-		<!-- Background -->
-		<include>DialogFadeBackgroundImage</include>
-		<include>DialogFadeBackgroundImage</include>
-		<include>DialogFadeBackgroundImage</include>
-
-		<!-- Main group -->
+	
 		<control type="group">
-			<include>DialogZoomAnimation</include>
-			<include>DialogBusy_coords1</include>
+			<include>BusyDepth</include>
 
-			<!-- Spinner -->
-			<control type="image">
-				<include>DialogBusy_coords2</include>
-				<texture colordiffuse="$VAR[DialogColor1]">$VAR[BusySpinner]</texture>
+			<!-- Background -->
+			<include>DialogFadeBackgroundImage</include>
+			<include>DialogFadeBackgroundImage</include>
+			<include>DialogFadeBackgroundImage</include>
+
+			<!-- Main group -->
+			<control type="group">
+				<include>DialogZoomAnimation</include>
+				<include>DialogBusy_coords1</include>
+
+				<!-- Spinner -->
+				<control type="image">
+					<include>DialogBusy_coords2</include>
+					<texture colordiffuse="$VAR[DialogColor1]">$VAR[BusySpinner]</texture>
+				</control>
+
 			</control>
-
+			
 		</control>
 
 	</controls>

--- a/xml/DialogButtonMenu.xml
+++ b/xml/DialogButtonMenu.xml
@@ -7,100 +7,104 @@
 
 	
 	<controls>
-
-		<!-- Background image -->
-		<include>DialogFadeBackgroundImage</include>
+	
 		<control type="group">
-			<animation effect="slide" start="-450,0" time="200">WindowOpen</animation>
-			<animation effect="slide" end="-450,0" time="200">WindowClose</animation>
+			<include>NotificationDepth</include>
 
-			<control type="image">
-				<include>DialogButtonMenu_coords1</include>
-				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
-			</control>
+			<!-- Background image -->
+			<include>DialogFadeBackgroundImage</include>
+			<control type="group">
+				<animation effect="slide" start="-460,0" time="200">WindowOpen</animation>
+				<animation effect="slide" end="-460,0" time="200">WindowClose</animation>
 
-			<control type="list" id="7000">
-				<include>DialogButtonMenu_coords2</include>
-				<onright>Close</onright>
+				<control type="image">
+					<include>DialogButtonMenu_coords1</include>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
+				</control>
 
-				<include content="SideMenuAnimation">
-					<param name="containerID">7000</param>
-				</include>
+				<control type="list" id="7000">
+					<include>DialogButtonMenu_coords2</include>
+					<onright>Close</onright>
 
-				<include>DialogButtonMenu_coords3</include>
-				
-				<include>DialogButtonMenu_coords4</include>
-				
-				<content>
-					<item>
-						<label>13012</label>
-						<onclick>XBMC.Quit()</onclick>
-						<visible>System.ShowExitButton</visible>
-					</item>
-					<item>
-						<label>13016</label>
-						<onclick>XBMC.Powerdown()</onclick>
-						<visible>System.CanPowerDown</visible>
-					</item>
-					<item>
-						<label>13011</label>
-						<onclick>XBMC.Suspend()</onclick>
-						<visible>System.CanSuspend</visible>
-					</item>
-					<item>
-						<label>13010</label>
-						<onclick>XBMC.Hibernate()</onclick>
-						<visible>System.CanHibernate</visible>
-					</item>
-					<item>
-						<label>13013</label>
-						<onclick>XBMC.Reset()</onclick>
-						<visible>System.CanReboot</visible>
-					</item>
-					<item>
-						<label>$LOCALIZE[20126] $INFO[system.profilename]</label>
-						<onclick>dialog.close(all,true)</onclick>
-						<onclick>System.LogOff</onclick>
-						<visible>System.HasLoginScreen | Integer.IsGreater(System.ProfileCount,1)</visible>
-						<visible>System.Loggedon</visible>
-					</item>
-					<item>
-						<label>20046</label>
-						<onclick>xbmc.mastermode</onclick>
-						<visible>System.HasLocks + System.IsMaster</visible>
-					</item>
-					<item>
-						<altlabel>20045</altlabel>
-						<onclick>xbmc.mastermode</onclick>
-						<visible>System.HasLocks + !System.IsMaster</visible>
-					</item>
-					<item>
-						<label>13017</label>
-						<onclick>XBMC.InhibitIdleShutdown(true)</onclick>
-						<visible>System.HasShutdown +!System.IsInhibit</visible>
-					</item>
-					<item>
-						<label>13018</label>
-						<onclick>XBMC.InhibitIdleShutdown(false)</onclick>
-						<visible>System.HasShutdown + System.IsInhibit</visible>
-					</item>
-					<item>
-						<label>20150</label>
-						<onclick>XBMC.AlarmClock(shutdowntimer,XBMC.Shutdown())</onclick>
-						<visible>!System.HasAlarm(shutdowntimer)</visible>
-						<visible>System.CanPowerDown | System.CanSuspend | System.CanHibernate</visible>
-					</item>
-					<item>
-						<label>20151 $INFO[System.Alarmpos,T-]</label>
-						<onclick>XBMC.CancelAlarm(shutdowntimer)</onclick>
-						<visible>System.HasAlarm(shutdowntimer)</visible>
-					</item>
-					<item>
-						<label>5</label>
-						<onclick>Close</onclick>
-						<onclick>ActivateWindow(Settings)</onclick>
-					</item>
-				</content>
+					<include content="SideMenuAnimation">
+						<param name="containerID">7000</param>
+					</include>
+
+					<include>DialogButtonMenu_coords3</include>
+					
+					<include>DialogButtonMenu_coords4</include>
+					
+					<content>
+						<item>
+							<label>13012</label>
+							<onclick>XBMC.Quit()</onclick>
+							<visible>System.ShowExitButton</visible>
+						</item>
+						<item>
+							<label>13016</label>
+							<onclick>XBMC.Powerdown()</onclick>
+							<visible>System.CanPowerDown</visible>
+						</item>
+						<item>
+							<label>13011</label>
+							<onclick>XBMC.Suspend()</onclick>
+							<visible>System.CanSuspend</visible>
+						</item>
+						<item>
+							<label>13010</label>
+							<onclick>XBMC.Hibernate()</onclick>
+							<visible>System.CanHibernate</visible>
+						</item>
+						<item>
+							<label>13013</label>
+							<onclick>XBMC.Reset()</onclick>
+							<visible>System.CanReboot</visible>
+						</item>
+						<item>
+							<label>$LOCALIZE[20126] $INFO[system.profilename]</label>
+							<onclick>dialog.close(all,true)</onclick>
+							<onclick>System.LogOff</onclick>
+							<visible>System.HasLoginScreen | Integer.IsGreater(System.ProfileCount,1)</visible>
+							<visible>System.Loggedon</visible>
+						</item>
+						<item>
+							<label>20046</label>
+							<onclick>xbmc.mastermode</onclick>
+							<visible>System.HasLocks + System.IsMaster</visible>
+						</item>
+						<item>
+							<altlabel>20045</altlabel>
+							<onclick>xbmc.mastermode</onclick>
+							<visible>System.HasLocks + !System.IsMaster</visible>
+						</item>
+						<item>
+							<label>13017</label>
+							<onclick>XBMC.InhibitIdleShutdown(true)</onclick>
+							<visible>System.HasShutdown +!System.IsInhibit</visible>
+						</item>
+						<item>
+							<label>13018</label>
+							<onclick>XBMC.InhibitIdleShutdown(false)</onclick>
+							<visible>System.HasShutdown + System.IsInhibit</visible>
+						</item>
+						<item>
+							<label>20150</label>
+							<onclick>XBMC.AlarmClock(shutdowntimer,XBMC.Shutdown())</onclick>
+							<visible>!System.HasAlarm(shutdowntimer)</visible>
+							<visible>System.CanPowerDown | System.CanSuspend | System.CanHibernate</visible>
+						</item>
+						<item>
+							<label>20151 $INFO[System.Alarmpos,T-]</label>
+							<onclick>XBMC.CancelAlarm(shutdowntimer)</onclick>
+							<visible>System.HasAlarm(shutdowntimer)</visible>
+						</item>
+						<item>
+							<label>5</label>
+							<onclick>Close</onclick>
+							<onclick>ActivateWindow(Settings)</onclick>
+						</item>
+					</content>
+				</control>
 			</control>
 		</control>
 

--- a/xml/DialogConfirm.xml
+++ b/xml/DialogConfirm.xml
@@ -10,6 +10,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 		
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogContextMenu.xml
+++ b/xml/DialogContextMenu.xml
@@ -7,43 +7,47 @@
 	</coordinates>
 
 	<controls>
-
-		<!-- Background image -->
-		<include>DialogFadeBackgroundImage</include>
+	
 		<control type="group">
-			<animation effect="slide" start="-450,0" end="0,0" time="200">WindowOpen</animation>
-			<animation effect="slide" start="0,0" end="-450,0" time="200">WindowClose</animation>
-			
-			<!-- Background -->
-			<control type="image">
-				<include>DialogContextMenu_coords1</include>
-				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
-			</control>
-			
+			<include>NotificationDepth</include>
 
-			<!-- Dialog group -->
+			<!-- Background image -->
+			<include>DialogFadeBackgroundImage</include>
 			<control type="group">
-				<include>DialogContextMenu_coords2</include>
-
-				<include content="SideMenuAnimation">
-					<param name="containerID">996</param>
-				</include>
-
-				<!-- Default grouplist -->
-				<control type="grouplist" id="996">
-					<include>DialogContextMenu_coords3</include>
-					<onright>Close</onright>
-					<onleft>Close</onleft>
-					<itemgap>0</itemgap>
+				<animation effect="slide" start="-460,0" time="200">WindowOpen</animation>
+				<animation effect="slide" end="-460,0" time="200">WindowClose</animation>
+				
+				<!-- Background -->
+				<control type="image">
+					<include>DialogContextMenu_coords1</include>
+					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
 				</control>
+				
 
-				<!-- Default button -->
-				<control type="button" id="1000">
-					<include>DialogContextMenu_coords4</include>
-					<align>center</align>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus52c.png</texturefocus>
+				<!-- Dialog group -->
+				<control type="group">
+					<include>DialogContextMenu_coords2</include>
+
+					<include content="SideMenuAnimation">
+						<param name="containerID">996</param>
+					</include>
+
+					<!-- Default grouplist -->
+					<control type="grouplist" id="996">
+						<include>DialogContextMenu_coords3</include>
+						<onright>Close</onright>
+						<onleft>Close</onleft>
+						<itemgap>0</itemgap>
+					</control>
+
+					<!-- Default button -->
+					<control type="button" id="1000">
+						<include>DialogContextMenu_coords4</include>
+						<align>center</align>
+						<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus52c.png</texturefocus>
+					</control>
+
 				</control>
-
 			</control>
 		</control>
 

--- a/xml/DialogExtendedProgressBar.xml
+++ b/xml/DialogExtendedProgressBar.xml
@@ -6,6 +6,7 @@
 	<zorder>100</zorder>
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			<animation effect="slide" end="0,50" time="200" condition="Window.IsActive(volumebar)">Conditional</animation>
 			<animation effect="slide" end="0,20" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True) | Window.IsActive(volumebar)">Conditional</animation>

--- a/xml/DialogFavourites.xml
+++ b/xml/DialogFavourites.xml
@@ -102,18 +102,19 @@
 		
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>

--- a/xml/DialogGameControllers.xml
+++ b/xml/DialogGameControllers.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogKeyboard.xml
+++ b/xml/DialogKeyboard.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogMediaSource.xml
+++ b/xml/DialogMediaSource.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogNotification.xml
+++ b/xml/DialogNotification.xml
@@ -6,6 +6,7 @@
 	<!-- infodialog -->
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			<animation effect="slide" end="0,50" time="200" condition="Window.IsActive(volumebar)">Conditional</animation>
 			<animation effect="slide" end="0,20" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True) | Window.IsActive(volumebar)">Conditional</animation>

--- a/xml/DialogNumeric.xml
+++ b/xml/DialogNumeric.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogPVRChannelGuide.xml
+++ b/xml/DialogPVRChannelGuide.xml
@@ -9,6 +9,7 @@
 
 		<!-- Menu -->
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>DialogPVRChannelGuide_coords1</include>
 
 			<!-- Background -->

--- a/xml/DialogPVRChannelManager.xml
+++ b/xml/DialogPVRChannelManager.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogPVRChannelsOSD.xml
+++ b/xml/DialogPVRChannelsOSD.xml
@@ -9,6 +9,7 @@
 
 		<!-- Menu -->
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>DialogPVRChannelsOSD_coords1</include>
 
 			<!-- Background -->

--- a/xml/DialogPVRGroupManager.xml
+++ b/xml/DialogPVRGroupManager.xml
@@ -17,6 +17,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogPVRGuideSearch.xml
+++ b/xml/DialogPVRGuideSearch.xml
@@ -6,6 +6,7 @@
 	<controls>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Dialog fanart -->
 			<include>DialogFanart</include>

--- a/xml/DialogPVRInfo.xml
+++ b/xml/DialogPVRInfo.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogPictureInfo.xml
+++ b/xml/DialogPictureInfo.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogPlayerProcessInfo.xml
+++ b/xml/DialogPlayerProcessInfo.xml
@@ -6,9 +6,11 @@
 	<controls>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<visible>!Window.IsVisible(shutdownmenu)</visible>
 			<include>OSDVisibleHiddenAnimation</include>
 			<include>OSDOpenCloseAnimation</include>
+			
 			<!-- Info -->
 			<control type="group">
 				<include>DialogPlayerProcessInfo_coords1</include>

--- a/xml/DialogSeekBar.xml
+++ b/xml/DialogSeekBar.xml
@@ -9,6 +9,7 @@
 	<controls>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>DialogSeekBar_coords1</include>
 	
 			<control type="slider" id="401">

--- a/xml/DialogSelect.xml
+++ b/xml/DialogSelect.xml
@@ -12,6 +12,7 @@
 			<include>DialogFanart</include>
 			
 			<control type="group">
+				<include>DialogDepth</include>
 				<!-- Animation -->
 				<include>DialogZoomAnimation</include>
 			
@@ -134,12 +135,13 @@
 		</control>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<visible>[Window.IsVisible(gamevideofilter) | Window.IsVisible(gamestretchmode) | Window.IsVisible(gamevideorotation)] + !Window.IsVisible(shutdownmenu)</visible>
 			<!-- Animation -->
-			<animation effect="slide" start="0,1480" time="400">WindowOpen</animation>
-			<animation effect="slide" end="0,1480" time="400">WindowClose</animation>
-			<animation effect="slide" start="0,1480" time="400">Visible</animation>
-			<animation effect="slide" end="0,1480" time="400">Hidden</animation>
+			<animation effect="slide" start="0,1490" time="200">WindowOpen</animation>
+			<animation effect="slide" end="0,1490" time="200">WindowClose</animation>
+			<animation effect="slide" start="0,1490" time="200">Visible</animation>
+			<animation effect="slide" end="0,1490" time="200">Hidden</animation>
 
 			<!-- Window Background -->
 			<control type="image">

--- a/xml/DialogSlider.xml
+++ b/xml/DialogSlider.xml
@@ -5,6 +5,7 @@
 
 	<controls>
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>DialogSlider_coords1</include>
 			
 			<!-- Animation -->

--- a/xml/DialogSubtitles.xml
+++ b/xml/DialogSubtitles.xml
@@ -5,22 +5,32 @@
 	
 	<controls>
 		<control type="group">
+		
+			<!-- Dialog background -->
+			<include>DialogFadeBackgroundImage</include>
+			<include>DialogFadeBackgroundImage</include>
+			<!-- Overlay -->
+			<control type="image">
+				<include>FullscreenOverlayDimensions</include>
+				<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
+				<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
+				<animation type="WindowOpen">
+					<effect type="zoom" start="70" end="100" center="auto" tween="back" easing="inout" time="300" />
+					<effect type="fade" start="0" end="100" time="300" tween="quadratic" easing="out" />
+				</animation>
+				<animation type="WindowClose">
+					<effect type="zoom" start="100" end="70" center="auto" time="300" />
+					<effect type="fade" start="100" end="0" time="300" tween="quadratic" easing="in" />
+				</animation>
+				<include>DialogBackgroundDepth</include>
+			</control>
 
 			<control type="group">
+				<include>DialogDepth</include>
+			
 				<!-- Animation -->
 				<include>DialogZoomAnimation</include>
 				
-				<!-- Dialog background -->
-				<include>DialogFadeBackgroundImage</include>
-				<include>DialogFadeBackgroundImage</include>
-				<!-- Overlay -->
-				<control type="image">
-					<include>FullscreenDimensions</include>
-					<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
-					<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
-					<include>WindowFadeAnimation</include>
-				</control>
-
 				<!-- Heading -->
 				<include content="Time">
 					<param name="heading">$INFO[Control.GetLabel(100)]</param>

--- a/xml/DialogTextViewer.xml
+++ b/xml/DialogTextViewer.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -14,6 +14,8 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
+			
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>
 			

--- a/xml/DialogVolumeBar.xml
+++ b/xml/DialogVolumeBar.xml
@@ -6,6 +6,7 @@
 	<!-- volumebar -->
 	<controls>
 		<control type="group">
+			<include>DialogDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			
 			<!-- Background -->

--- a/xml/EventLog.xml
+++ b/xml/EventLog.xml
@@ -64,18 +64,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>

--- a/xml/FileBrowser.xml
+++ b/xml/FileBrowser.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 		
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/GameOSD.xml
+++ b/xml/GameOSD.xml
@@ -7,6 +7,7 @@
 
 		<!-- Player status -->
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>GameOSD_coords1</include>
 			<visible>player.forwarding | player.rewinding | player.paused | player.istempo</visible>
 			<visible>![Window.IsVisible(gamevideofilter) | Window.IsVisible(gamestretchmode) | Window.IsVisible(gamevideorotation) | Window.IsVisible(gamevolume) | Window.IsVisible(gamecontrollers) | Window.IsVisible(gameadvancedsettings) | Window.IsVisible(shutdownmenu)]</visible>
@@ -29,6 +30,7 @@
 		</control>
 	
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>GameOSD_coords4</include>
 			<visible>![Window.IsActive(gamevideofilter) | Window.IsVisible(gamestretchmode) | Window.IsVisible(gamevideorotation) | Window.IsVisible(gamevolume) | Window.IsVisible(gamecontrollers) | Window.IsVisible(gameadvancedsettings) | Window.IsVisible(shutdownmenu)]</visible>
 			<include>OSDVisibleHiddenAnimation</include>

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -349,42 +349,6 @@
 		</control>
 	</include>
 	
-	<!-- Dialog button background -->
-	<include name="dialogButtonBackground">
-		<definition>
-			<control type="image">
-				<include>dialogButtonBackground_coords1</include>
-				<texture colordiffuse="$VAR[TextColor1]">common/Border.png</texture>
-				<visible>ControlGroup($PARAM[id]).HasFocus</visible>
-				<include>VisibleFadeAnimation</include>
-			</control>
-			<control type="image">
-				<include>dialogButtonBackground_coords1</include>
-				<texture colordiffuse="$VAR[TextColor2]">common/Border.png</texture>
-				<visible>!ControlGroup($PARAM[id]).HasFocus</visible>
-				<include>VisibleFadeAnimation</include>
-			</control>
-			<control type="image">
-				<include>dialogButtonBackground_coords2</include>
-				<texture colordiffuse="$VAR[TextColor1]">common/Border.png</texture>
-				<visible>ControlGroup($PARAM[id]).HasFocus</visible>
-				<include>VisibleFadeAnimation</include>
-			</control>
-			<control type="image">
-				<include>dialogButtonBackground_coords2</include>
-				<texture colordiffuse="$VAR[TextColor2]">common/Border.png</texture>
-				<visible>!ControlGroup($PARAM[id]).HasFocus</visible>
-				<include>VisibleFadeAnimation</include>
-			</control>
-			<control type="image">
-				<include>dialogButtonBackground_coords3</include>
-				<visible>ControlGroup($PARAM[id]).HasFocus</visible>
-				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
-				<include>VisibleFadeAnimation</include>
-			</control>
-		</definition>
-	</include>
-	
 	<!-- Sidemenu menucontrol -->
 	<include name="SidemenuMenucontrol">
 		<definition>
@@ -431,39 +395,6 @@
 					<height>30</height>
 					<texture colordiffuse="$VAR[DialogColor2]">sub-menu-down.png</texture>
 					<animation effect="fade" start="100" end="0" time="200" condition="Integer.IsEqual(Container.NumItems,0) + Window.IsVisible(busydialog)">Conditional</animation>
-				</control>
-			</control>
-		</definition>
-	</include>
-	
-	<!-- Dialog button indicator -->
-	<include name="dialogButtonIndicator">
-		<definition>
-			<control type="group">
-				<visible>$PARAM[visibility]</visible>
-				<animation effect="fade" start="0" end="100" time="200">VisibleChange</animation>
-				<animation effect="slide" time="200" start="-200,0" end="0,0" delay="300">WindowOpen</animation>
-				<animation effect="slide" time="200" start="0,0" end="-200,0" delay="300">WindowClose</animation>
-				<control type="image">
-					<left>10</left>
-					<centertop>50%</centertop>
-					<width>30</width>
-					<height>30</height>
-					<texture colordiffuse="$VAR[DialogColor2]">sub-menu-left.png</texture>
-				</control>
-			</control>
-			
-			<control type="group">
-				<visible>$PARAM[visibility]</visible>
-				<animation effect="fade" start="0" end="100" time="200">VisibleChange</animation>
-				<animation effect="slide" time="200" start="200,0" end="0,0" delay="300">WindowOpen</animation>
-				<animation effect="slide" time="200" start="0,0" end="200,0" delay="300">WindowClose</animation>
-				<control type="image">
-					<right>10</right>
-					<centertop>50%</centertop>
-					<width>30</width>
-					<height>30</height>
-					<texture colordiffuse="$VAR[DialogColor2]">sub-menu-right.png</texture>
 				</control>
 			</control>
 		</definition>
@@ -530,6 +461,7 @@
 				<animation effect="slide" end="0,1480" time="400" condition="String.IsEqual(Skin.String(MaskingBars),1.78:1)">Conditional</animation>
 				<animation effect="slide" end="0,12" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.35:1)">Conditional</animation>
 				<animation effect="slide" end="0,107" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.00:1)">Conditional</animation>
+				<include>BusyDepth</include>
 			</control>
 			<!-- Bottom bar -->
 			<control type="image">
@@ -539,6 +471,7 @@
 				<animation effect="slide" end="0,-1480" time="400" condition="String.IsEqual(Skin.String(MaskingBars),1.78:1)">Conditional</animation>
 				<animation effect="slide" end="0,-12" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.35:1)">Conditional</animation>
 				<animation effect="slide" end="0,-107" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.00:1)">Conditional</animation>
+				<include>BusyDepth</include>
 			</control>
 		</definition>
 	</include>

--- a/xml/Includes_DialogSettings.xml
+++ b/xml/Includes_DialogSettings.xml
@@ -9,6 +9,7 @@
 			<include>DialogFanart</include>
 
 			<control type="group">
+				<include>DialogDepth</include>
 			
 				<!-- Animation -->
 				<include>DialogZoomAnimation</include>
@@ -127,9 +128,11 @@
 		<controls>
 
 			<control type="group">
+				<include>DialogDepth</include>
 				<include>DialogSettings_coords6</include>
-				<!-- Animation -->
 				<visible>!Window.IsVisible(10153) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(playerprocessinfo) + !Window.IsVisible(SliderDialog) + !Window.IsVisible(FileBrowser) + !Window.IsVisible(shutdownmenu) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
+				
+				<!-- Animation -->
 				<include>OSDVisibleHiddenAnimation</include>
 				<include>OSDOpenCloseAnimation</include>
 

--- a/xml/Includes_Home.xml
+++ b/xml/Includes_Home.xml
@@ -42,10 +42,11 @@
 			<include>skinshortcuts-template-vertical</include>
 		</control>
 
-		<!-- Sub Menu -->
+		<!-- Side Menu -->
 		<control type="group" id="9010">
+			<include>NotificationDepth</include>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<visible>ControlGroup(9010).HasFocus</visible>
 			</control>
@@ -64,9 +65,9 @@
 				</control>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9010).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9010).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>

--- a/xml/Includes_Windows_Dialogs.xml
+++ b/xml/Includes_Windows_Dialogs.xml
@@ -68,15 +68,17 @@
 	<include name="WindowBackgroundImage">
 		<!-- Black background image -->
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture background="true">common/white.png</texture>
 			<colordiffuse>FF000000</colordiffuse>
 			<aspectratio>scale</aspectratio>
+			<include>BackgroundDepth</include>
 		</control>
 		<!-- Background video -->
 		<control type="videowindow">
 			<include>FullscreenDimensions</include>
 			<visible>Player.HasVideo + Skin.HasSetting(BackgroundVideo)</visible>
+			<include>BackgroundDepth</include>
 		</control>
 
 		<!-- Color -->
@@ -89,6 +91,7 @@
 			<aspectratio>scale</aspectratio>
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+			<include>BackgroundDepth</include>
 		</control>
 		<!-- Single background image -->
 		<control type="image">
@@ -100,6 +103,7 @@
 			<aspectratio>scale</aspectratio>
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
+			<include>BackgroundDepth</include>
 		</control>
 		<!-- Multiple background images -->
 		<control type="multiimage">
@@ -116,6 +120,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 		
 		<!-- Single individual background image -->
@@ -129,6 +134,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 		<!-- Multiple individual background images -->
 		<control type="multiimage">
@@ -145,6 +151,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 		
 		<!-- Artists Slideshow -->
@@ -157,6 +164,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 		<control type="multiimage">
 			<include>FullscreenDimensions</include>
@@ -170,6 +178,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 		
 		<!-- Fanart -->
@@ -183,6 +192,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 
 		<!-- Visualisation -->
@@ -192,14 +202,16 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>WindowFadeAnimation</include>
+			<include>BackgroundDepth</include>
 		</control>
 
 		<!-- Overlay -->
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
 			<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
 			<visible>!Window.Is(visualisation) | [Window.Is(visualisation) + [[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] | Window.IsActive(musicosd)]]</visible>
+			<include>BackgroundDepth</include>
 		</control>
 	</include>
 	
@@ -207,11 +219,12 @@
 	<include name="DialogFanart">
 		<!-- Black background image -->
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture background="true">common/white.png</texture>
 			<colordiffuse>FF000000</colordiffuse>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Color -->
 		<control type="image">
@@ -221,6 +234,7 @@
 			<visible>String.IsEqual(Skin.String(BackgroundDefaultImage),no) | String.IsEqual(Skin.String(BackgroundSingleImage),solid)</visible>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Single background image -->
 		<control type="image">
@@ -229,6 +243,7 @@
 			<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(9000).ListItem.Property(background)) + String.IsEmpty(ListItem.Art(fanart))</visible>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Multiple background images -->
 		<control type="multiimage">
@@ -241,6 +256,7 @@
 			<randomize>true</randomize>
 			<loop>yes</loop>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Fanart -->
 		<control type="image" id="10000">
@@ -250,10 +266,11 @@
 			<fadetime>400</fadetime>
 			<visible>!Skin.HasSetting(HideFanart)</visible>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Overlay -->
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
 			<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
 			<animation type="WindowOpen">
@@ -264,23 +281,25 @@
 				<effect type="zoom" start="100" end="70" center="auto" time="300" />
 				<effect type="fade" start="100" end="0" time="300" tween="quadratic" easing="in" />
 			</animation>
+			<include>DialogBackgroundDepth</include>
 		</control>
 	</include>
 
 	<!-- Dialog fade background image -->
 	<include name="DialogFadeBackgroundImage">
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 			<animation effect="fade" start="0" end="100" time="200">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+			<include>DialogBackgroundDepth</include>
 		</control>
 	</include>
 
 	<!-- Options background image -->
 	<include name="OptionsBackgroundImage">
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture border="20">dialogs/OptionsBackground.png</texture>
 		</control>
 	</include>
@@ -358,5 +377,106 @@
     <include name="CustomBackgroundFolderDuration60">
 		<timeperimage>60000</timeperimage>
     </include>
+	
+	<!-- 3D depth -->
+	
+	<!-- Background depth -->
+	<include name="BackgroundDepth">
+		<depth>-0.25</depth>
+	</include>
+	
+	<!-- Window depth -->
+	<include name="WindowDepth">
+		<depth>0</depth>
+	</include>
+	
+	<!-- Dialog background -->
+	<include name="DialogBackgroundDepth">
+		<depth>0.25</depth>
+	</include>
+	
+	<!-- Dialog depth -->
+	<include name="DialogDepth">
+		<depth>0.5</depth>
+	</include>
+	
+	<!-- Side/context menu and notification depth depth -->
+	<include name="NotificationDepth">
+		<depth>0.75</depth>
+	</include>
+	
+	<!-- Busy dialog depth depth -->
+	<include name="BusyDepth">
+		<depth>1</depth>
+	</include>
+	
+	<!-- Dialog button background -->
+	<include name="dialogButtonBackground">
+		<definition>
+			<control type="image">
+				<include>dialogButtonBackground_coords1</include>
+				<texture colordiffuse="$VAR[TextColor1]">common/Border.png</texture>
+				<visible>ControlGroup($PARAM[id]).HasFocus</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+			<control type="image">
+				<include>dialogButtonBackground_coords1</include>
+				<texture colordiffuse="$VAR[TextColor2]">common/Border.png</texture>
+				<visible>!ControlGroup($PARAM[id]).HasFocus</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+			<control type="image">
+				<include>dialogButtonBackground_coords2</include>
+				<texture colordiffuse="$VAR[TextColor1]">common/Border.png</texture>
+				<visible>ControlGroup($PARAM[id]).HasFocus</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+			<control type="image">
+				<include>dialogButtonBackground_coords2</include>
+				<texture colordiffuse="$VAR[TextColor2]">common/Border.png</texture>
+				<visible>!ControlGroup($PARAM[id]).HasFocus</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+			<control type="image">
+				<include>dialogButtonBackground_coords3</include>
+				<visible>ControlGroup($PARAM[id]).HasFocus</visible>
+				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
+				<include>VisibleFadeAnimation</include>
+			</control>
+		</definition>
+	</include>
+	
+	<!-- Dialog button indicator -->
+	<include name="dialogButtonIndicator">
+		<definition>
+			<control type="group">
+				<visible>$PARAM[visibility]</visible>
+				<animation effect="fade" start="0" end="100" time="200">VisibleChange</animation>
+				<animation effect="slide" time="200" start="-200,0" end="0,0" delay="300">WindowOpen</animation>
+				<animation effect="slide" time="200" start="0,0" end="-200,0" delay="300">WindowClose</animation>
+				<control type="image">
+					<left>10</left>
+					<centertop>50%</centertop>
+					<width>30</width>
+					<height>30</height>
+					<texture colordiffuse="$VAR[DialogColor2]">sub-menu-left.png</texture>
+				</control>
+			</control>
+			
+			<control type="group">
+				<visible>$PARAM[visibility]</visible>
+				<animation effect="fade" start="0" end="100" time="200">VisibleChange</animation>
+				<animation effect="slide" time="200" start="200,0" end="0,0" delay="300">WindowOpen</animation>
+				<animation effect="slide" time="200" start="0,0" end="200,0" delay="300">WindowClose</animation>
+				<control type="image">
+					<right>10</right>
+					<centertop>50%</centertop>
+					<width>30</width>
+					<height>30</height>
+					<texture colordiffuse="$VAR[DialogColor2]">sub-menu-right.png</texture>
+				</control>
+			</control>
+		</definition>
+	</include>
 
 </includes>

--- a/xml/MusicOSD.xml
+++ b/xml/MusicOSD.xml
@@ -6,6 +6,7 @@
 	<controls>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<animation effect="fade" start="100" end="0" time="200" condition="Window.IsTopMost(DialogSelect.xml)">Conditional</animation>
 			<visible>!Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(playerprocessinfo) + !Window.IsVisible(shutdownmenu)</visible>
 			<include>MusicOSD_coords1</include>

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -131,6 +131,7 @@
 		</control>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>MusicVisualisation_coords6</include>
 			<visible>[Window.IsActive(seekbar) | Window.IsActive(musicosd) | [Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)]] + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(playerprocessinfo) + !Window.IsVisible(shutdownmenu)</visible>
 			<animation effect="fade" start="100" end="0" time="200" condition="Window.IsTopMost(DialogSelect.xml)">Conditional</animation>

--- a/xml/MyGames.xml
+++ b/xml/MyGames.xml
@@ -68,18 +68,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>

--- a/xml/MyMusicNav.xml
+++ b/xml/MyMusicNav.xml
@@ -100,18 +100,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPVRChannels.xml
+++ b/xml/MyPVRChannels.xml
@@ -161,18 +161,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPVRGuide.xml
+++ b/xml/MyPVRGuide.xml
@@ -223,18 +223,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPVRRecordings.xml
+++ b/xml/MyPVRRecordings.xml
@@ -161,18 +161,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPVRSearch.xml
+++ b/xml/MyPVRSearch.xml
@@ -147,18 +147,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPVRTimers.xml
+++ b/xml/MyPVRTimers.xml
@@ -85,18 +85,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPics.xml
+++ b/xml/MyPics.xml
@@ -61,18 +61,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyPlaylist.xml
+++ b/xml/MyPlaylist.xml
@@ -79,18 +79,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>

--- a/xml/MyPrograms.xml
+++ b/xml/MyPrograms.xml
@@ -68,18 +68,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="image">
 					<include>OptionsSideMenu1</include>
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/MyVideoNav.xml
+++ b/xml/MyVideoNav.xml
@@ -161,18 +161,19 @@
 
 		<!-- Options -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<visible>!Skin.HasSetting(KioskMode)</visible>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>

--- a/xml/MyWeather.xml
+++ b/xml/MyWeather.xml
@@ -163,18 +163,19 @@
 
 			<!-- Options -->
 			<control type="group" id="9002">
+				<include>NotificationDepth</include>
 				<visible>!Skin.HasSetting(KioskMode)</visible>
 				<control type="image">
-					<include>FullscreenDimensions</include>
+					<include>FullscreenOverlayDimensions</include>
 					<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 					<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 					<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 					<visible>ControlGroup(9002).HasFocus</visible>
 				</control>
 				<control type="group">
-					<left>-450</left>
+					<left>-460</left>
 					<top>0</top>
-					<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+					<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 					<control type="image">
 						<include>OptionsSideMenu1</include>
 						<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
@@ -222,6 +223,7 @@
 		
 		<!-- Busy -->
 		<control type="group">
+			<include>BusyDepth</include>
 			<visible>String.IsEqual(Weather.Location,$LOCALIZE[503])</visible>
 			<!-- Background -->
 			<include>DialogFadeBackgroundImage</include>

--- a/xml/PlayerControls.xml
+++ b/xml/PlayerControls.xml
@@ -7,6 +7,7 @@
 	<controls>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>PlayerControls_coords1</include>
 			<animation type="WindowOpen">
 				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>

--- a/xml/Pointer.xml
+++ b/xml/Pointer.xml
@@ -2,37 +2,42 @@
 <window>
 	<!-- pointer -->
 	<defaultcontrol></defaultcontrol>
-
+	
 	<controls>
+		
+		<control type="group">
+			<include>BusyDepth</include>
+			
+			<!-- Pointer -->
+			<control type="image" id="1">
+				<width>32</width>
+				<height>32</height>
+				<texture>mouse.png</texture>
+			</control>
 
-		<!-- Pointer -->
-		<control type="image" id="1">
-			<width>32</width>
-			<height>32</height>
-			<texture>mouse.png</texture>
+			<!-- Pointer focus -->
+			<control type="image" id="2">
+				<width>32</width>
+				<height>32</height>
+				<texture>mouse.png</texture>
+			</control>
+
+			<!-- Pointer drag -->
+			<control type="image" id="3">
+				<width>32</width>
+				<height>32</height>
+				<texture>MouseDrag.png</texture>
+			</control>
+
+			<!-- Pointer click -->
+			<control type="image" id="4">
+				<width>32</width>
+				<height>32</height>
+				<texture>MouseClick.png</texture>
+			</control>
+			
 		</control>
-
-		<!-- Pointer focus -->
-		<control type="image" id="2">
-			<width>32</width>
-			<height>32</height>
-			<texture>mouse.png</texture>
-		</control>
-
-		<!-- Pointer drag -->
-		<control type="image" id="3">
-			<width>32</width>
-			<height>32</height>
-			<texture>MouseDrag.png</texture>
-		</control>
-
-		<!-- Pointer click -->
-		<control type="image" id="4">
-			<width>32</width>
-			<height>32</height>
-			<texture>MouseClick.png</texture>
-		</control>
-
+		
 	</controls>
 
 </window>

--- a/xml/SettingsCategory.xml
+++ b/xml/SettingsCategory.xml
@@ -108,19 +108,20 @@
 					</control>
 				</control>
 
-			<!-- Options -->
+			<!-- Settings quick-nav -->
 			<control type="group" id="9002">
+				<include>NotificationDepth</include>
 				<control type="image">
-					<include>FullscreenDimensions</include>
+					<include>FullscreenOverlayDimensions</include>
 					<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 					<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 					<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 					<visible>ControlGroup(9002).HasFocus</visible>
 				</control>
 				<control type="group">
-					<left>-450</left>
+					<left>-460</left>
 					<top>0</top>
-					<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+					<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 					<control type="image">
 						<include>OptionsSideMenu1</include>
 						<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
@@ -130,7 +131,6 @@
 						<texturefocus>noop</texturefocus>
 					</control>
 
-					<!-- Look controls -->
 					<control type="grouplist" id="3001">
 						<include>OptionsSideMenu3</include>
 						<onleft>3</onleft>
@@ -144,7 +144,6 @@
 							<param name="containerID">3001</param>
 						</include>
 
-						<!-- Settings quick-nav -->
 						<control type="button" id="90">
 							<label>14206</label>
 							<height>52</height>

--- a/xml/SettingsProfile.xml
+++ b/xml/SettingsProfile.xml
@@ -12,7 +12,6 @@
 		<!-- Time -->
 		<include>Time</include>
 
-
 		<!-- Default list -->
 		<control type="group" id="50">
 			<control type="grouplist" id="500">
@@ -86,19 +85,20 @@
 			</control>
 		</control>
 
-		<!-- Options -->
+		<!-- Settings quick-nav -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>
@@ -109,7 +109,6 @@
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
 				</control>
 
-				<!-- Look controls -->
 				<control type="grouplist" id="3001">
 					<include>OptionsSideMenu3</include>
 					<onleft>50</onleft>
@@ -123,7 +122,6 @@
 						<param name="containerID">3001</param>
 					</include>
 
-					<!-- Settings quick-nav -->
 					<control type="button" id="190">
 						<label>14206</label>
 						<height>52</height>

--- a/xml/SettingsSystemInfo.xml
+++ b/xml/SettingsSystemInfo.xml
@@ -204,19 +204,20 @@
 			</control>
 		</control>
 
-		<!-- Options -->
+		<!-- Settings quick-nav -->
 		<control type="group" id="9002">
+			<include>NotificationDepth</include>
 			<control type="image">
-				<include>FullscreenDimensions</include>
+				<include>FullscreenOverlayDimensions</include>
 				<texture colordiffuse="$VAR[DarkenColor]">dialogs/DialogTextBackground.png</texture>
 				<animation effect="fade" start="0" end="100" time="200">Visible</animation>
 				<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="group">
-				<left>-450</left>
+				<left>-460</left>
 				<top>0</top>
-				<animation effect="slide" start="0,0" end="450,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9002).HasFocus">Conditional</animation>
 				<control type="button">
 					<include>OptionsSideMenu1</include>
 					<texturefocus>noop</texturefocus>
@@ -227,7 +228,6 @@
 					<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>
 				</control>
 
-				<!-- Look controls -->
 				<control type="grouplist" id="3001">
 					<include>OptionsSideMenu3</include>
 					<onleft>50</onleft>
@@ -241,7 +241,6 @@
 						<param name="containerID">3001</param>
 					</include>
 
-					<!-- Settings quick-nav -->
 					<control type="button" id="190">
 						<label>14206</label>
 						<height>52</height>

--- a/xml/SlideShow.xml
+++ b/xml/SlideShow.xml
@@ -2,5 +2,4 @@
 <window>
 	<!-- slideshow -->
 	<defaultcontrol>2</defaultcontrol>
-
 </window>

--- a/xml/SmartPlaylistEditor.xml
+++ b/xml/SmartPlaylistEditor.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/SmartPlaylistRule.xml
+++ b/xml/SmartPlaylistRule.xml
@@ -9,6 +9,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/VideoFullScreen.xml
+++ b/xml/VideoFullScreen.xml
@@ -15,6 +15,7 @@
 	<controls>
 		
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>VideoFullScreen_coords1</include>
 
 			<!-- Background -->
@@ -50,6 +51,7 @@
 		</control>
 
 		<control type="group" id="1">
+			<include>DialogDepth</include>
 			<include>VideoFullScreen_coords6</include>
 			
 			<control type="group" id="1">
@@ -499,6 +501,7 @@
 			<animation effect="slide" end="0,1480" time="400" condition="String.IsEqual(Skin.String(MaskingBars),1.78:1)">Conditional</animation>
 			<animation effect="slide" end="0,12" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.35:1)">Conditional</animation>
 			<animation effect="slide" end="0,107" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.00:1)">Conditional</animation>
+			<include>BusyDepth</include>
 		</control>
 		<control type="image" id="1">
 			<include>MaskingBars_coords2</include>
@@ -507,6 +510,7 @@
 			<animation effect="slide" end="0,-1480" time="400" condition="String.IsEqual(Skin.String(MaskingBars),1.78:1)">Conditional</animation>
 			<animation effect="slide" end="0,-12" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.35:1)">Conditional</animation>
 			<animation effect="slide" end="0,-107" time="200" condition="String.IsEqual(Skin.String(MaskingBars),2.00:1)">Conditional</animation>
+			<include>BusyDepth</include>
 		</control>
 
 	</controls>

--- a/xml/VideoOSD.xml
+++ b/xml/VideoOSD.xml
@@ -15,6 +15,7 @@
 		</control>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>VideoOSD_coords2</include>
 			<visible>!Window.IsVisible(VideoBookmarks) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(teletext) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(playerprocessinfo) + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(1105) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
 			<include>OSDVisibleHiddenAnimation</include>

--- a/xml/VideoOSDBookmarks.xml
+++ b/xml/VideoOSDBookmarks.xml
@@ -6,6 +6,7 @@
 	<controls>
 		
 		<control type="list" id="11">
+			<include>DialogDepth</include>
 			<include>VideoOSDBookmarks_coords1</include>
 			<onleft>noop</onleft>
 			<onright>noop</onright>
@@ -30,6 +31,7 @@
 		</control>
 
 		<control type="group">
+			<include>DialogDepth</include>
 			<include>VideoOSDBookmarks_coords4</include>
 			<animation type="WindowOpen">
 				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>

--- a/xml/script-skin_helper_service-ColorPicker.xml
+++ b/xml/script-skin_helper_service-ColorPicker.xml
@@ -11,6 +11,7 @@
 		<include>DialogFanart</include>
 
 		<control type="group">
+			<include>DialogDepth</include>
 		
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>

--- a/xml/script-skinshortcuts.xml
+++ b/xml/script-skinshortcuts.xml
@@ -9,11 +9,12 @@
 	
 		<!-- Black background image -->
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture background="true">common/white.png</texture>
 			<colordiffuse>FF000000</colordiffuse>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Color -->
 		<control type="image">
@@ -23,6 +24,7 @@
 			<visible>String.IsEqual(Skin.String(BackgroundDefaultImage),no) | String.IsEqual(Skin.String(BackgroundSingleImage),solid)</visible>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		
 		<!-- Single background image -->
@@ -32,6 +34,7 @@
 			<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(211).ListItem.Property(background))</visible>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Multiple background images -->
 		<control type="multiimage">
@@ -44,6 +47,7 @@
 			<randomize>true</randomize>
 			<loop>yes</loop>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		
 		<!-- Single individual background image -->
@@ -55,6 +59,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		<!-- Multiple individual background images -->
 		<control type="multiimage">
@@ -69,6 +74,7 @@
 			<animation effect="fade" start="0" end="100" time="200" delay="70">Visible</animation>
 			<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 			<include>DialogZoomAnimation</include>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		
 		<!-- Fanart -->
@@ -78,11 +84,12 @@
 			<aspectratio>scale</aspectratio>
 			<fadetime>400</fadetime>
 			<visible>!Skin.HasSetting(HideFanart)</visible>
+			<include>DialogBackgroundDepth</include>
 		</control>
 		
 		<!-- Overlay -->
 		<control type="image">
-			<include>FullscreenDimensions</include>
+			<include>FullscreenOverlayDimensions</include>
 			<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
 			<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
 			<animation type="WindowOpen">
@@ -93,9 +100,12 @@
 				<effect type="zoom" start="100" end="70" center="auto" time="300" />
 				<effect type="fade" start="100" end="0" time="300" tween="quadratic" easing="in" />
 			</animation>
+			<include>DialogBackgroundDepth</include>
 		</control>
 
 		<control type="group">
+			<include>DialogDepth</include>
+		
 			<!-- Animation -->
 			<include>DialogZoomAnimation</include>
 			

--- a/xml/script-upnext-stillwatching-simple.xml
+++ b/xml/script-upnext-stillwatching-simple.xml
@@ -10,6 +10,7 @@
 	
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			<animation effect="slide" end="0,50" time="200" condition="Window.IsActive(volumebar)">Conditional</animation>
 			<animation effect="slide" end="0,20" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True) | Window.IsActive(volumebar)">Conditional</animation>

--- a/xml/script-upnext-stillwatching.xml
+++ b/xml/script-upnext-stillwatching.xml
@@ -10,6 +10,7 @@
 	
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			<animation effect="slide" end="0,50" time="200" condition="Window.IsActive(volumebar)">Conditional</animation>
 			<animation effect="slide" end="0,20" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True) | Window.IsActive(volumebar)">Conditional</animation>

--- a/xml/script-upnext-upnext-simple.xml
+++ b/xml/script-upnext-upnext-simple.xml
@@ -10,6 +10,7 @@
 	
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			<animation effect="slide" end="0,50" time="200" condition="Window.IsActive(volumebar)">Conditional</animation>
 			<animation effect="slide" end="0,20" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True) | Window.IsActive(volumebar)">Conditional</animation>

--- a/xml/script-upnext-upnext.xml
+++ b/xml/script-upnext-upnext.xml
@@ -10,6 +10,7 @@
 	
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<animation effect="slide" end="0,50" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True)">Conditional</animation>
 			<animation effect="slide" end="0,50" time="200" condition="Window.IsActive(volumebar)">Conditional</animation>
 			<animation effect="slide" end="0,20" time="200" condition="String.IsEqual(Window(10000).Property(isCaching),True) | Window.IsActive(volumebar)">Conditional</animation>


### PR DESCRIPTION
AddonBrowser.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

Coordinates_Includes.xml:
- reorder dialog button coordinates

Defaults.xml:
- add depth includes

DialogAddonInfo.xml:
- add depth include

DialogAddonSettings.xml:
- add depth include

DialogBusy.xml:
- add depth include

DialogButtonMenu.xml:
- add depth include

DialogConfirm.xml:
- add depth include

DialogContextMenu.xml:
- add depth include

DialogExtendedProgressBar.xml:
- add depth include

DialogFavourites.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

DialogGameControllers.xml:
- add depth include

DialogKeyboard.xml:
- add depth include

DialogMediaSource.xml:
- add depth include

DialogMusicInfo.xml:
- add depth include

DialogNotification.xml:
- add depth include

DialogNumeric.xml:
- add depth include

DialogPictureInfo.xml:
- add depth include

DialogPlayerProcessInfo.xml:
- add depth include

DialogPVRChannelGuide.xml:
- add depth include

DialogPVRChannelManager.xml:
- add depth include

DialogPVRChannelsOSD.xml:
- add depth include

DialogPVRGroupManager.xml:
- add depth include

DialogPVRGuideSearch.xml:
- add depth include

DialogPVRInfo.xml:
- add depth include

DialogSeekBar.xml:
- add depth include

DialogSelect.xml:
- add depth includes
- adjust game settings animations

DialogSlider.xml:
- add depth include

DialogSubtitles.xml:
- replace overlay image
- add depth include

DialogTextViewer.xml:
- add depth include

DialogVideoInfo.xml:
- add depth include

DialogVolumeBar.xml:
- add depth include

EventLog.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

FileBrowser.xml:
- add depth include

GameOSD.xml:
- add depth includes

Includes.xml:
- move dialog buttons includes to different include file
- add depth includes to masking bars

Includes_DialogSettings.xml:
- add depth includes

Includes_Home.xml:
- add depth include to side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

Includes_Windows_Dialogs.xml:
- replace FullscreenDimensions include of background images by new FullscreenOverlayDimensions include
- add depth includes to background images
- add new depth includes
- move dialog button includes from other include file

MusicOSD.xml:
- add depth include

MusicVisualisation.xml:
- add depth include

MyGames.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyMusicNav.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPics.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPlaylist.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPrograms.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPVRChannels.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPVRGuide.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPVRRecordings.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPVRSearch.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyPVRTimers.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyVideoNav.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

MyWeather.xml:
- add depth include to options side menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

PlayerControls.xml:
- add depth include

Pointer.xml:
- add depth include

script-skin_helper_sevice-ColorPicker.xml:
- add depth include

script-skinshortcuts.xml:
- replace FullscreenDimensions include of background images by new FullscreenOverlayDimensions include
- add depth includes

script-upnext-stillwatching-simple.xml:
- add depth include

script-upnext-stillwatching.xml:
- add depth include

script-upnext-upnext-simple.xml:
- add depth include

script-upnext-upnext.xml:
- add depth include

SettingsCategory.xml:
- add depth include to settings quick-nav menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

SettingsProfile.xml:
- add depth include to settings quick-nav menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

SettingsCategory.xml:
- add depth include to settings quick-nav menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

SettingsSystemInfo.xml:
- add depth include to settings quick-nav menu
- replace FullscreenDimensions include by new FullscreenOverlayDimensions include
- move options menu slightly left to avoid it being inactively visible during 3D mode

SmartPlaylistEditor.xml:
- add depth include

SmartPlaylistRule.xml:
- add depth include

VideoFullScreen.xml:
- add depth include

VideoOSD.xml:
- add depth includes

VideoOSDBookmarks.xml:
- add depth includes

addon.xml:
- update changelog

Changelog.md:
- update changelog