### PR TITLE
Bugfixes

### DIFF
--- a/shortcuts/14204-1.DATA.xml
+++ b/shortcuts/14204-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>19217</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultAddonPVRClient.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/15016-1.DATA.xml
+++ b/shortcuts/15016-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>35049</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultAddonGame.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/19021-1.DATA.xml
+++ b/shortcuts/19021-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>19216</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultAddonPVRClient.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/2-1.DATA.xml
+++ b/shortcuts/2-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>31056</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultMusicAlbums.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/2.DATA.xml
+++ b/shortcuts/2.DATA.xml
@@ -4,6 +4,7 @@
 		<label2>32020</label2>
 		<icon>DefaultPlaylist.png</icon>
 		<thumb />
+		<visible>Integer.IsGreater(MusicPlayer.PlaylistLength,1)</visible>
 		<action>ActivateWindow(MusicPlaylist)</action>
 	</shortcut>
 	<shortcut>

--- a/shortcuts/3.DATA.xml
+++ b/shortcuts/3.DATA.xml
@@ -4,6 +4,7 @@
 		<label2>32020</label2>
 		<icon>DefaultPlaylist.png</icon>
 		<thumb />
+		<visible>Integer.IsGreater(VideoPlayer.PlaylistLength,1)</visible>
 		<action>ActivateWindow(VideoPlaylist)</action>
 	</shortcut>
 	<shortcut>

--- a/shortcuts/31091-1.DATA.xml
+++ b/shortcuts/31091-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>31091</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>logo_big.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/mainmenu.DATA.xml
+++ b/shortcuts/mainmenu.DATA.xml
@@ -44,7 +44,7 @@
 	</shortcut>
 	<shortcut>
 		<label>31091</label>
-		<label2>Custom shortcut</label2>
+		<label2>31397</label2>
 		<icon>logo_big.png</icon>
 		<thumb />
 		<action>RunScript(service.osmc.settings)</action>
@@ -87,7 +87,7 @@
 	</shortcut>
 	<shortcut>
 		<label>341</label>
-		<label2>32034</label2>
+		<label2>31397</label2>
 		<icon>DefaultDVDFull.png</icon>
 		<thumb />
 		<action>XBMC.PlayDVD()</action>

--- a/shortcuts/movies-1.DATA.xml
+++ b/shortcuts/movies-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>31054</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultMovies.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/programs-1.DATA.xml
+++ b/shortcuts/programs-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>10001</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultAddonProgram.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/tvshows-1.DATA.xml
+++ b/shortcuts/tvshows-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>31118</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultTVShows.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/shortcuts/weather-1.DATA.xml
+++ b/shortcuts/weather-1.DATA.xml
@@ -2,7 +2,7 @@
 <shortcuts>
 	<shortcut>
 		<label>10508</label>
-		<label2>32099</label2>
+		<label2>31160</label2>
 		<icon>DefaultWeather.png</icon>
 		<thumb />
 		<action>noop</action>

--- a/xml/Coordinates_Custom_Cache_Progress.xml
+++ b/xml/Coordinates_Custom_Cache_Progress.xml
@@ -8,27 +8,27 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Cache_Progress_coords1_4:3</include>
 	</include>
 	<include name="Custom_Cache_Progress_coords1_16:9">
-		<right>0</right>
+		<right>-100</right>
 		<top>110</top>
-		<width>550</width>
+		<width>650</width>
 		<height>40</height>
 	</include>
 	<include name="Custom_Cache_Progress_coords1_21:9">
-		<right>0</right>
+		<right>-100</right>
 		<top>110</top>
-		<width>550</width>
+		<width>650</width>
 		<height>40</height>
 	</include>
 	<include name="Custom_Cache_Progress_coords1_21:9_masked">
-		<right>0</right>
+		<right>-100</right>
 		<top>290</top>
-		<width>550</width>
+		<width>650</width>
 		<height>40</height>
 	</include>
 	<include name="Custom_Cache_Progress_coords1_4:3">
-		<right>0</right>
+		<right>-100</right>
 		<top>110</top>
-		<width>550</width>
+		<width>650</width>
 		<height>40</height>
 	</include>
 	

--- a/xml/Coordinates_script-upnext-stillwatching-simple.xml
+++ b/xml/Coordinates_script-upnext-stillwatching-simple.xml
@@ -20,7 +20,7 @@
 		<height>77</height>
 	</include>
 	<include name="script-upnext-stillwatching-simple_coords1_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>-100</right>
 		<width>650</width>
 		<height>77</height>
@@ -51,7 +51,7 @@
 		<height>77</height>
 	</include>
 	<include name="script-upnext-stillwatching-simple_coords2_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>0</right>
 		<width>550</width>
 		<height>77</height>

--- a/xml/Coordinates_script-upnext-stillwatching.xml
+++ b/xml/Coordinates_script-upnext-stillwatching.xml
@@ -20,7 +20,7 @@
 		<height>107</height>
 	</include>
 	<include name="script-upnext-stillwatching_coords1_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>-100</right>
 		<width>650</width>
 		<height>107</height>
@@ -51,7 +51,7 @@
 		<height>107</height>
 	</include>
 	<include name="script-upnext-stillwatching_coords2_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>0</right>
 		<width>550</width>
 		<height>107</height>

--- a/xml/Coordinates_script-upnext-upnext-simple.xml
+++ b/xml/Coordinates_script-upnext-upnext-simple.xml
@@ -20,7 +20,7 @@
 		<height>77</height>
 	</include>
 	<include name="script-upnext-upnext-simple_coords1_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>-100</right>
 		<width>650</width>
 		<height>77</height>
@@ -51,7 +51,7 @@
 		<height>77</height>
 	</include>
 	<include name="script-upnext-upnext-simple_coords2_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>0</right>
 		<width>550</width>
 		<height>77</height>

--- a/xml/Coordinates_script-upnext-upnext.xml
+++ b/xml/Coordinates_script-upnext-upnext.xml
@@ -20,7 +20,7 @@
 		<height>107</height>
 	</include>
 	<include name="script-upnext-upnext_coords1_21:9_masked">
-		<top>90</top>
+		<top>270</top>
 		<right>-100</right>
 		<width>650</width>
 		<height>107</height>
@@ -45,7 +45,7 @@
 		<height>107</height>
 	</include>
 	<include name="script-upnext-upnext_coords2_21:9">
-		<top>90</top>
+		<top>270</top>
 		<right>0</right>
 		<width>550</width>
 		<height>107</height>
@@ -187,11 +187,11 @@
 		<width>260</width>
 	</include>
 	
-	<include name="script-upnext-upnext_coords6">
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">script-upnext-upnext_coords6_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">script-upnext-upnext_coords6_21:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">script-upnext-upnext_coords6_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-upnext-upnext_coords6_4:3</include>
+	<include name="script-upnext-upnext_coords7">
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + True">script-upnext-upnext_coords7_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">script-upnext-upnext_coords7_21:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,16:9) + False">script-upnext-upnext_coords7_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-upnext-upnext_coords7_4:3</include>
 	</include>
 	<include name="script-upnext-upnext_coords7_16:9">
 		<right>0</right>

--- a/xml/Custom_Cache_Progress.xml
+++ b/xml/Custom_Cache_Progress.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window type="dialog" id="1100">
-	<zorder>100</zorder>
+	<!-- customcachedialog -->
 	<visible>Player.Caching</visible>
 	<onload>SetProperty(isCaching,False,10000)</onload>
 	<onload>AlarmClock(isCachingTimer,SetProperty(isCaching,True,10000),00:01,silent)</onload>
 	<onunload>SetProperty(isCaching,False,10000)</onunload>
 	<onunload>CancelAlarm(isCachingTimer,silent)</onunload>
+	<zorder>100</zorder>
 	<controls>
 		<control type="group">
+			<include>NotificationDepth</include>
 			<visible>Player.Caching + String.IsEqual(Window(10000).Property(isCaching),True)</visible>
-			<left>1920</left>
-			<width>550</width>
-			<animation effect="slide" end="-550,0" time="200">Visible</animation>
+			<animation effect="slide" start="550,0" time="200">Visible</animation>
 			<animation effect="slide" end="0,0" time="200">Hidden</animation>
 
+			<!-- Background -->
 			<control type="image">
 				<include>Custom_Cache_Progress_coords1</include>
 				<texture colordiffuse="$VAR[OverlayColor]">dialogs/Background.png</texture>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -3,10 +3,10 @@
 	<!-- movieinformation -->
 	<defaultcontrol always="true">8</defaultcontrol>
 	<onload condition="!String.IsEmpty(Window(12003).Property(extended))">ClearProperty(extended,12003)</onload>
-	<onload condition="String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])">SendClick(50)</onload>
+	<onload condition="!String.IsEmpty(Window(12003).Property(cast))">ClearProperty(cast,12003)</onload>
 	<onload condition="System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
-	<onunload condition="String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])">SendClick(50)</onunload>
 	<onunload>ClearProperty(extended,12003)</onunload>
+	<onunload>ClearProperty(cast,12003)</onunload>
 
 	<controls>
 
@@ -27,7 +27,7 @@
 			<!-- Poster image -->
 			<control type="group">
 				<visible>!Container.Content(musicvideos)</visible>
-				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + [String.IsEmpty(Window(12003).Property(extended)) | !String.IsEmpty(Window(12003).Property(extended)) + String.IsEmpty(ListItem.RatingAndVotes) + String.IsEmpty(ListItem.RatingAndVotes(imdb)) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) + String.IsEmpty(ListItem.Property(AudioCodec.1)) + String.IsEmpty(ListItem.Property(SubtitleLanguage.1))]</visible>
+				<visible>String.IsEmpty(Window(12003).Property(cast)) + [String.IsEmpty(Window(12003).Property(extended)) | !String.IsEmpty(Window(12003).Property(extended)) + String.IsEmpty(ListItem.RatingAndVotes) + String.IsEmpty(ListItem.RatingAndVotes(imdb)) + String.IsEmpty(ListItem.RatingAndVotes(metacritic)) + String.IsEmpty(ListItem.RatingAndVotes(rottentomatoes)) + String.IsEmpty(ListItem.RatingAndVotes(themoviedb)) + String.IsEmpty(ListItem.Property(AudioCodec.1)) + String.IsEmpty(ListItem.Property(SubtitleLanguage.1))]</visible>
 				<include>VisibleFadeAnimation</include>
 				<control type="image">
 					<include>DialogVideoInfo_coords1</include>
@@ -39,7 +39,7 @@
 
 			<!-- Actor image -->
 			<control type="group">
-				<visible>String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
+				<visible>!String.IsEmpty(Window(12003).Property(cast))</visible>
 				<include>VisibleFadeAnimation</include>
 				<control type="image">
 					<include>DialogVideoInfo_coords1</include>
@@ -58,8 +58,18 @@
 				<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
 				<aspectratio align="center" aligny="center">keep</aspectratio>
 			</control>
-
 			
+			<!-- Director -->
+			<control type="fadelabel">
+				<include>DialogVideoInfo_coords2</include>
+				<font>Font27</font>
+				<align>center</align>
+				<label>$INFO[ListItem.Director]</label>
+				<textcolor>$VAR[TextColor2]</textcolor>
+				<visible>Control.HasFocus(13) + [!String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot) | !String.IsEmpty(Window(12003).Property(cast))]</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+
 			<!-- Filename and path -->
 			<control type="fadelabel">
 				<include>DialogVideoInfo_coords2</include>
@@ -78,7 +88,7 @@
 				<align>center</align>
 				<label>$INFO[ListItem.LastPlayed,$LOCALIZE[568]: ,]$INFO[ListItem.PlayCount, &#8226; $LOCALIZE[576]: ,]</label>
 				<textcolor>$VAR[TextColor2]</textcolor>
-				<visible>!Control.HasFocus(6)</visible>
+				<visible>!Control.HasFocus(6) + ![Control.HasFocus(13) + [!String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot) | !String.IsEmpty(Window(12003).Property(cast))]]</visible>
 				<visible>!String.IsEmpty(ListItem.LastPlayed)</visible>
 				<include>VisibleFadeAnimation</include>
 			</control>
@@ -87,7 +97,7 @@
 			<control type="group" id="100">
 				<include>DialogVideoInfo_coords3</include>
 				<visible>!Container.Content(musicvideos)</visible>
-				<visible>!String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + [String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | !String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)]</visible>
+				<visible>String.IsEmpty(Window(12003).Property(cast)) + [String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | !String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)]</visible>
 				<include>VisibleFadeAnimation</include>
 
 				<!-- Details -->
@@ -533,7 +543,7 @@
 				<textcolor>$VAR[TextColor2]</textcolor>
 				<label>$INFO[ListItem.Plot]</label>
 				<autoscroll delay="10000" time="1700" repeat="12000">True</autoscroll>
-				<visible>!String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | !String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)</visible>
+				<visible>String.IsEmpty(Window(12003).Property(cast)) + [!String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)]</visible>
 				<include>VisibleFadeAnimation</include>
 			</control>
 
@@ -548,7 +558,7 @@
 				<viewtype label="">list</viewtype>
 				<pagecontrol>60</pagecontrol>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible allowhiddenfocus="true">String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
+				<visible allowhiddenfocus="true">!String.IsEmpty(Window(12003).Property(cast))</visible>
 				<include>VisibleFadeAnimation</include>
 
 				<include>DialogVideoInfo_coords10</include>
@@ -570,14 +580,14 @@
 				<texturesliderbarfocus border="11,1,1,1" colordiffuse="$VAR[DialogColor1]">common/ScrollbarGripFO.png</texturesliderbarfocus>
 				<textureslidernib></textureslidernib>
 				<textureslidernibfocus></textureslidernibfocus>
-				<visible>!Skin.HasSetting(Scrollbars) + String.IsEqual(Control.GetLabel(5),$LOCALIZE[207]) + String.IsEmpty(Window(12003).Property(extended))</visible>
+				<visible>!Skin.HasSetting(Scrollbars) + !String.IsEmpty(Window(12003).Property(cast)) + String.IsEmpty(Window(12003).Property(extended))</visible>
 				<include>VisibleFadeAnimation</include>
 			</control>
 			
 			<!-- Extended info -->
 			<control type="group">
 				<include>DialogVideoInfo_coords13</include>
-				<visible>!String.IsEmpty(Window(12003).Property(extended))</visible>
+				<visible>String.IsEmpty(Window(12003).Property(cast)) + !String.IsEmpty(Window(12003).Property(extended))</visible>
 				<visible>!Container.Content(musicvideos)</visible>
 				<include>VisibleFadeAnimation</include>
 
@@ -728,16 +738,31 @@
 					<altlabel>33029</altlabel>
 					<onclick condition="String.IsEmpty(Window(12003).Property(extended))">SetProperty(extended,14115,12003)</onclick>
 					<onclick condition="!String.IsEmpty(Window(12003).Property(extended))">ClearProperty(extended,12003)</onclick>
-					<usealttexture>Control.IsVisible(101)</usealttexture>
-					<visible>!Container.Content(musicvideos) + !String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])</visible>
+					<onclick condition="!String.IsEmpty(Window(12003).Property(cast))">ClearProperty(cast,12003)</onclick>
+					<usealttexture>!String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)</usealttexture>
+					<visible>!Container.Content(musicvideos)</visible>
 				</control>
 				<!-- Cast Button -->
-				<control type="button" id="5">
+				<control type="togglebutton" id="16">
 					<width>Auto</width>
 					<label>206</label>
-					<onclick condition="String.IsEqual(Control.GetLabel(5),$LOCALIZE[207])">SetFocus(50)</onclick>
-					<onclick>ClearProperty(extended,12003)</onclick>
+					<altlabel>33029</altlabel>
+					<onclick condition="String.IsEmpty(Window(12003).Property(cast))">SetProperty(cast,14115,12003)</onclick>
+					<onclick condition="!String.IsEmpty(Window(12003).Property(cast))">ClearProperty(cast,12003)</onclick>
+					<usealttexture>!String.IsEmpty(Window(12003).Property(cast))</usealttexture>
 					<visible>!String.IsEmpty(ListItem.Cast)</visible>
+					<visible>String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | !String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)</visible>
+				</control>
+				<!-- Cast Button -->
+				<control type="togglebutton" id="17">
+					<width>Auto</width>
+					<label>206</label>
+					<altlabel>207</altlabel>
+					<onclick condition="String.IsEmpty(Window(12003).Property(cast))">SetProperty(cast,14115,12003)</onclick>
+					<onclick condition="!String.IsEmpty(Window(12003).Property(cast))">ClearProperty(cast,12003)</onclick>
+					<usealttexture>!String.IsEmpty(Window(12003).Property(cast))</usealttexture>
+					<visible>!String.IsEmpty(ListItem.Cast)</visible>
+					<visible>!String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Details) | String.IsEmpty(Window(12003).Property(extended)) + String.IsEqual(Skin.String(videoinfodialogfirstpage),Plot)</visible>
 				</control>
 				<!-- Director Button -->
 				<control type="button" id="13">

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -387,6 +387,7 @@
 				<animation effect="slide" time="200" start="0,0" end="0,200">WindowClose</animation>
 				<animation effect="slide" end="0,-187" time="400" condition="False + String.IsEqual(Skin.String(MaskingBars),2.40:1)">Conditional</animation>
 				<animation effect="slide" end="0,-175" time="200" condition="False + String.IsEqual(Skin.String(MaskingBars),2.35:1)">Conditional</animation>
+				<animation effect="slide" end="0,-170" time="200" condition="False + String.IsEqual(Skin.String(MaskingBars),2.33:1)">Conditional</animation>
 				<animation effect="slide" end="0,-80" time="200" condition="False + String.IsEqual(Skin.String(MaskingBars),2.00:1)">Conditional</animation>
 				<control type="image">
 					<bottom>10</bottom>

--- a/xml/script-skinshortcuts-static.xml
+++ b/xml/script-skinshortcuts-static.xml
@@ -4,7 +4,7 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<label>$LOCALIZE[342]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultMovies.png</icon>
 			<thumb />
 			<property name="labelID">movies</property>
@@ -13,7 +13,6 @@
 			<onclick>ActivateWindow(Videos,videodb://movies/titles/,return)</onclick>
 			<property name="path">ActivateWindow(Videos,videodb://movies/titles/,return)</property>
 			<property name="list">videodb://movies/titles/</property>
-			<visible>True</visible>
 			<property name="submenuVisibility">movies</property>
 			<property name="group">mainmenu</property>
 			<property name="hasSubmenu">True</property>
@@ -21,7 +20,7 @@
 		<item id="2">
 			<property name="id">$NUMBER[2]</property>
 			<label>$LOCALIZE[20343]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultTVShows.png</icon>
 			<thumb />
 			<property name="labelID">tvshows</property>
@@ -30,7 +29,6 @@
 			<onclick>ActivateWindow(Videos,videodb://tvshows/titles/,return)</onclick>
 			<property name="path">ActivateWindow(Videos,videodb://tvshows/titles/,return)</property>
 			<property name="list">videodb://tvshows/titles/</property>
-			<visible>True</visible>
 			<property name="submenuVisibility">tvshows</property>
 			<property name="group">mainmenu</property>
 			<property name="hasSubmenu">True</property>
@@ -38,7 +36,7 @@
 		<item id="3">
 			<property name="id">$NUMBER[3]</property>
 			<label>$LOCALIZE[3]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultVideo.png</icon>
 			<thumb />
 			<property name="labelID">videos</property>
@@ -54,7 +52,7 @@
 		<item id="4">
 			<property name="id">$NUMBER[4]</property>
 			<label>$LOCALIZE[2]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultMusicAlbums.png</icon>
 			<thumb />
 			<property name="labelID">music</property>
@@ -70,7 +68,7 @@
 		<item id="5">
 			<property name="id">$NUMBER[5]</property>
 			<label>$LOCALIZE[10002]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultPicture.png</icon>
 			<thumb />
 			<property name="labelID">pictures</property>
@@ -86,7 +84,7 @@
 		<item id="6">
 			<property name="id">$NUMBER[6]</property>
 			<label>$LOCALIZE[15016]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultGameAddons.png</icon>
 			<thumb />
 			<property name="labelID">15016</property>
@@ -102,8 +100,8 @@
 		<item id="7">
 			<property name="id">$NUMBER[7]</property>
 			<label>$LOCALIZE[31091]</label>
-			<label2>Custom shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[Custom shortcut]</label2>
+			<icon>logo_big.png</icon>
 			<thumb />
 			<property name="labelID">service.osmc.settings</property>
 			<property name="defaultID">service.osmc.settings</property>
@@ -118,8 +116,8 @@
 		<item id="8">
 			<property name="id">$NUMBER[8]</property>
 			<label>$LOCALIZE[1036]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultFavourites.png</icon>
 			<thumb />
 			<property name="labelID">1036</property>
 			<property name="defaultID">1036</property>
@@ -134,7 +132,7 @@
 		<item id="9">
 			<property name="id">$NUMBER[9]</property>
 			<label>$LOCALIZE[10001]</label>
-			<label2>Common Shortcut</label2>
+			<label2>$LOCALIZE[31397]</label2>
 			<icon>DefaultProgram.png</icon>
 			<thumb />
 			<property name="labelID">programs</property>
@@ -150,8 +148,8 @@
 		<item id="10">
 			<property name="id">$NUMBER[10]</property>
 			<label>$LOCALIZE[12600]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultWeather.png</icon>
 			<thumb />
 			<property name="labelID">weather</property>
 			<property name="defaultID">weather</property>
@@ -159,7 +157,6 @@
 			<onclick>ActivateWindow(Weather)</onclick>
 			<property name="path">ActivateWindow(Weather)</property>
 			<property name="list">Weather</property>
-			<visible>True</visible>
 			<property name="submenuVisibility">weather</property>
 			<property name="group">mainmenu</property>
 			<property name="hasSubmenu">False</property>
@@ -167,8 +164,8 @@
 		<item id="11">
 			<property name="id">$NUMBER[11]</property>
 			<label>$LOCALIZE[14204]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultLiveTV.png</icon>
 			<thumb />
 			<property name="labelID">14204</property>
 			<property name="defaultID">14204</property>
@@ -176,7 +173,6 @@
 			<onclick>ActivateWindow(TVGuide)</onclick>
 			<property name="path">ActivateWindow(TVGuide)</property>
 			<property name="list">TVGuide</property>
-			<visible>True</visible>
 			<property name="submenuVisibility">num-14204</property>
 			<property name="group">mainmenu</property>
 			<property name="hasSubmenu">True</property>
@@ -184,8 +180,8 @@
 		<item id="12">
 			<property name="id">$NUMBER[12]</property>
 			<label>$LOCALIZE[19021]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultRadio.png</icon>
 			<thumb />
 			<property name="labelID">19021</property>
 			<property name="defaultID">19021</property>
@@ -193,7 +189,6 @@
 			<onclick>ActivateWindow(RadioGuide)</onclick>
 			<property name="path">ActivateWindow(RadioGuide)</property>
 			<property name="list">RadioGuide</property>
-			<visible>True</visible>
 			<property name="submenuVisibility">num-19021</property>
 			<property name="group">mainmenu</property>
 			<property name="hasSubmenu">True</property>
@@ -201,7 +196,7 @@
 		<item id="13">
 			<property name="id">$NUMBER[13]</property>
 			<label>$LOCALIZE[341]</label>
-			<label2>$ADDON[script.skinshortcuts 32034]</label2>
+			<label2>$LOCALIZE[$ADDON[script.skinshortcuts 32034]]</label2>
 			<icon>DefaultDVDFull.png</icon>
 			<thumb />
 			<property name="labelID">341</property>
@@ -210,7 +205,6 @@
 			<onclick>XBMC.PlayDVD()</onclick>
 			<property name="path">XBMC.PlayDVD()</property>
 			<property name="list">XBMC.PlayDVD()</property>
-			<visible>True</visible>
 			<property name="submenuVisibility">num-341</property>
 			<property name="group">mainmenu</property>
 			<property name="hasSubmenu">True</property>
@@ -218,8 +212,8 @@
 		<item id="14">
 			<property name="id">$NUMBER[14]</property>
 			<label>$LOCALIZE[10004]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultSettings.png</icon>
 			<thumb />
 			<property name="labelID">settings</property>
 			<property name="defaultID">settings</property>
@@ -234,8 +228,8 @@
 		<item id="15">
 			<property name="id">$NUMBER[15]</property>
 			<label>$LOCALIZE[33060]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultPower.png</icon>
 			<thumb />
 			<property name="labelID">33060</property>
 			<property name="defaultID">33060</property>
@@ -254,8 +248,8 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">1</property>
 			<label>$LOCALIZE[652]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultYear.png</icon>
 			<thumb />
 			<property name="labelID">652</property>
 			<property name="defaultID">652</property>
@@ -263,7 +257,6 @@
 			<onclick>ActivateWindow(10025,"library://video/movies/years.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/movies/years.xml/",return)</property>
 			<property name="list">library://video/movies/years.xml/</property>
-			<visible>True</visible>
 			<property name="group">movies</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -271,8 +264,8 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">1</property>
 			<label>$LOCALIZE[135]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultGenre.png</icon>
 			<thumb />
 			<property name="labelID">135</property>
 			<property name="defaultID">135</property>
@@ -280,7 +273,6 @@
 			<onclick>ActivateWindow(10025,"library://video/movies/genres.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/movies/genres.xml/",return)</property>
 			<property name="list">library://video/movies/genres.xml/</property>
-			<visible>True</visible>
 			<property name="group">movies</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -288,8 +280,8 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">1</property>
 			<label>$LOCALIZE[344]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultActor.png</icon>
 			<thumb />
 			<property name="labelID">344</property>
 			<property name="defaultID">344</property>
@@ -297,7 +289,6 @@
 			<onclick>ActivateWindow(10025,"library://video/movies/actors.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/movies/actors.xml/",return)</property>
 			<property name="list">library://video/movies/actors.xml/</property>
-			<visible>True</visible>
 			<property name="group">movies</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -305,8 +296,8 @@
 			<property name="id">$NUMBER[4]</property>
 			<property name="mainmenuid">1</property>
 			<label>$LOCALIZE[20348]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultDirector.png</icon>
 			<thumb />
 			<property name="labelID">20348</property>
 			<property name="defaultID">20348</property>
@@ -314,7 +305,6 @@
 			<onclick>ActivateWindow(10025,"library://video/movies/directors.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/movies/directors.xml/",return)</property>
 			<property name="list">library://video/movies/directors.xml/</property>
-			<visible>True</visible>
 			<property name="group">movies</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -322,8 +312,8 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">2</property>
 			<label>$LOCALIZE[652]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultYear.png</icon>
 			<thumb />
 			<property name="labelID">652</property>
 			<property name="defaultID">652</property>
@@ -331,7 +321,6 @@
 			<onclick>ActivateWindow(10025,"library://video/tvshows/years.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/tvshows/years.xml/",return)</property>
 			<property name="list">library://video/tvshows/years.xml/</property>
-			<visible>True</visible>
 			<property name="group">tvshows</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -339,8 +328,8 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">2</property>
 			<label>$LOCALIZE[135]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultGenre.png</icon>
 			<thumb />
 			<property name="labelID">135</property>
 			<property name="defaultID">135</property>
@@ -348,7 +337,6 @@
 			<onclick>ActivateWindow(10025,"library://video/tvshows/genres.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/tvshows/genres.xml/",return)</property>
 			<property name="list">library://video/tvshows/genres.xml/</property>
-			<visible>True</visible>
 			<property name="group">tvshows</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -356,8 +344,8 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">2</property>
 			<label>$LOCALIZE[344]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultActor.png</icon>
 			<thumb />
 			<property name="labelID">344</property>
 			<property name="defaultID">344</property>
@@ -365,7 +353,6 @@
 			<onclick>ActivateWindow(10025,"library://video/tvshows/actors.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/tvshows/actors.xml/",return)</property>
 			<property name="list">library://video/tvshows/actors.xml/</property>
-			<visible>True</visible>
 			<property name="group">tvshows</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -373,8 +360,8 @@
 			<property name="id">$NUMBER[4]</property>
 			<property name="mainmenuid">2</property>
 			<label>$LOCALIZE[20388]</label>
-			<label2>Videos</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultStudios.png</icon>
 			<thumb />
 			<property name="labelID">20388</property>
 			<property name="defaultID">20388</property>
@@ -382,7 +369,6 @@
 			<onclick>ActivateWindow(10025,"library://video/tvshows/studios.xml/",return)</onclick>
 			<property name="path">ActivateWindow(10025,"library://video/tvshows/studios.xml/",return)</property>
 			<property name="list">library://video/tvshows/studios.xml/</property>
-			<visible>True</visible>
 			<property name="group">tvshows</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -390,15 +376,15 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">3</property>
 			<label>$LOCALIZE[13350]</label>
-			<label2>Videos</label2>
-			<icon>DefaultFolder.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultPlaylist.png</icon>
 			<thumb />
 			<property name="labelID">13350</property>
 			<property name="defaultID">13350</property>
 			<onclick>ActivateWindow(VideoPlaylist)</onclick>
 			<property name="path">ActivateWindow(VideoPlaylist)</property>
 			<property name="list">VideoPlaylist</property>
-			<visible>[True] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),videos)</visible>
+			<visible>[Integer.IsGreater(VideoPlayer.PlaylistLength,1)] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),videos)</visible>
 			<property name="group">videos</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -406,7 +392,7 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">3</property>
 			<label>$LOCALIZE[1037]</label>
-			<label2>Videos</label2>
+			<label2>$LOCALIZE[32020]</label2>
 			<icon>DefaultAddonVideo.png</icon>
 			<thumb />
 			<property name="labelID">1037</property>
@@ -422,8 +408,8 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">3</property>
 			<label>$LOCALIZE[744]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultMusicVideos.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultFolder.png</icon>
 			<thumb />
 			<property name="labelID">744</property>
 			<property name="defaultID">744</property>
@@ -438,15 +424,15 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">4</property>
 			<label>$LOCALIZE[13350]</label>
-			<label2>$ADDON[script.skinshortcuts 32019]</label2>
-			<icon>DefaultFolder.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultPlaylist.png</icon>
 			<thumb />
 			<property name="labelID">13350</property>
 			<property name="defaultID">13350</property>
 			<onclick>ActivateWindow(MusicPlaylist)</onclick>
 			<property name="path">ActivateWindow(MusicPlaylist)</property>
 			<property name="list">MusicPlaylist</property>
-			<visible>[True] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),music)</visible>
+			<visible>[Integer.IsGreater(MusicPlayer.PlaylistLength,1)] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),music)</visible>
 			<property name="group">music</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -454,7 +440,7 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">4</property>
 			<label>$LOCALIZE[1038]</label>
-			<label2>$ADDON[script.skinshortcuts 32019]</label2>
+			<label2>$LOCALIZE[32020]</label2>
 			<icon>DefaultAddonMusic.png</icon>
 			<thumb />
 			<property name="labelID">1038</property>
@@ -470,7 +456,7 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">4</property>
 			<label>$LOCALIZE[744]</label>
-			<label2>$ADDON[script.skinshortcuts 32019]</label2>
+			<label2>$LOCALIZE[32020]</label2>
 			<icon>DefaultFolder.png</icon>
 			<thumb />
 			<property name="labelID">744</property>
@@ -486,7 +472,7 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">5</property>
 			<label>$LOCALIZE[1039]</label>
-			<label2>$ADDON[script.skinshortcuts 32020]</label2>
+			<label2>$LOCALIZE[32020]</label2>
 			<icon>DefaultAddonPicture.png</icon>
 			<thumb />
 			<property name="labelID">1039</property>
@@ -502,8 +488,8 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">10</property>
 			<label>$LOCALIZE[19019]</label>
-			<label2>$ADDON[script.skinshortcuts 32017]</label2>
-			<icon>DefaultTVShows.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultLiveTV.png</icon>
 			<thumb />
 			<property name="labelID">19019</property>
 			<property name="defaultID">19019</property>
@@ -511,7 +497,6 @@
 			<onclick>ActivateWindow(TVChannels)</onclick>
 			<property name="path">ActivateWindow(TVChannels)</property>
 			<property name="list">TVChannels</property>
-			<visible>True</visible>
 			<property name="group">14204</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -519,8 +504,8 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">10</property>
 			<label>$LOCALIZE[19163]</label>
-			<label2>$ADDON[script.skinshortcuts 32017]</label2>
-			<icon>DefaultTVShows.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>home/recordings.png</icon>
 			<thumb />
 			<property name="labelID">19163</property>
 			<property name="defaultID">19163</property>
@@ -528,7 +513,6 @@
 			<onclick>ActivateWindow(TVRecordings)</onclick>
 			<property name="path">ActivateWindow(TVRecordings)</property>
 			<property name="list">TVRecordings</property>
-			<visible>True</visible>
 			<property name="group">14204</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -536,8 +520,8 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">10</property>
 			<label>$LOCALIZE[19040]</label>
-			<label2>$ADDON[script.skinshortcuts 32017]</label2>
-			<icon>DefaultTVShows.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>home/timers.png</icon>
 			<thumb />
 			<property name="labelID">19040</property>
 			<property name="defaultID">19040</property>
@@ -545,7 +529,6 @@
 			<onclick>ActivateWindow(TVTimers)</onclick>
 			<property name="path">ActivateWindow(TVTimers)</property>
 			<property name="list">TVTimers</property>
-			<visible>True</visible>
 			<property name="group">14204</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -553,8 +536,8 @@
 			<property name="id">$NUMBER[4]</property>
 			<property name="mainmenuid">10</property>
 			<label>$LOCALIZE[137]</label>
-			<label2>$ADDON[script.skinshortcuts 32017]</label2>
-			<icon>DefaultTVShows.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>home/search-tv.png</icon>
 			<thumb />
 			<property name="labelID">137</property>
 			<property name="defaultID">137</property>
@@ -562,7 +545,6 @@
 			<onclick>ActivateWindow(TVSearch)</onclick>
 			<property name="path">ActivateWindow(TVSearch)</property>
 			<property name="list">TVSearch</property>
-			<visible>True</visible>
 			<property name="group">14204</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -570,8 +552,8 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">11</property>
 			<label>$LOCALIZE[19019]</label>
-			<label2>$ADDON[script.skinshortcuts 32087]</label2>
-			<icon>DefaultAudio.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>DefaultRadio.png</icon>
 			<thumb />
 			<property name="labelID">19019</property>
 			<property name="defaultID">19019</property>
@@ -579,7 +561,6 @@
 			<onclick>ActivateWindow(RadioChannels)</onclick>
 			<property name="path">ActivateWindow(RadioChannels)</property>
 			<property name="list">RadioChannels</property>
-			<visible>True</visible>
 			<property name="group">19021</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -587,8 +568,8 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">11</property>
 			<label>$LOCALIZE[19163]</label>
-			<label2>$ADDON[script.skinshortcuts 32087]</label2>
-			<icon>DefaultAudio.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>home/recordings.png</icon>
 			<thumb />
 			<property name="labelID">19163</property>
 			<property name="defaultID">19163</property>
@@ -596,7 +577,6 @@
 			<onclick>ActivateWindow(RadioRecordings)</onclick>
 			<property name="path">ActivateWindow(RadioRecordings)</property>
 			<property name="list">RadioRecordings</property>
-			<visible>True</visible>
 			<property name="group">19021</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -604,8 +584,8 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">11</property>
 			<label>$LOCALIZE[19040]</label>
-			<label2>$ADDON[script.skinshortcuts 32087]</label2>
-			<icon>DefaultAudio.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>home/timers.png</icon>
 			<thumb />
 			<property name="labelID">19040</property>
 			<property name="defaultID">19040</property>
@@ -613,7 +593,6 @@
 			<onclick>ActivateWindow(RadioTimers)</onclick>
 			<property name="path">ActivateWindow(RadioTimers)</property>
 			<property name="list">RadioTimers</property>
-			<visible>True</visible>
 			<property name="group">19021</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -621,8 +600,8 @@
 			<property name="id">$NUMBER[4]</property>
 			<property name="mainmenuid">11</property>
 			<label>$LOCALIZE[137]</label>
-			<label2>$ADDON[script.skinshortcuts 32087]</label2>
-			<icon>DefaultAudio.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>home/search-tv.png</icon>
 			<thumb />
 			<property name="labelID">137</property>
 			<property name="defaultID">137</property>
@@ -630,7 +609,6 @@
 			<onclick>ActivateWindow(RadioSearch)</onclick>
 			<property name="path">ActivateWindow(RadioSearch)</property>
 			<property name="list">RadioSearch</property>
-			<visible>True</visible>
 			<property name="group">19021</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -638,15 +616,15 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">12</property>
 			<label>$LOCALIZE[600]</label>
-			<label2>Kodi Command</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[32020]</label2>
+			<icon>RipCD.png</icon>
 			<thumb />
 			<property name="labelID">600</property>
 			<property name="defaultID">600</property>
 			<onclick>RipCD</onclick>
 			<property name="path">RipCD</property>
 			<property name="list">RipCD</property>
-			<visible>System.HasMediaAudioCD + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-341)</visible>
+			<visible>[System.HasMediaAudioCD] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-341)</visible>
 			<property name="group">341</property>
 			<property name="isSubmenu">True</property>
 		</item>
@@ -654,7 +632,7 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">12</property>
 			<label>$LOCALIZE[31090]</label>
-			<label2>Common menu item</label2>
+			<label2>$LOCALIZE[32020]</label2>
 			<icon>DefaultDVDFull.png</icon>
 			<thumb />
 			<property name="labelID">31090</property>
@@ -670,8 +648,8 @@
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">13</property>
 			<label>$LOCALIZE[13200]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultUser.png</icon>
 			<thumb />
 			<property name="labelID">13200</property>
 			<property name="defaultID">13200</property>
@@ -686,8 +664,8 @@
 			<property name="id">$NUMBER[2]</property>
 			<property name="mainmenuid">13</property>
 			<label>$LOCALIZE[130]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultIconInfo.png</icon>
 			<thumb />
 			<property name="labelID">130</property>
 			<property name="defaultID">130</property>
@@ -702,8 +680,8 @@
 			<property name="id">$NUMBER[3]</property>
 			<property name="mainmenuid">13</property>
 			<label>$LOCALIZE[7]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultFile.png</icon>
 			<thumb />
 			<property name="labelID">7</property>
 			<property name="defaultID">7</property>
@@ -718,8 +696,8 @@
 			<property name="id">$NUMBER[4]</property>
 			<property name="mainmenuid">13</property>
 			<label>$LOCALIZE[10040]</label>
-			<label2>Common Shortcut</label2>
-			<icon>DefaultShortcut.png</icon>
+			<label2>$LOCALIZE[31397]</label2>
+			<icon>DefaultAddon.png</icon>
 			<thumb />
 			<property name="labelID">10040</property>
 			<property name="defaultID">10040</property>
@@ -736,12 +714,12 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">1</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[31054]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultMovies.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">31054</property>
+			<property name="defaultID">31054</property>
 			<property name="widget">library</property>
 			<property name="widgetName">$LOCALIZE[31054]</property>
 			<property name="widgetType">movies</property>
@@ -756,12 +734,12 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">2</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[31118]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultTVShows.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">31118</property>
+			<property name="defaultID">31118</property>
 			<property name="widget">library</property>
 			<property name="widgetName">$LOCALIZE[31118]</property>
 			<property name="widgetType">tvshows</property>
@@ -776,12 +754,12 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">4</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[31056]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultMusicAlbums.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">31056</property>
+			<property name="defaultID">31056</property>
 			<property name="widget">library</property>
 			<property name="widgetName">$LOCALIZE[31056]</property>
 			<property name="widgetType">albums</property>
@@ -796,17 +774,16 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">6</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[35049]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultAddonGame.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">35049</property>
+			<property name="defaultID">35049</property>
 			<property name="widget">GameWidget</property>
 			<property name="widgetName">$LOCALIZE[35049]</property>
 			<property name="widgetType">custom</property>
 			<property name="widgetPath">addons://sources/game/</property>
-			<property name="widgetTarget" />
 			<property name="path">noop</property>
 			<property name="list">noop</property>
 			<visible>[True] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-15016)</visible>
@@ -816,17 +793,16 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">8</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[10001]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultAddonProgram.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">programs</property>
+			<property name="defaultID">programs</property>
 			<property name="widget">addon</property>
 			<property name="widgetName">$LOCALIZE[10001]</property>
 			<property name="widgetType">program</property>
 			<property name="widgetPath">addons://sources/executable</property>
-			<property name="widgetTarget">programs</property>
 			<property name="path">noop</property>
 			<property name="list">noop</property>
 			<visible>[True] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),programs)</visible>
@@ -836,12 +812,12 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">9</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[10508]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultWeather.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">10508</property>
+			<property name="defaultID">10508</property>
 			<property name="widget">WeatherWidget</property>
 			<property name="widgetName">$LOCALIZE[10508]</property>
 			<property name="widgetType">custom</property>
@@ -855,12 +831,12 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">10</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
-			<icon>DefaultShortcut.png</icon>
+			<label>$LOCALIZE[19217]</label>
+			<label2>$LOCALIZE[31160]</label2>
+			<icon>DefaultAddonPVRClient.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">19217</property>
+			<property name="defaultID">19217</property>
 			<property name="widget">pvr</property>
 			<property name="widgetName">$LOCALIZE[19217]</property>
 			<property name="widgetType">pvr</property>
@@ -875,12 +851,12 @@
 		<item id="1">
 			<property name="id">$NUMBER[1]</property>
 			<property name="mainmenuid">11</property>
-			<label>$LOCALIZE[31160]</label>
-			<label2 />
+			<label>$LOCALIZE[19216]</label>
+			<label2>$LOCALIZE[31160]</label2>
 			<icon>DefaultShortcut.png</icon>
 			<thumb />
-			<property name="labelID">widget</property>
-			<property name="defaultID">widget</property>
+			<property name="labelID">19216</property>
+			<property name="defaultID">19216</property>
 			<property name="widget">pvr</property>
 			<property name="widgetName">$LOCALIZE[19216]</property>
 			<property name="widgetType">pvr</property>
@@ -1168,106 +1144,10 @@
 			<onfocus>Control.Move(10006,1)</onfocus>
 		</control>
 		<control type="group">
-			<include>widgetHeading-OSMC_coords</include>
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-15016)</visible>
-			<visible>Integer.IsGreater(Container(10006).NumItems,0)</visible>
-			<animation type="Visible">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
-			</animation>
-			<animation type="Hidden">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
-			</animation>
-
-			<!-- Widget has focus -->
-			<control type="grouplist">
-				<orientation>vertical</orientation>
-				<usecontrolcoords>true</usecontrolcoords>
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
-
-				<!-- Widget details -->
-				<control type="textbox">
-					<include>widgetdetails_coords</include>
-					<height>auto</height>
-					<font>Font33</font>
-					<align>right</align>
-					<aligny>top</aligny>
-					<label>$VAR[widgetDetails]</label>
-					<textcolor>$VAR[TextColor1]</textcolor>
-				</control>
-				
-				<!-- Widget heading -->
-				<control type="label">
-					<include>widgetdetails_coords</include>
-					<height>46</height>
-					<font>Font33</font>
-					<align>right</align>
-					<aligny>top</aligny>
-					<label>$LOCALIZE[35049]</label>
-					<textcolor>$VAR[TextColor2]</textcolor>
-					<scroll>True</scroll>
-				</control>
-				
-			</control>
-			<!-- Reloading indicator -->
-			<control type="group">
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
-				<include>widgetreloadingindicator_coords</include>
-				<include>skinshortcuts-template-reloading</include>
-			</control>
-			
-			<!-- Widget does not have focus -->
-			<control type="group">
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
-				
-				<!-- Widget heading -->
-				<control type="label">
-					<include>widgetdetails_coords</include>
-					<height>46</height>
-					<font>Font33</font>
-					<align>right</align>
-					<aligny>top</aligny>
-					<label>$LOCALIZE[35049]</label>
-					<textcolor>$VAR[TextColor2]</textcolor>
-					<scroll>True</scroll>
-				</control>
-				
-			</control>
-			<!-- Reloading indicator -->
-			<control type="group">
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
-				<include>widgetreloadingindicator_coords</include>
-				<include>skinshortcuts-template-reloading</include>
-			</control>
+			<include content="widgetHeading">
+				<param name="container">10006</param>
+			</include>
 		</control>
 		<control id="10008" type="list">
 			<left>1300</left>

--- a/xml/script-upnext-stillwatching-simple.xml
+++ b/xml/script-upnext-stillwatching-simple.xml
@@ -5,8 +5,6 @@
 	<animation effect="slide" start="550,0" time="200">WindowOpen</animation>
 	<animation effect="slide" end="550,0" time="200">WindowClose</animation>
 	<zorder>100</zorder>
-	<onload>SetProperty(scriptdialog,script-upnext-stillwatching-simple.xml,10000)</onload>
-	<onunload>ClearProperty(scriptdialog,10000)</onunload>
 	
 	<controls>
 		<control type="group">

--- a/xml/script-upnext-stillwatching.xml
+++ b/xml/script-upnext-stillwatching.xml
@@ -5,8 +5,6 @@
 	<animation effect="slide" start="550,0" time="200">WindowOpen</animation>
 	<animation effect="slide" end="550,0" time="200">WindowClose</animation>
 	<zorder>100</zorder>
-	<onload>SetProperty(scriptdialog,script-upnext-stillwatching.xml,10000)</onload>
-	<onunload>ClearProperty(scriptdialog,10000)</onunload>
 	
 	<controls>
 		<control type="group">

--- a/xml/script-upnext-upnext-simple.xml
+++ b/xml/script-upnext-upnext-simple.xml
@@ -5,8 +5,6 @@
 	<animation effect="slide" start="550,0" time="200">WindowOpen</animation>
 	<animation effect="slide" end="550,0" time="200">WindowClose</animation>
 	<zorder>100</zorder>
-	<onload>SetProperty(scriptdialog,script-upnext-upnext-simple.xml,10000)</onload>
-	<onunload>ClearProperty(scriptdialog,10000)</onunload>
 	
 	<controls>
 		<control type="group">

--- a/xml/script-upnext-upnext.xml
+++ b/xml/script-upnext-upnext.xml
@@ -5,8 +5,6 @@
 	<animation effect="slide" start="550,0" time="200">WindowOpen</animation>
 	<animation effect="slide" end="550,0" time="200">WindowClose</animation>
 	<zorder>100</zorder>
-	<onload>SetProperty(scriptdialog,script-upnext-upnext.xml,10000)</onload>
-	<onunload>ClearProperty(scriptdialog,10000)</onunload>
 	
 	<controls>
 		<control type="group">


### PR DESCRIPTION
14204-1.DATA.xml:
- fix second label

15016-1.DATA.xml:
- fix second label

19021-1.DATA.xml:
- fix second label

2-1.DATA.xml:
- fix second label

2.DATA.xml:
- add conditional visibility to only show current playlist while playlist is populated

3.DATA.xml:
- add conditional visibility to only show current playlist while playlist is populated

31091-1.DATA.xml:
- fix second label

mainmenu.DATA.xml:
- fix second labels

movies-1.DATA.xml:
- fix second label

programs-1.DATA.xml:
- fix second label

tvshows-1.DATA.xml:
- fix second label

weather-1.DATA.xml:
- fix second label

Coordinates_Custom_Cache_Progress.xml:
- increase width of dialog background to avoid 3D depth gap

Coordinates_script-upnext-stillwatching-simple.xml:
- fix scope coordinates

Coordinates_script-upnext-stillwatching.xml:
- fix scope coordinates

Coordinates_script-upnext-upnext-simple.xml:
- fix scope coordinates

Coordinates_script-upnext-upnext.xml:
- fix scope coordinates
- fix coordinates include

Custom_Cache_Progress.xml:
- fix dialog positioning and animation

DialogVideoInfo.xml:
- change cast list behaviour (triggered via window property)
- add director information line above button groulist
- rework cast and extended info button

Includes.xml:
- add new scope animation to submenu indicator

script-skinshortcuts-static.xml:
- fix second labels and icons of home menu and submenu entries as well as widgets
- fix game widget heading and details

script-upnext-stillwatching-simple.xml:
- remove unnecessary onload and onunload

script-upnext-stillwatching.xml:
- remove unnecessary onload and onunload

script-upnext-upnext-simple.xml:
- remove unnecessary onload and onunload

script-upnext-upnext.xml:
- remove unnecessary onload and onunload