### PR TITLE
Add new info button to video and music fullscreen playback windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,10 +7,12 @@
 _New_
 - add new v19 features (music library, movie sets, PVR additions and chapter/EDL markers in video OSD)
 - add channel sort by and sort order toggles to PVR guide side menu
-- add artist, album and radio now/next information to fullscreen music playback window
+- add artist, album and radio now/next information to fullscreen music/radio playback window
+- add new info button to video and music OSD
 
 _Improved_
 - rework look of default fullscreen music playback screen to match general skin look
+- refine video fullscreen OSD and info dialog behaviour
 
 _Fixed_
 - add missing "play recorded programme" button to PVR info dialog
@@ -346,7 +348,10 @@ Release
 _accomodate for changes of the v19 skin engine_
 
 strings.po:
-- remove deprecated localizes for bigger music OSD album art setting (31115, 31319)
+- remove deprecated localizes (31154, 31168)
+- remove deprecated localizes for bigger music OSD album art setting (31319)
+- replace deprecated localizes by new music/radio fullscreen information first setting localizes (31115, 31150, 31152, 31153)
+- update PVR fullscreen playback localize (31171)
 
 Textures.xbt:
 - update textures file with new OSD ranges and new PVR reminder icon
@@ -367,8 +372,15 @@ Coordinates_MusicVisualisation.xml:
 Coordinates_VideoFullScreen.xml:
 - add new coordinates for chapter and EDL markers
 
+Coordinates_VideoOSD.xml:
+- update right options width for new info button
+
 DialogAddonInfo.xml:
 - add new versions and update buttons
+
+DialogFullScreenInfo.xml:
+- add new onleft and onright controls to switch between PVR now and next information
+- change onclick to close info dialog
 
 DialogMusicInfo.xml:
 - add new release date, orignal date, BPM and file information detail labels
@@ -382,6 +394,9 @@ DialogVideoInfo.xml:
 - add new movie set poster image
 - rework visibility conditions for new movie set information
 
+Includes.xml:
+- add new onloads for new music/radio fullscreen information first setting
+
 MusicOSD.xml:
 - add new info button
 
@@ -394,15 +409,22 @@ MyPVRGuide.xml:
 
 SkinSettings.xml:
 - remove deprecated bigger music OSD album art setting
+- add new music/radio fullscreen information first settings
 
 Variables.xml:
 - adjust MusicNextPlaying variables to avoid showing wrong information while shuffle is enabled during playback
 
 Variables_SkinSettings.xml:
 - remove SkinSettingsExplanation variable value of deprecated bigger music OSD album art setting
+- change/add new variables for new music/radio fullscreen information first settings
 
 VideoFullScreen.xml:
 - add new chapter and EDL markers
+
+VideoOSD.xml:
+- adjust controls onleft for new info button
+- add onback to controls grouplists to close fullscreen info dialog when closing the video OSD
+- add new info button to right controls
 
 addon.xml:
 - bump version to 19.0.0

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new v19 features (music library, movie sets, PVR additions and chapter/EDL markers in video OSD)[CR]- add channel sort by and sort order toggles to PVR guide side menu[CR]- add artist, album and radio now/next information to fullscreen music playback window[CR][CR][B]Improved[/B][CR]- rework look of default fullscreen music playback screen to match general skin look[CR][CR][B]Fixed[/B][CR]- add missing "play recorded programme" button to PVR info dialog</news>
+		<news>[B]New[/B][CR]- add new v19 features (music library, movie sets, PVR additions and chapter/EDL markers in video OSD)[CR]- add channel sort by and sort order toggles to PVR guide side menu[CR]- add artist, album and radio now/next information to fullscreen music/radio playback window[CR]- add new info button to video and music OSD[CR][CR][B]Improved[/B][CR]- rework look of default fullscreen music playback screen to match general skin look[CR][CR][B]Fixed[/B][CR]- add missing "play recorded programme" button to PVR info dialog</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -542,6 +542,11 @@ msgctxt "#31114"
 msgid "Wall small"
 msgstr ""
 
+#: /SkinSettings.xml
+msgctxt "#31115"
+msgid "Show information in fullscreen music playback first"
+msgstr ""
+
 #: /Viewtype533.xml
 msgctxt "#31116"
 msgid "Wall small info"
@@ -712,29 +717,24 @@ msgctxt "#31149"
 msgid "Disable music listened to status in library"
 msgstr ""
 
-#: /Custom_Backup.xml
+#: /SkinSettings.xml
 msgctxt "#31150"
-msgid "Please enable the Skin Helper Service Skin Backup add-on under[CR]Settings/Add-on browser/My add-ons[CR]to be able to backup and restore skin settings."
+msgid "Show information in fullscreen radio playback first"
 msgstr ""
 
-#: /Custom_Backup.xml /Custom_Customization.xml /Custom_Disabled_Add-on.xml /Custom_Welcome.xml
+#: /Custom_Welcome.xml
 msgctxt "#31151"
 msgid "OK"
 msgstr ""
 
-#: /Custom_Backup.xml /Custom_Customization.xml /Custom_Disabled_Add-on.xml
+#: /SkinSettings.xml
 msgctxt "#31152"
-msgid "Open Add-on browser"
+msgid "The fullscreen music playback window can either show basic playback information next to the cover/icon art or an album/album artist description. The other information is accessible via the i button in the music player OSD. (default: Basic)[CR]Options available: Basic, Album, Artist"
 msgstr ""
 
-#: /Custom_Customization.xml
+#: /SkinSettings.xml
 msgctxt "#31153"
-msgid "Please enable the Skin Helper Service add-on under[CR]Settings/Add-on browser/My add-ons[CR]to be able to customize the main menu."
-msgstr ""
-
-#: /Custom_Disabled_Add-on.xml
-msgctxt "#31154"
-msgid "Please enable the add-on under Settings/Add-on browser/My add-ons to be able to use it."
+msgid "The fullscreen radio playback window can either show basic playback information next to the cover/icon art or the plot of the current and next programme. The other information is accessible via the i button in the music player OSD. (default: Basic)[CR]Options available: Basic, Now, Next"
 msgstr ""
 
 #: /Custom_Welcome.xml
@@ -802,11 +802,6 @@ msgctxt "#31167"
 msgid "Recently added movies"
 msgstr ""
 
-#: /Custom_Backup.xml /Custom_Customization.xml /Custom_Disabled_Add-on.xml /Custom_Welcome.xml
-msgctxt "#31168"
-msgid "Enable add-on"
-msgstr ""
-
 #: /Custom_Welcome.xml
 msgctxt "#31169"
 msgid "Welcome"
@@ -819,7 +814,7 @@ msgstr ""
 
 #: /VideoFullScreen.xml
 msgctxt "#31171"
-msgid "Press OK for details"
+msgid "Press left/right button for details"
 msgstr ""
 
 #: /script-skinshortcuts.xml

--- a/xml/Coordinates_VideoOSD.xml
+++ b/xml/Coordinates_VideoOSD.xml
@@ -217,22 +217,22 @@
 	</include>
 	<include name="VideoOSD_coords9_16:9">
 		<right>0</right>
-		<width>480</width>
+		<width>540</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords9_21:9">
 		<right>0</right>
-		<width>480</width>
+		<width>540</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords9_21:9_masked">
 		<right>0</right>
-		<width>480</width>
+		<width>540</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords9_4:3">
 		<right>0</right>
-		<width>480</width>
+		<width>540</width>
 		<height>60</height>
 	</include>
 	

--- a/xml/Custom_Overlay_Debug.xml
+++ b/xml/Custom_Overlay_Debug.xml
@@ -909,6 +909,17 @@
 				<label>$INFO[Skin.AspectRatio]</label>
 				<visible>!String.IsEmpty(Skin.AspectRatio)</visible>
 			</control>
+			
+			<!-- Player Show Info label -->
+			<control type="fadelabel">
+				<include>Custom_Overlay_Debug_coords2</include>
+				<textcolor>FF0000FF</textcolor>
+				<shadowcolor>FF000000</shadowcolor>
+				<font>font13</font>
+				<align>right</align>
+				<label>ShowInfo</label>
+				<visible>Player.ShowInfo</visible>
+			</control>
 		
 		</control>
 

--- a/xml/DialogFullScreenInfo.xml
+++ b/xml/DialogFullScreenInfo.xml
@@ -7,8 +7,11 @@
 	
 		<control type="button" id="100">
 			<include>DialogFavourites_coords</include>
-			<onclick condition="String.IsEmpty(Window(12005).Property(shownext))">SetProperty(shownext,True,12005)</onclick>
-			<onclick condition="!String.IsEmpty(Window(12005).Property(shownext))">ClearProperty(shownext,12005)</onclick>
+			<onright condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + String.IsEmpty(Window(12005).Property(shownext))">SetProperty(shownext,True,12005)</onright>
+			<onleft condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + String.IsEmpty(Window(12005).Property(shownext))">SetProperty(shownext,True,12005)</onleft>
+			<onright condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + !String.IsEmpty(Window(12005).Property(shownext))">ClearProperty(shownext,12005)</onright>
+			<onleft condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + !String.IsEmpty(Window(12005).Property(shownext))">ClearProperty(shownext,12005)</onleft>
+			<onclick condition="Window.IsActive(VideoOSD)">Dialog.Close(fullscreeninfo)</onclick>
 			<texturefocus></texturefocus>
 		</control>
 

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -183,6 +183,8 @@
 		<onload condition="String.IsEqual(Skin.String(mediaflags),Language)">Skin.SetString(mediaflags,Language first)</onload>
 		<onload condition="String.IsEmpty(Skin.String(MaskingBars))">Skin.SetString(MaskingBars,2.40:1)</onload>
 		<onload condition="String.IsEmpty(Skin.String(DefaultVideosView))">Skin.SetString(DefaultVideosView,List)</onload>
+		<onload condition="String.IsEmpty(Skin.String(musicinformationfirst))">Skin.SetString(musicinformationfirst,Basic)</onload>
+		<onload condition="String.IsEmpty(Skin.String(radioinformationfirst))">Skin.SetString(radioinformationfirst,Basic)</onload>
 	</include>
 	
 	<!-- Default forced views -->

--- a/xml/Includes_Windows_Dialogs.xml
+++ b/xml/Includes_Windows_Dialogs.xml
@@ -221,7 +221,7 @@
 			<texture background="true">$INFO[Skin.String(OSMCBackgroundOverlay),overlays/,.png]</texture>
 			<aspectratio>scale</aspectratio>
 			<colordiffuse>$VAR[BackgroundColor]</colordiffuse>
-			<visible>!Window.Is(visualisation) | [Window.Is(visualisation) + [[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] | Window.IsActive(musicosd)]]</visible>
+			<visible>!Window.Is(visualisation) | [Window.Is(visualisation) + [Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)]]</visible>
 			<include>WindowDepth</include>
 		</control>
 	</include>

--- a/xml/MusicOSD.xml
+++ b/xml/MusicOSD.xml
@@ -212,17 +212,27 @@
 					<include>MusicOSD_coords7</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDInfoNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDInfoNF.png</texturenofocus>
-					<onclick condition="String.IsEmpty(Window(12006).Property(extended)) + !String.IsEmpty(MusicPlayer.Property(Album_Description))">SetProperty(extended,album,12006)</onclick>
-					<onclick condition="String.IsEmpty(Window(12006).Property(extended)) + String.IsEmpty(MusicPlayer.Property(Album_Description)) + !String.IsEmpty(MusicPlayer.Property(Artist_Description))">SetProperty(extended,artist,12006)</onclick>
-					<onclick condition="String.IsEmpty(Window(12006).Property(extended)) + !String.IsEmpty(VideoPlayer.Plot) + Pvr.IsPlayingRadio">SetProperty(extended,plotnow,12006)</onclick>
-					<onclick condition="String.IsEmpty(Window(12006).Property(extended)) + String.IsEmpty(VideoPlayer.Plot) + !String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">SetProperty(extended,plotnext,12006)</onclick>
-					<onclick condition="String.IsEqual(Window(12006).Property(extended),album) + !String.IsEmpty(MusicPlayer.Property(Artist_Description))">SetProperty(extended,artist,12006)</onclick>
-					<onclick condition="String.IsEqual(Window(12006).Property(extended),album) + String.IsEmpty(MusicPlayer.Property(Artist_Description))">ClearProperty(extended,12006)</onclick>
-					<onclick condition="String.IsEqual(Window(12006).Property(extended),artist)">ClearProperty(extended,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + !Player.ShowInfo">SetProperty(extended,basic,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + !Player.ShowInfo">Info</onclick>
+					<onclick condition="String.IsEqual(Window(12006).Property(extended),basic) + !String.IsEmpty(MusicPlayer.Property(Album_Description)) + !Pvr.IsPlayingRadio">SetProperty(extended,album,12006)</onclick>
+					<onclick condition="String.IsEqual(Window(12006).Property(extended),basic) + String.IsEmpty(MusicPlayer.Property(Album_Description)) + !String.IsEmpty(MusicPlayer.Property(Artist_Description)) + !Pvr.IsPlayingRadio">SetProperty(extended,artist,12006)</onclick>
+					<onclick condition="String.IsEqual(Window(12006).Property(extended),album) + !String.IsEmpty(MusicPlayer.Property(Artist_Description)) + !Pvr.IsPlayingRadio">SetProperty(extended,artist,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + Player.ShowInfo + String.IsEqual(Window(12006).Property(extended),basic) + String.IsEmpty(MusicPlayer.Property(Album_Description)) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) + !Pvr.IsPlayingRadio">Info</onclick>
+					<onclick condition="Skin.HasSetting(MusicOSD) + String.IsEqual(Window(12006).Property(extended),basic) + String.IsEmpty(MusicPlayer.Property(Album_Description)) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) + !Pvr.IsPlayingRadio">SetProperty(extended,basic,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + Player.ShowInfo + String.IsEqual(Window(12006).Property(extended),album) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) + !Pvr.IsPlayingRadio">Info</onclick>
+					<onclick condition="Skin.HasSetting(MusicOSD) + String.IsEqual(Window(12006).Property(extended),album) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) + !Pvr.IsPlayingRadio">SetProperty(extended,basic,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + Player.ShowInfo + String.IsEqual(Window(12006).Property(extended),artist) + !Pvr.IsPlayingRadio">Info</onclick>
+					<onclick condition="Skin.HasSetting(MusicOSD) + String.IsEqual(Window(12006).Property(extended),artist) + !Pvr.IsPlayingRadio">SetProperty(extended,basic,12006)</onclick>
+					<onclick condition="String.IsEqual(Window(12006).Property(extended),basic) + !String.IsEmpty(VideoPlayer.Plot) + Pvr.IsPlayingRadio">SetProperty(extended,plotnow,12006)</onclick>
+					<onclick condition="String.IsEqual(Window(12006).Property(extended),basic) + String.IsEmpty(VideoPlayer.Plot) + !String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">SetProperty(extended,plotnext,12006)</onclick>
 					<onclick condition="String.IsEqual(Window(12006).Property(extended),plotnow) + !String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">SetProperty(extended,plotnext,12006)</onclick>
-					<onclick condition="String.IsEqual(Window(12006).Property(extended),plotnow) + String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">ClearProperty(extended,12006)</onclick>
-					<onclick condition="String.IsEqual(Window(12006).Property(extended),plotnext) + Pvr.IsPlayingRadio">ClearProperty(extended,12006)</onclick>
-					<visible>!String.IsEmpty(MusicPlayer.Property(Album_Description)) | !String.IsEmpty(MusicPlayer.Property(Artist_Description)) | [!String.IsEmpty(VideoPlayer.Plot) | !String.IsEmpty(VideoPlayer.NextPlot)] + Pvr.IsPlayingRadio + VideoPlayer.HasEpg</visible>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + Player.ShowInfo + String.IsEqual(Window(12006).Property(extended),basic) + String.IsEmpty(VideoPlayer.Plot) + String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">Info</onclick>
+					<onclick condition="Skin.HasSetting(MusicOSD) + String.IsEqual(Window(12006).Property(extended),basic) + String.IsEmpty(VideoPlayer.Plot) + String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">SetProperty(extended,basic,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + Player.ShowInfo + String.IsEqual(Window(12006).Property(extended),plotnow) + String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">Info</onclick>
+					<onclick condition="Skin.HasSetting(MusicOSD) + String.IsEqual(Window(12006).Property(extended),plotnow) + String.IsEmpty(VideoPlayer.NextPlot) + Pvr.IsPlayingRadio">SetProperty(extended,basic,12006)</onclick>
+					<onclick condition="!Skin.HasSetting(MusicOSD) + Player.ShowInfo + String.IsEqual(Window(12006).Property(extended),plotnext) + Pvr.IsPlayingRadio">Info</onclick>
+					<onclick condition="Skin.HasSetting(MusicOSD) + String.IsEqual(Window(12006).Property(extended),plotnext) + Pvr.IsPlayingRadio">SetProperty(extended,basic,12006)</onclick>
+					<visible>!Skin.HasSetting(MusicOSD) | [!String.IsEmpty(MusicPlayer.Property(Album_Description)) | !String.IsEmpty(MusicPlayer.Property(Artist_Description))] + [!Pvr.IsPlayingRadio | Pvr.IsPlayingRadio + !VideoPlayer.HasEpg] | [!String.IsEmpty(VideoPlayer.Plot) | !String.IsEmpty(VideoPlayer.NextPlot)] + Pvr.IsPlayingRadio</visible>
 				</control>
 				
 				<!-- Channels -->
@@ -294,9 +304,9 @@
 				<include>MusicOSD_coords9</include>
 				<visible>!Pvr.IsPlayingRadio</visible>
 				<animation effect="slide" end="60,0" time="0" condition="!Integer.IsGreater(MusicPlayer.PlaylistLength,1)">Conditional</animation>
-				<animation effect="slide" end="60,0" time="0" condition="String.IsEmpty(MusicPlayer.Property(Album_Description)) + String.IsEmpty(MusicPlayer.Property(Artist_Description))">Conditional</animation>
-				<animation effect="slide" end="60,0" time="0" condition="Visualisation.Enabled + !Visualisation.HasPresets + !Pvr.IsPlayingRadio">Conditional</animation>
-				<animation effect="slide" end="120,0" time="0" condition="!Visualisation.Enabled + !Visualisation.HasPresets + !Pvr.IsPlayingRadio">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(14)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="Control.IsVisible(19) + !Control.IsVisible(20)">Conditional</animation>
+				<animation effect="slide" end="120,0" time="0" condition="!Control.IsVisible(19)">Conditional</animation>
 
 				<control type="image">
 					<include>MusicOSD_coords7</include>

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -3,8 +3,12 @@
 	<!-- visualisation -->
 	<defaultcontrol></defaultcontrol>
 	<onload condition="System.HasAddon(script.artistslideshow)">RunScript(script.artistslideshow)</onload>
-	<onload condition="!String.IsEmpty(Window(12006).Property(extended))">ClearProperty(extended,12006)</onload>
-	<onunload>ClearProperty(extended,12006)</onunload>
+	<onload condition="!Pvr.IsPlayingRadio + String.IsEqual(Skin.String(musicinformationfirst),Basic)">SetProperty(extended,basic,12006)</onload>
+	<onload condition="!Pvr.IsPlayingRadio + String.IsEqual(Skin.String(musicinformationfirst),Album)">SetProperty(extended,album,12006)</onload>
+	<onload condition="!Pvr.IsPlayingRadio + String.IsEqual(Skin.String(musicinformationfirst),Artist)">SetProperty(extended,artist,12006)</onload>
+	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),Basic)">SetProperty(extended,basic,12006)</onload>
+	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),Now)">SetProperty(extended,plotnow,12006)</onload>
+	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),Next)">SetProperty(extended,plotnext,12006)</onload>
 
 	<controls>
 
@@ -24,12 +28,11 @@
 				<fadetime>200</fadetime>
 				<texture background="true">$INFO[MusicPlayer.Cover]</texture>
 				<aspectratio align="center" aligny="center">keep</aspectratio>
-				<visible>!Skin.HasSetting(MusicOSDSize)</visible>
 			</control>
 
 			<!-- Now playing (music) -->
 			<control type="grouplist">
-				<visible>String.IsEmpty(Window(12006).Property(extended))</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + [String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),Album) + String.IsEmpty(MusicPlayer.Property(Album_Description)) | String.IsEqual(Window(12006).Property(extended),Artist) + String.IsEmpty(MusicPlayer.Property(Artist_Description))]</visible>
 				<visible>!Pvr.IsPlayingRadio</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords2</include>
@@ -85,7 +88,7 @@
 			
 			<!-- Now playing (radio) -->
 			<control type="grouplist">
-				<visible>String.IsEmpty(Window(12006).Property(extended))</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + [String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),Now) + String.IsEmpty(VideoPlayer.Plot) | String.IsEqual(Window(12006).Property(extended),Next) + String.IsEmpty(VideoPlayer.NextPlot)]</visible>
 				<visible>Pvr.IsPlayingRadio</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords2</include>
@@ -158,7 +161,7 @@
 			<!-- Next playing -->
 			<control type="grouplist">
 				<visible>MusicPlayer.HasNext | Pvr.IsPlayingRadio + VideoPlayer.HasEpg</visible>
-				<visible>String.IsEmpty(Window(12006).Property(extended))</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + [String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),Album) + String.IsEmpty(MusicPlayer.Property(Album_Description)) | String.IsEqual(Window(12006).Property(extended),Artist) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) | String.IsEqual(Window(12006).Property(extended),Now) + String.IsEmpty(VideoPlayer.Plot) | String.IsEqual(Window(12006).Property(extended),Next) + String.IsEmpty(VideoPlayer.NextPlot)]</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords4</include>
 				<orientation>vertical</orientation>
@@ -191,7 +194,7 @@
 			
 			<!-- Album description -->
 			<control type="group">
-				<visible>String.IsEqual(Window(12006).Property(extended),album)</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + String.IsEqual(Window(12006).Property(extended),Album) + !String.IsEmpty(MusicPlayer.Property(Album_Description))</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords5</include>
 				
@@ -233,7 +236,7 @@
 			
 			<!-- Artist description -->
 			<control type="group">
-				<visible>String.IsEqual(Window(12006).Property(extended),artist)</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + String.IsEqual(Window(12006).Property(extended),Artist) + !String.IsEmpty(MusicPlayer.Property(Artist_Description))</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords5</include>
 				
@@ -275,7 +278,7 @@
 			
 			<!-- Radio plot (now) -->
 			<control type="group">
-				<visible>String.IsEqual(Window(12006).Property(extended),plotnow)</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + String.IsEqual(Window(12006).Property(extended),Now) + !String.IsEmpty(VideoPlayer.Plot)</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords5</include>
 				
@@ -317,7 +320,7 @@
 			
 			<!-- Radio plot (next) -->
 			<control type="group">
-				<visible>String.IsEqual(Window(12006).Property(extended),plotnext)</visible>
+				<visible>[Player.ShowInfo + !Skin.HasSetting(MusicOSD) | Skin.HasSetting(MusicOSD)] + String.IsEqual(Window(12006).Property(extended),Next) + !String.IsEmpty(VideoPlayer.NextPlot)</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords5</include>
 				

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -764,8 +764,32 @@
 					<textcolor>$VAR[TextColor2]</textcolor>
 					<visible>Skin.HasSetting(AutoMusicVisPlayback)</visible>
 				</control>
+				<!-- Show additional information first (music) -->
+				<control type="button" id="420">
+					<include>SkinSettings_coords16</include>
+					<font>Font33</font>
+					<label>$LOCALIZE[31115]</label>
+					<label2>$INFO[Skin.String(musicinformationfirst)]</label2>
+					<onclick condition="String.IsEqual(Skin.String(musicinformationfirst),Album)">Skin.SetString(musicinformationfirst,Basic)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(musicinformationfirst),Basic)">Skin.SetString(musicinformationfirst,Artist)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(musicinformationfirst),Artist)">Skin.SetString(musicinformationfirst,Album)</onclick>
+					<focusedcolor>$VAR[TextColor1]</focusedcolor>
+					<textcolor>$VAR[TextColor2]</textcolor>
+				</control>
+				<!-- Show additional information first (radio) -->
+				<control type="button" id="421">
+					<include>SkinSettings_coords16</include>
+					<font>Font33</font>
+					<label>$LOCALIZE[31150]</label>
+					<label2>$INFO[Skin.String(radioinformationfirst)]</label2>
+					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),Next)">Skin.SetString(radioinformationfirst,Basic)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),Basic)">Skin.SetString(radioinformationfirst,Now)</onclick>
+					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),Now)">Skin.SetString(radioinformationfirst,Next)</onclick>
+					<focusedcolor>$VAR[TextColor1]</focusedcolor>
+					<textcolor>$VAR[TextColor2]</textcolor>
+				</control>
 				<!-- Never hide music OSD -->
-				<control type="radiobutton" id="420">
+				<control type="radiobutton" id="422">
 					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31040</label>

--- a/xml/Variables_SkinSettings.xml
+++ b/xml/Variables_SkinSettings.xml
@@ -125,7 +125,9 @@
 		<value condition="Control.HasFocus(415)">$LOCALIZE[31315]</value>
 		<value condition="Control.HasFocus(418)">$LOCALIZE[31316]</value>
 		<value condition="Control.HasFocus(419)">$LOCALIZE[31317]</value>
-		<value condition="Control.HasFocus(420)">$LOCALIZE[31318]</value>
+		<value condition="Control.HasFocus(420)">$LOCALIZE[31152]</value>
+		<value condition="Control.HasFocus(421)">$LOCALIZE[31153]</value>
+		<value condition="Control.HasFocus(422)">$LOCALIZE[31318]</value>
 		<value condition="Container(9000).HasFocus(5) + !ControlGroup(10000).HasFocus">$LOCALIZE[31320]</value>
 		<value condition="Control.HasFocus(501)">$LOCALIZE[31321]</value>
 		<value condition="Control.HasFocus(502)">$LOCALIZE[31322]</value>

--- a/xml/VideoFullScreen.xml
+++ b/xml/VideoFullScreen.xml
@@ -478,7 +478,6 @@
 					<control type="label" id="1">
 						<include>VideoFullScreen_coords35</include>
 						<align>right</align>
-						<font>Font33-light</font>
 						<label>31171</label>
 						<font>Font25</font>
 					</control>

--- a/xml/VideoOSD.xml
+++ b/xml/VideoOSD.xml
@@ -31,10 +31,11 @@
 			<control type="grouplist">
 				<include>VideoOSD_coords4</include>
 				<itemgap>0</itemgap>
-				<onleft>23</onleft>
+				<onleft>24</onleft>
 				<onright>12</onright>
 				<onup>30</onup>
 				<ondown>30</ondown>
+				<onback condition="Player.ShowInfo">Info</onback>
 				<orientation>horizontal</orientation>
 
 				<!-- Spacer -->
@@ -193,6 +194,7 @@
 				<onright>1</onright>
 				<onup>5</onup>
 				<ondown>5</ondown>
+				<onback condition="Player.ShowInfo">Info</onback>
 				<orientation>horizontal</orientation>
 
 				<!-- 3D mode -->
@@ -228,8 +230,16 @@
 					<onclick>ActivateWindow(159)</onclick>
 				</control>
 				
-				<!-- Bookmarks -->
+				<!-- Information -->
 				<control type="button" id="16">
+					<include>VideoOSD_coords8</include>
+					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDInfoNF.png</texturefocus>
+					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDInfoNF.png</texturenofocus>
+					<onclick>Info</onclick>
+				</control>
+				
+				<!-- Bookmarks -->
+				<control type="button" id="17">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDBookmarksNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDBookmarksNF.png</texturenofocus>
@@ -238,7 +248,7 @@
 				</control>
 				
 				<!-- Playlist -->
-				<control type="button" id="17">
+				<control type="button" id="18">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDPlaylistNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDPlaylistNF.png</texturenofocus>
@@ -248,7 +258,7 @@
 				</control>
 				
 				<!-- Channels -->
-				<control type="button" id="18">
+				<control type="button" id="19">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDChannelNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDChannelNF.png</texturenofocus>
@@ -257,7 +267,7 @@
 				</control>
 				
 				<!-- Channel EPG -->
-				<control type="button" id="19">
+				<control type="button" id="20">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDEPGNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDEPGNF.png</texturenofocus>
@@ -266,7 +276,7 @@
 				</control>
 				
 				<!-- Teletext -->
-				<control type="button" id="20">
+				<control type="button" id="21">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDTextNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDTextNF.png</texturenofocus>
@@ -275,7 +285,7 @@
 				</control>
 				
 				<!-- DVD menu -->
-				<control type="button" id="21">
+				<control type="button" id="22">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDDvdNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDDvdNF.png</texturenofocus>
@@ -284,7 +294,7 @@
 				</control>
 				
 				<!-- Resolution select -->
-				<control type="button" id="22">
+				<control type="button" id="23">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[DialogColor1]">osd/OSDResNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[DialogColor2]">osd/OSDResNF.png</texturenofocus>
@@ -293,7 +303,7 @@
 				</control>
 
 				<!-- Masking -->
-				<control type="button" id="23">
+				<control type="button" id="24">
 					<include>VideoOSD_coords8</include>
 					<texturefocus></texturefocus>
 					<texturenofocus></texturenofocus>
@@ -306,79 +316,79 @@
 			<!-- Masking images -->
 			<control type="group">
 				<include>VideoOSD_coords10</include>
-				<visible>Control.IsVisible(23)</visible>
+				<visible>Control.IsVisible(24)</visible>
 
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor2]">osd/OSDMask240NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.40:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(23)</visible>
+					<visible>!Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDMask240NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.40:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(23)</visible>
+					<visible>Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor2]">osd/OSDMask235NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.35:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(23)</visible>
+					<visible>!Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDMask235NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.35:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(23)</visible>
+					<visible>Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor2]">osd/OSDMask233NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.33:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(23)</visible>
+					<visible>!Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDMask233NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.33:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(23)</visible>
+					<visible>Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor2]">osd/OSDMask200NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.00:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(23)</visible>
+					<visible>!Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDMask200NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.00:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(23)</visible>
+					<visible>Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor2]">osd/OSDMask178NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),1.78:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(23)</visible>
+					<visible>!Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDMask178NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),1.78:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(23)</visible>
+					<visible>Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor2]">osd/OSDMaskAutoNF.png</texture>
 					<visible>Skin.HasSetting(AutomaticMasking) + [String.Contains(Player.FileName,-AR178-) | String.Contains(Player.FileName,-AR178.) | String.Contains(Player.FileName,-AR178_) | String.Contains(Player.FileName,.AR178-) | String.Contains(Player.FileName,.AR178.) | String.Contains(Player.FileName,.AR178_) | String.Contains(Player.FileName,_AR178-) | String.Contains(Player.FileName,_AR178.) | String.Contains(Player.FileName,_AR178_) | String.Contains(Player.FileName,-AR235-) | String.Contains(Player.FileName,-AR235.) | String.Contains(Player.FileName,-AR235_) | String.Contains(Player.FileName,.AR235-) | String.Contains(Player.FileName,.AR235.) | String.Contains(Player.FileName,.AR235_) | String.Contains(Player.FileName,_AR235-) | String.Contains(Player.FileName,_AR235.) | String.Contains(Player.FileName,_AR235_) | String.Contains(Player.FileName,-AR233-) | String.Contains(Player.FileName,-AR233.) | String.Contains(Player.FileName,-AR233_) | String.Contains(Player.FileName,.AR233-) | String.Contains(Player.FileName,.AR233.) | String.Contains(Player.FileName,.AR233_) | String.Contains(Player.FileName,_AR233-) | String.Contains(Player.FileName,_AR233.) | String.Contains(Player.FileName,_AR233_) | String.Contains(Player.FileName,-AR200-) | String.Contains(Player.FileName,-AR200.) | String.Contains(Player.FileName,-AR200_) | String.Contains(Player.FileName,.AR200-) | String.Contains(Player.FileName,.AR200.) | String.Contains(Player.FileName,.AR200_) | String.Contains(Player.FileName,_AR200-) | String.Contains(Player.FileName,_AR200.) | String.Contains(Player.FileName,_AR200_) | String.Contains(Player.FileName,-AR240-) | String.Contains(Player.FileName,-AR240.) | String.Contains(Player.FileName,-AR240_) | String.Contains(Player.FileName,.AR240-) | String.Contains(Player.FileName,.AR240.) | String.Contains(Player.FileName,.AR240_) | String.Contains(Player.FileName,_AR240-) | String.Contains(Player.FileName,_AR240.) | String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(23)</visible>
+					<visible>!Control.HasFocus(24)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[DialogColor1]">osd/OSDMaskAutoNF.png</texture>
 					<visible>Skin.HasSetting(AutomaticMasking) + [String.Contains(Player.FileName,-AR178-) | String.Contains(Player.FileName,-AR178.) | String.Contains(Player.FileName,-AR178_) | String.Contains(Player.FileName,.AR178-) | String.Contains(Player.FileName,.AR178.) | String.Contains(Player.FileName,.AR178_) | String.Contains(Player.FileName,_AR178-) | String.Contains(Player.FileName,_AR178.) | String.Contains(Player.FileName,_AR178_) | String.Contains(Player.FileName,-AR235-) | String.Contains(Player.FileName,-AR235.) | String.Contains(Player.FileName,-AR235_) | String.Contains(Player.FileName,.AR235-) | String.Contains(Player.FileName,.AR235.) | String.Contains(Player.FileName,.AR235_) | String.Contains(Player.FileName,_AR235-) | String.Contains(Player.FileName,_AR235.) | String.Contains(Player.FileName,_AR235_) | String.Contains(Player.FileName,-AR233-) | String.Contains(Player.FileName,-AR233.) | String.Contains(Player.FileName,-AR233_) | String.Contains(Player.FileName,.AR233-) | String.Contains(Player.FileName,.AR233.) | String.Contains(Player.FileName,.AR233_) | String.Contains(Player.FileName,_AR233-) | String.Contains(Player.FileName,_AR233.) | String.Contains(Player.FileName,_AR233_) | String.Contains(Player.FileName,-AR200-) | String.Contains(Player.FileName,-AR200.) | String.Contains(Player.FileName,-AR200_) | String.Contains(Player.FileName,.AR200-) | String.Contains(Player.FileName,.AR200.) | String.Contains(Player.FileName,.AR200_) | String.Contains(Player.FileName,_AR200-) | String.Contains(Player.FileName,_AR200.) | String.Contains(Player.FileName,_AR200_) | String.Contains(Player.FileName,-AR240-) | String.Contains(Player.FileName,-AR240.) | String.Contains(Player.FileName,-AR240_) | String.Contains(Player.FileName,.AR240-) | String.Contains(Player.FileName,.AR240.) | String.Contains(Player.FileName,.AR240_) | String.Contains(Player.FileName,_AR240-) | String.Contains(Player.FileName,_AR240.) | String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(23)</visible>
+					<visible>Control.HasFocus(24)</visible>
 				</control>
 
 			</control>


### PR DESCRIPTION
strings.po:
- add new localize for new music/radio fullscreen information first setting (31115)
- remove deprecated localizes (31154, 31168)
- replace deprecated localizes by new music/radio fullscreen information first setting localizes (31150, 31152, 31153)
- update PVR fullscreen playback localize (31171)

Coordinates_VideoOSD.xml:
- update right options width for new info button

Custom_Overlay_Debug.xml:
- add Player.ShowInfo to debug overlay

DialogFullScreenInfo.xml:
- add new onleft and onright controls to switch between PVR now and next information
- change onclick to close info dialog

Includes.xml:
- add new onloads for new music/radio fullscreen information first setting

Includes_Windows_Dialogs.xml:
- change visibility of background overlay to prevent it from showing while music OSD is active

MusicOSD.xml:
- rework new music/radio fullscreen information first setting to toggle through all modes including no info at all
- rework animation conditions of repeat images to be bound to visibility of other buttons

MusicVisualisation.xml:
- rework new music/radio fullscreen information first onloads to set window properties according to the new skin setting
- rework conditional visibilities of fullscreen music/radio playback with new fullscreen information first setting properties

SkinSettings.xml:
- add new music/radio fullscreen information first settings

Variables_SkinSettings.xml:
- change/add new variables for new music/radio fullscreen information first settings

VideoFullScreen.xml:
- fix PVR label font

VideoOSD.xml:
- adjust controls onleft for new info button
- add onback to controls grouplists to close fullscreen info dialog when closing the video OSD
- add new info button to right controls
- update conditions visibilities of masking images

addon.xml:
- update changelog

Changelog.md:
- update changelog