### PR TITLE
Add videos and music root directory to home menu entry and submenu customization dialog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,15 @@
-**Changes**
+**Changes to the OSMC skin**
+
+---
+
+**_v18.5.0_**
+
+_Improved_
+- add videos and music root directory to home menu entry and submenu customization dialog
+
+---
+
+**_v18.4.0 - October 2020_**
 
 _New_
 - add channel group switching buttons to OSD PVR channels list
@@ -32,510 +43,292 @@ _Fixed_
 - fix widget icon fallback
 - fix PVR OSD dialogs
 
-**Changelog v18.4.0**
+---
 
-_Rename viewtype54 to viewtype534_
-_Rename viewtype536 to viewtype537_
-_Add new square versions of existing views for music and video addons (viewtype523, viewtype524, viewtype525, viewtype536, viewtype537, viewtype538, viewtype539)_
+**_v18.3.0 - May 2020_**
 
-strings.po:
-- change 'main menu' to 'home menu', 'entry' to 'item', 'side menu' to 'submenu' and 'customisation/customise' to 'customization/customize' in all strings
-- add new localize for Library Node Editor submenu button (31400)
-- add new localizes for automatic masking setting (31401, 31402, 31403)
-- adjust localize of plot font size setting (31326)
-- add new localize for new addon info dialog label (31404)
-- add new localize for fullscreen live TV playback OSD info dialog (31171)
-- add new localizes for new recommended/supported addons (31405, 31406, 31407, 31408)
-- add new localizes for new video addons default view setting (31409, 31410, 31411, 31412)
+_New_
+- add standard Kodi 'Menu' key functionality to access side menu in all windows
+- add new Wide low info view
+- add support for Up Next addon
+- add playlist button to video OSD
+- add 3D depth information to GUI elements
+- add new widget layouts (square and square small)
+- add new 2.33:1 scope masking option
 
-Textures.xbt:
-- update textures file with new watched/listened to indicator files
-- update textures file with new automatic aspect ratio OSD control icon
+_Improved_
+- make Wide low view accessible for music views
+- make disabled text colour more readable
+- improve widget details and window headings
+- improve debug overlay
+- improve overall handling of music videos
+- improve playlist window
+- add missing scrollbars
+- rework most dialogs for consistency
+- improve widget positioning and widget icon size
+- improve skinshortcuts management dialog
+- improve video info dialog button behaviour
+- remove unnecessary song and picture list view
+
+_Fixed_
+- fix settings button labels for 21:9 and 4:3 modes
+- fix music playlist editor window
+- fix side menu return button behaviour
+- fix edge alignment of dialogs and windows
+- fix watched/listened to status for a play count higher than 1
+
+---
+
+**_v18.2.0 - March 2020_**
+
+_New_
+- add new pre-defined widgets
+- add setting to change whether video info dialog shows details or plot first
+- add setting to set a solid colour instead of background images
+- add audio and subtitle language information to media flags
+- add setting to toggle media flags information shown (first)
+- add new seek indicator to audio and video player
+- add new scope version
+- add new scrolling label
+- add new never hide music information during playback setting
+- add skin settings explanations
+- add setting to hide item count
+
+_Improved_
+- rework home menu customization dialogs
+- improve sort by and sort order toggles
+- improve video info dialog (animations and buttons)
+- improve alignment and positioning of item count and media flags
+- show view toggle only when more than one view is available
+- improve info dialogs (more information/layout with video and addon info dialogs)
+- update Artist Slideshow integration (v3 update)
+- improve OSD animations
+- show item count with empty containers
+- improve music player during radio playback
+- improve visible window elements when busy dialog is active
+- let live TV and radio OSD listen to Kodi OSD settings
+
+_Fixed_
+- move hide scrollbars setting to skin settings window
+- hide MyOSMC home menu entry and widget on non-OSMC systems
+- fix overlapping in views with big horizontal titles
+- add scrollbar to music album info dialog (if details list is too long)
+- fix now playing dialog for radio and live TV playback
+- fix kiosk mode behaviour
+
+---
+
+**_v18.1.0 - November 2019_**
+
+_New_
+- add 21:9 and 4:3 modes
+- add option to show lock icon for encrypted PVR channels (show encrypted channel icons by default)
+
+_Improved_
+- use OSMC busy spinner for widget loading
+- add Disabled option to Adjust OSD on-time during video pause button
+- rework skin structure for Transiflex localization
+- improve widget icon animations
+- rework dialog animations to prevent bright transition
+
+_Fixed_
+- don't show parts of weather widget during widget loading
+- localize all labels
+
+---
+
+**_v18.0.1 - October 2019_**
+
+_New_
+- add new video player OSD settings (show OSD after beginning of playback and before end of playback)
+- add new second video info dialog screen (with extended rating, audio and subtitle information and bigger plot text box)
+- add new wall info view (based on wall view)
+- add new adjust representation of video duration setting
+- add new multi image (folder) background option
+- add new individual background option for home menu entries
+- add new options for music OSD to automatically show
+- add user rating to music and video library
+- add new side-menu player controls
+- add new options to hide watched indicator in video library and listened to indicator in music library
+
+_Improved_
+- add audio information to video info dialog
+- use font type for bold, light and italic instead of label formatting (where possible)
+- prevent stacking of window/dialog text during background video playback
+- show special watched indicator icons for videos watched more than once
+- add listened to indicator for music
+
+_Fixed_
+- only offer rip CD feature when an audio CD is present
+
+---
+
+**_v18.0.0 - May 2019_**
+
+_New_
+- add new subtitle selection to match v18 requirements
+- add new games section to match v18 requirements
+- add new resolution select button/dialog in video player
+- add player icon to now playing dialog
+- add new dependency button in addon info dialog to match v18 requirements
+- new color options (color sets, background gradients, adjustable opacity)
+- add PVR channel number input dialog
+- add PVR timeshift status dialog
+- add welcome dialog on non-OSMC devices
+- add director button to video info dialog
+- add new views (wide low, wall small, wall low, wall info, list info)
+- add new sub-menu indicator icon
+- add "Random TV shows" widget as new standard for TV shows home menu entry
+- add new dialog navigation indicators
+- add ratings toggle for IMDb, Metacritic, Rotten Tomatoes and TVDb
+- add new video player OSD settings (show OSD after beginning of playback and before end of playback)
+
+_Improved_
+- adjust syntax, values, labels and infobools to match v18 requirements
+- adjust PVR section to match v18 requirements
+- highlighting color now adjusts according to text color
+- streamline OSD animations
+- add missing adjustable plot fonts
+- let favourites dialog behave like a normal window
+- add file path and name to refresh button in video info dialog
+- add song/album year to music player
+- add wide list as music view
+- add music OSD album art size switch
+- adjust widget headings to always show and adjust animations to match widget animations
+- add option to change widget labels
+
+_Fixed_
+- show proper game widget title when not using skinshortcuts script
+- highlighting is now more consistent
+- fix current position/time remaining and current time/end time for PVR playback
+- hide deprecated previous/next channel buttons in PVR playback OSD
+- fix background of subtitle settings window
+- fix layout of PVR playback dialogs
+- fix dialog list navigation
+- change font size of media tags to prevent overlap with titles/details
+- only offer rip CD feature when an audio CD is present
+
+---
+
+**_v17.0.5 - June 2018_**
+
+_New_
+- add option to adjust dim factor of unfocused art 
+- add option for additional text highlight
+- add channel icon to PVR info dialog
+- add new widget options (through skin.helper.widgets script)
+- add AURO media flags (based on file naming)
+- add new cover art highlighting (size change depending on focused state)
+- add new movie collection indicator
+
+_Improved_
+- add more weather information to weather window
+- refine music icons
+- remove watched status for music items (in views and widgets)
+- adjust representation of object based audio codec tags
+- refine positioning and scaling of media tag icons
+- adjust viewtype 55 for music and add-ons to match viewtype 53 for movies and TV shows
+- improve highlight color of selected text
+- change appearance of all progress icons to round shape
+- add no dimming of cover art
+- dim watched and collection indicator depending on cover dimming setting
+- update watched overlay icon to match appearance of new movie collection indicator
+- add current control ID to debug overlay
+- change overlay color setting to match appearance of background color setting
+
+_Fixed_
+- fix scrollbar in music navigation
+- fix item widths in various windows
+- fix weather window
+- fix focused items in addon list view (e.g. YouTube)
+- fix PVR views to add scrolling and adapt season/episode representation
+- fix widget details label for PVR items (when using skinshortcuts script)
+- fix scrollbar in file browser
+
+---
+
+**_v17.0.4 - March 2018_**
+
+_New_
+- music track duration added to music info dialog
+- 3D label shown under media flags now (after first playback and/or if named according to Kodi wiki)
+- Atmos/DTS:X label shown under media flags now (if named according to Kodi wiki)
+- show codec information in music “now playing” window
+- show current audio/subtitle stream in info dialog during full screen video playback
+- add file size label next to duration label in file view
+- add adjustable font sizes/styles to plot/description texts (addon info, music info, full screen info, PVR info and video info dialog) – font sizes 27 (S), 30 (M), 33 (L) and 36 (XL) available in normal and light
+- add option to show date above system time
+- add option to adjust OSD on-time during video pause
+- add option to hide thumbnail art of unwatched TV show episodes
+
+_Improved_
+- show resolution with “p”-suffix (global)
+- show 4K resolution as 2160p (global)
+- adjust playback time and finish time in “now playing” dialog to match representation in full screen video playback window
+- show media flags in a two-line textbox
+- translate video/audio codecs in media flags to more understandable labels
+- add scrolling of long titles in “now playing” window for music
+- add scrolling of long album titles/artist tags in music list view
+- show more specific channel layout information (2.0, 5.1, 7.1, etc.)
+- replace “Aired on” in details of TV show episodes (in list view) by translatable “First air date”
+- adjust representation of season/episode titles to one syntax everywhere: S01E01
+- replace "Loading…" upon widget loading at startup of mediacenter by translatable "Please wait…"
+- add cycling of controls highlight in context menu
+
+_Fixed_
+- window heading and system clock moved slightly down and reduced width of “now playing” dialog to avoid overlaps
+- adjust height of plot textbox in list view to avoid overlap with new media flag representation
+- use titles when available instead of item labels
+- recognize TV show specials and show them correctly (no season, just episode S1)
+- adjust width of scrolling titles in wall view and wide list view to avoid overlap with new media flags
+- “now playing” dialog now shows album/artist tags correctly even when one of them or both are not present in the currently playing music file
+- fix custom background color option
+- bring back current playlist button in music OSD functionality
+
+---
+
+**_v17.0.3 - July 2017_**
+
+---
+
+**_v17.0.2 - March 2017_**
+
+---
+
+**_v17.0.1 - March 2017_**
+
+---
+
+**_v16.9.3 - January 2017_**
+
+---
+
+**_v16.9.3 - January 2017_**
+
+---
+
+**_v16.9.2 - November 2016_**
+
+Fix crash in PVR guide window; Font updates
+
+---
+
+**_v16.9.1 - November 2016_**
+
+Library image fixes and now playing information
+
+---
+
+**_v16.9.0 - September 2016_**
+
+Release
+
+---
+
+**Changelog v18.5.0**
 
 overrides.xml:
-- add new home menu node for favourites
-- add new favourites widget shortcut to additional widgets section
-
-template.xml:
-- fix deprecated IsEmpty conditions
-- rework watched/listened to widget indicator
-- add collection indicator to widgets
-
-AddonBrowser.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-Coordinates_AddonBrowser.xml:
-- add addon version to second row list label
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_Custom_DialogMasking.xml:
-- adjust coordinates for new OSD masking aspect ratio dialog layout
-
-Coordinates_DialogAddonInfo.xml:
-- adjust height if details group list and description textbox
-
-Coordinates_DialogButtonMenu.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-
-Coordinates_DialogFavourites.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_DialogGameControllers.xml:
-- decrease scrollbar height
-
-Coordinates_DialogKeyboard.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-
-Coordinates_DialogMediaSource.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-
-Coordinates_DialogMusicInfo.xml:
-- adjust height if details group list and description textbox
-- remove deprecated coordinate includes
-
-Coordinates_DialogPictureInfo.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_DialogPVRChannelGuide.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_DialogPVRChannelManager.xml:
-- fix ActiveChannel fade animations
-- add NonFocusFadeAnimation includes to focusedlayout
-- decrease scrollbar height
-
-Coordinates_DialogPVRChannelsOSD.xml:
-- add new coordinates for channel group heading and channel group switch buttons
-- rework coordinates for improved OSD guide dialog
-- remove unnecessary fade animations
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_DialogPVRGroupManager.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_DialogPVRInfo.xml:
-- adjust height if details group list and plot textbox
-
-Coordinates_DialogSelect.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- fix icon fade animations
-- decrease scrollbar height
-
-Coordinates_DialogSubtitles.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- fix icon fade animations
-- decrease scrollbar height
-
-Coordinates_DialogTextViewer.xml:
-- decrease scrollbar height
-
-Coordinates_DialogVideoInfo.xml:
-- decrease scrollbar height
-
-Coordinates_EventLog.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_FileBrowser.xml:
-- fix icon fade animations
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_FileManager.xml:
-- fix label width when label2 is not empty
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_Home.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-
-Coordinates_LoginScreen.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-
-Coordinates_MyGames.xml:
-- decrease scrollbar height and fix positioning
-- add new coordinates includes for new wide scrollbar
-
-Coordinates_MyMusicNav.xml:
-- decrease scrollbar height and fix positioning
-
-Coordinates_MyMusicPlaylistEditor.xml:
-- add NonFocusFadeAnimation includes to focusedlayout
-- remove unnecessary non-focus controls
-- decrease scrollbar height
-
-Coordinates_MyPics.xml:
-- decrease scrollbar height
-
-Coordinates_MyPlaylist.xml:
-- decrease scrollbar height
-
-Coordinates_MyPrograms.xml:
-- decrease scrollbar height and fix positioning
-- add new coordinates includes for new wide scrollbar
-
-Coordinates_MyPVRChannels.xml:
-- fix placing and width of label controls
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_MyPVRGuide.xml:
-- add fade animation to non-focus recording and timer images
-- add NonFocusFadeAnimation includes to focusedlayout
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-- decrease scrollbar height
-
-Coordinates_MyPVRRecordings.xml:
-- fix width of 4:3 label controls
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_MyPVRSearch.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-- decrease scrollbar height
-
-Coordinates_MyPVRTimers.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-- decrease scrollbar height
-
-Coordinates_MyVideoNav.xml:
-- decrease scrollbar height
-
-Coordinates_script-skinshortcuts.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- decrease scrollbar height
-
-Coordinates_SettingsProfile.xml:
-- fix width of label and image controls
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-
-Coordinates_SmartPlaylistEditor.xml:
-- place focusedlayout items into a group control and add NonFocusFadeAnimation includes
-
-Coordinates_VideoOSDBookmarks.xml:
-- add NonFocusFadeAnimation includes to focusedlayout
-
-Coordinates_MyVideoNav.xml:
-- fix height and positioning of scrollbars
-
-Coordinates_Viewtype50.xml:
-- add missing collection indicator
-- add NonFocusFadeAnimation includes to focusedlayout
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-
-Coordinates_Viewtype51.xml:
-- add missing collection indicator
-- add NonFocusFadeAnimation includes to focusedlayout
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-
-Coordinates_Viewtype511.xml:
-- add missing collection indicator
-- add NonFocusFadeAnimation includes to focusedlayout
-- replace icon fade animations by new NonFocusImageFadeAnimation include
-
-Coordinates_Viewtype52.xml:
-- rework watched/listened to and collection indicators
-- change cover art dimensions
-
-Coordinates_Viewtype521.xml:
-- rework watched/listened to and collection indicators
-- change horizontal list dimensions
-- change cover art dimensions
-
-Coordinates_Viewtype522.xml:
-- rework watched/listened to and collection indicators
-- change horizontal list dimensions
-- change cover art dimensions
-
-Coordinates_Viewtype523.xml:
-- add new addons, games and videos images includes
-
-Coordinates_Viewtype53.xml:
-- rework watched/listened to and collection indicators
-- change cover art dimensions
-
-Coordinates_Viewtype531.xml:
-- rework watched/listened to and collection indicators
-- change panel dimensions
-- change cover art dimensions
-
-Coordinates_Viewtype532.xml:
-- rework watched/listened to and collection indicators
-- change panel dimensions
-- change cover art dimensions
-
-Coordinates_Viewtype533.xml:
-- rework watched/listened to and collection indicators
-- change cover art dimensions
-
-Coordinates_Viewtype534.xml:
-- rework watched/listened to and collection indicators
-- change cover art dimensions
-
-Coordinates_Viewtype536.xml:
-- rework coordinates includes for new video addons and music views
-
-Custom_DialogMasking.xml:
-- change heading localize
-- rework buttons options to match skin settings masking aspect ratio setting layout
-
-DialogAddonInfo.xml:
-- add new onload and unload for second info dialog page
-- add new addon origin detail label
-- rework description textbox for second info dialog page
-- add new extended info button for second info dialog page
-
-DialogFavourites.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-DialogMusicInfo.xml:
-- add new onload and unload for second info dialog page
-- add new filename and path label
-- add missing detail labels
-- replace type label localize
-- rework description textbox for second info dialog page
-- add new extended info button for second info dialog page
-
-DialogPVRChannelsOSD.xml:
-- add new channel group heading, channel group switch buttons and indicators
-- rework coordinates for improved OSD channels dialog
-
-DialogPVRInfo.xml:
-- add new onload and unload for second info dialog page
-- fix heading to show PVR show title
-- rework plot textbox for second info dialog page
-- add new extended info button for second info dialog page
-- change Channel Name label to match representation in other places
-- add missing detail labels
-
-DialogSeekBar.xml:
-- change visibility condition of seek control to hide it while seeking during PVR playback
-- add missing PVR slider seek control
-
-DialogVideoInfo.xml:
-- rework visibility conditions, onup and usealttexture for new movie set information page
-- add new movie set poster image
-- rework order of detail labels
-- add new set detail label
-- rework plot textbox for second info dialog page
-- add new extended info button for second info dialog page
-
-EventLog.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-Home.xml:
-- rework RSS feed with animation for masking
-
-Includes.xml:
-- rename/add/remove includes files
-- rework masking animations for new automatic masking
-- change onload for new info dialog settings
-- change onload for new video addons default view setting
-- add new DefaultView include
-- replace visible change fade animation by VisibleFadeAnimation include
-- update SubmenuIndicator conditional visibilities with new viewtypes
-
-Includes_Home.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-Includes_Time_NowPlaying.xml:
-- rework now playing information completely (more specifically for all player media types)
-- rework animations for new video addons and music views
-
-Includes_Windows_Dialogs.xml:
-- replace VisibleFadeAnimation include animations by VisibleChange animation
-- add new NonFocusFadeAnimation include
-- replace visible change fade animation by VisibleFadeAnimation include
-- add new NonFocusImageFadeAnimation include
-
-LoginScreen.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MusicVisualisation.xml:
-- rework fullscreen music playback information
-
-MyGames.xml:
-- add changed/new viewtypes
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyMusicNav.xml:
-- fix default view to 'list'
-- add new Library Node Editor button to submenu
-- add changed/new viewtypes
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPics.xml:
-- add new view
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPlaylist.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPrograms.xml:
-- add changed/new viewtypes
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyVideoNav.xml:
-- remove deprecated scrollbars
-- add new views
-
-MyPVRChannels.xml:
-- change channel group label ID to '29'
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPVRGuide.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPVRRecordings.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPVRSearch.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyPVRTimers.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyVideoNav.xml:
-- fix default view to 'list'
-- add new Library Node Editor button to submenu
-- replace visible change fade animation by VisibleFadeAnimation include
-
-MyWeather.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-script-skinshortcuts.xml:
-- remove unnecessary non-focus fade animation
-
-script-skinshortcuts-static.xml:
-- fix deprecated IsEmpty conditions
-- rework watched/listened to widget indicator
-- add collection indicator to widgets
-
-Settings.xml:
-- fix non-focus fade animations
-
-SettingsCategory.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-SettingsProfile.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-SettingsScreenCalibration.xml:
-- rework masking animations for new automatic masking
-
-SettingsSystemInfo.xml:
-- replace visible change fade animation by VisibleFadeAnimation include
-
-SkinSettings.xml:
-- add new automatic masking setting
-- change info dialog setting for new second info dialog pages
-- add ColorPicker and Library Node Editor to recommended/supported addons
-- add new setting to force a specific view for video addons
-
-Variables.xml:
-- change channel group label ID of PVR channel window heading to '29'
-- simplify PVRDescription and PVRDescriptionDialogGuide variables and add genre info label
-- add disc number info label to MusicInfoLabel variable
-- rework addonInformation variable
-- rework VideoPlayerChannelNumber variable to match representation in other places
-- add TV show poster condition to mediaImages variable
-- replace TV show and season poster conditions by DBTYPE episode icon art in VideoInfoImage variable
-- add new videos values to ContentType variable
-- add new episodes, videos, addons, images and files values to as well as remove deprecated values from Label2 variable
-- remove deprecated Label2-episodes variable
-
-Variables_SkinSettings.xml:
-- add new automatic masking setting explanation variable
-- rework SkinSettingsExplanation variable for changed info dialog setting
-- add new addon-skinhelpercolorpicker and addon-librarynodeeditor variables for added recommended/supported addons
-- rework SkinSettingsExplanation variable for added recommended/supported addons explanations
-- rework SkinSettingsExplanation variable for added video addons force view settings explanations
-
-VideoFullScreen.xml:
-- rework masking animations for new automatic masking
-- replace label of Live TV next information by new localize
-
-VideoOSD.xml:
-- change conditional visibility and add new icon to masking control button for new automatic masking aspect ratio setting
-
-Viewtype50.xml:
-- fix alignment of cover art (centred)
-- rework list visibility condition to be shown for less content types
-
-Viewtype51.xml:
-- remove collection indicator from cover art
-- fix alignment of cover art (centred)
-- rework list visibility condition to be shown for more content types
-- add DefaultView include
-
-Viewtype511.xml:
-- remove collection indicator from cover art
-- fix alignment of cover art (centred)
-- rework list visibility condition to be shown for more content types
-- add DefaultView include
-
-Viewtype52.xml:
-- fix alignment of cover art (centred)
-- fix visibility to only use view for movies and TV shows
-- remove unnecessary non-focus fade animation
-
-Viewtype521.xml:
-- fix alignment of cover art (centred)
-- fix visibility to only use view for movies and TV shows
-- remove unnecessary non-focus fade animation
-
-Viewtype522.xml:
-- fix alignment of cover art (centred)
-
-Viewtype523.xml:
-- rework visibility conditions with more content types
-- add DefaultView include
-- remove unnecessary non-focus fade animation
-
-Viewtype524.xml:
-- remove unnecessary non-focus fade animation
-
-Viewtype53.xml:
-- fix alignment of cover art (centred)
-- remove unnecessary non-focus fade animation
-
-Viewtype531.xml:
-- change onleft and pagecontrol for new scrollbar
-- fix alignment of cover art (centred)
-
-Viewtype532.xml:
-- change onleft and pagecontrol for new scrollbar
-- fix alignment of cover art (centred)
-- remove unnecessary non-focus fade animation
-
-Viewtype533.xml:
-- fix alignment of cover art (centred)
-
-Viewtype534.xml:
-- fix alignment of cover art (centred)
-- remove unnecessary non-focus fade animation
-
-Viewtype535.xml:
-- rework visibility conditions with more content types
-- add DefaultView include
-- remove unnecessary non-focus fade animation
-
-Viewtype537.xml:
-- rework visibility conditions with more content types
-- add DefaultView include
-- remove unnecessary non-focus fade animation
+- add new videos and music root directory to home menu entry and submenu customization dialog
 
 addon.xml:
-- bump version to 18.4.0
-
-README.md
-- update readme with links to GitHub release page and OSMC Skin wiki article
+- bump version to 18.5.0

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="18.4.0" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="18.5.0" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.14.0"/>
 	</requires>
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add channel group switching buttons to OSD PVR channels list[CR]- add Library Node Editor support[CR]- new square versions of existing views for video addons and music[CR]- add automatic masking for scope skin version[CR]- add second dialog page to music, PVR and addon info dialog[CR]- add setting to force a specific view for video addons[CR]- add missing PVR seek slider[CR][CR][B]Improved[/B][CR]- improve wording in skin settings[CR]- improve watched/listened to indicator for all views/widgets[CR]- adjust media window view positioning and size[CR]- adjust wall and wide view for music[CR]- improve spacing of wall low view[CR]- improve PVR descriptions[CR]- rework now playing information and fullscreen music playback information[CR]- add missing detail labels to PVR and music info dialogs[CR]- show TV show episode thumb in video info dialog[CR]- use the more extended list view for more content types (addons, games, files and pictures)[CR]- improve second label of more extended list view[CR]- add wide view support to games and programs[CR]- harmonize non-focus animations[CR]- improve scrollbar size relative to their controls[CR]- add favourites to home menu entry/submenu and widget customization dialog[CR][CR][B]Fixed[/B][CR]- fix default view music and video navigation[CR]- fix PVR channel window heading label[CR]- fix widget icon fallback[CR]- fix PVR OSD dialogs</news>
+		<news>[B]Improved[/B][CR]- add videos and music root directory to home menu entry and submenu customization dialog</news>
 	</extension>
 </addon>

--- a/shortcuts/mainmenu.DATA.xml
+++ b/shortcuts/mainmenu.DATA.xml
@@ -26,7 +26,7 @@
 		<label2>31397</label2>
 		<icon>DefaultMusicAlbums.png</icon>
 		<thumb />
-		<action>ActivateWindow(Music,root,return)</action>
+		<action>ActivateWindow(Music,root)</action>
 	</shortcut>
 	<shortcut>
 		<label>10002</label>

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -16,6 +16,7 @@
 	<groupings>
 		<!-- Video -->
 		<node label="3">
+			<shortcut label="$LOCALIZE[3]" icon="DefaultFolder.png">ActivateWindow(Videos,root)</shortcut>
 			<content>video</content>
 			<node label="136">
 				<content>playlist-video</content>
@@ -27,6 +28,7 @@
 		</node>
 		<!-- Music -->
 		<node label="2">
+			<shortcut label="$LOCALIZE[2]" icon="DefaultFolder.png">ActivateWindow(Music,root)</shortcut>
 			<content>music</content>
 			<node label="136">
 				<content>playlist-audio</content>
@@ -42,8 +44,8 @@
 		</node>
 		<!-- Games -->
 		<node label="10821">
+			<shortcut label="$LOCALIZE[10821]" icon="DefaultFolder.png">ActivateWindow(Games)</shortcut>
 			<shortcut label="35049" icon="DefaultAddonGame.png">ActivateWindow(Games,Addons,return)</shortcut>
-			<shortcut label="$LOCALIZE[10821]" icon="DefaultFolder.png">ActivateWindow(games,return)</shortcut>
 		</node>
 		<!-- PVR -->
 		<node label="14204" condition="PVR.HasTVChannels | PVR.HasRadioChannels">

--- a/xml/Coordinates_Viewtype53.xml
+++ b/xml/Coordinates_Viewtype53.xml
@@ -50,7 +50,7 @@
 			<include content="image-53">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -104,7 +104,7 @@
 			<include content="image-53">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -158,7 +158,7 @@
 			<include content="image-53">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -212,7 +212,7 @@
 			<include content="image-53">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -273,7 +273,7 @@
 				<!-- Image - TV -->
 				<include content="image-53-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -324,7 +324,7 @@
 				<!-- Image - TV -->
 				<include content="image-53-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -375,7 +375,7 @@
 				<!-- Image - TV -->
 				<include content="image-53-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -426,7 +426,7 @@
 				<!-- Image - TV -->
 				<include content="image-53-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">

--- a/xml/Coordinates_Viewtype531.xml
+++ b/xml/Coordinates_Viewtype531.xml
@@ -259,7 +259,7 @@
 			<include content="image-531">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -313,7 +313,7 @@
 			<include content="image-531">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -366,7 +366,7 @@
 			<include content="image-531">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -420,7 +420,7 @@
 			<include content="image-531">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -481,7 +481,7 @@
 				<!-- Image - TV -->
 				<include content="image-531-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -532,7 +532,7 @@
 				<!-- Image - TV -->
 				<include content="image-531-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -583,7 +583,7 @@
 				<!-- Image - TV -->
 				<include content="image-531-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -634,7 +634,7 @@
 				<!-- Image - TV -->
 				<include content="image-531-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">

--- a/xml/Coordinates_Viewtype532.xml
+++ b/xml/Coordinates_Viewtype532.xml
@@ -50,7 +50,7 @@
 			<include content="image-532">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -104,7 +104,7 @@
 			<include content="image-532">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -158,7 +158,7 @@
 			<include content="image-532">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -212,7 +212,7 @@
 			<include content="image-532">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -273,7 +273,7 @@
 				<!-- Image - TV -->
 				<include content="image-532-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -324,7 +324,7 @@
 				<!-- Image - TV -->
 				<include content="image-532-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -375,7 +375,7 @@
 				<!-- Image - TV -->
 				<include content="image-532-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -426,7 +426,7 @@
 				<!-- Image - TV -->
 				<include content="image-532-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">

--- a/xml/Coordinates_Viewtype533.xml
+++ b/xml/Coordinates_Viewtype533.xml
@@ -259,7 +259,7 @@
 			<include content="image-533">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -313,7 +313,7 @@
 			<include content="image-533">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -367,7 +367,7 @@
 			<include content="image-533">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -421,7 +421,7 @@
 			<include content="image-533">
 				<param name="fallback">DefaultTVShows.png</param>
 				<param name="colordiffuse">$VAR[DiffusePosterNF]</param>
-				<param name="visible">!Container.Content(movies)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 			</include>
 			<!-- Collection -->
 			<control type="group">
@@ -482,7 +482,7 @@
 				<!-- Image - TV -->
 				<include content="image-533-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -533,7 +533,7 @@
 				<!-- Image - TV -->
 				<include content="image-533-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -584,7 +584,7 @@
 				<!-- Image - TV -->
 				<include content="image-533-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">
@@ -635,7 +635,7 @@
 				<!-- Image - TV -->
 				<include content="image-533-focused">
 					<param name="fallback">DefaultTVShows.png</param>
-					<param name="visible">!Container.Content(movies)</param>
+					<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
 				</include>
 				<!-- Collection -->
 				<control type="group">


### PR DESCRIPTION
mainmenu.DATA.xml:
- fix default music home menu entry path

overrides.xml:
- add videos and music root directory to home menu and submenu entry section
- fix order of games section

Coordinates_Viewtype53.xml:
- fix conditional visibility of TV show image

Coordinates_Viewtype531.xml:
- fix conditional visibility of TV show image

Coordinates_Viewtype532.xml:
- fix conditional visibility of TV show image

Coordinates_Viewtype533.xml:
- fix conditional visibility of TV show image

addon.xml:
- bump to 18.5.0
- update changelog

Changelog.md:
- rework changelog layout
- update changelog