### PR TITLE
Remove fullscreen music player information settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -348,9 +348,7 @@ Release
 _accommodate  for changes of the v19 skin engine_
 
 strings.po:
-- remove deprecated localizes (31154, 31168)
-- remove deprecated localizes for bigger music OSD album art setting (31319)
-- replace deprecated localizes by new music/radio fullscreen information first setting localizes (31115, 31150, 31152, 31153)
+- remove deprecated localizes (31115, 31150, 31152, 31153, 31154, 31168, 31319)
 - update PVR fullscreen playback localize (31171)
 
 Textures.xbt:
@@ -394,22 +392,18 @@ DialogVideoInfo.xml:
 - add new movie set poster image
 - rework visibility conditions for new movie set information
 
-Includes.xml:
-- add new onloads for new music/radio fullscreen information first setting
-
 MusicOSD.xml:
 - add new info button
 
 MusicVisualisation.xml:
 - rework look of default fullscreen music playback window to match general skin look
-- rework fullscreen music playback to show additional album, artist and radio now/next description
+- rework fullscreen music playback to show additional album, artist and radio now/next/RDS information
 
 MyPVRGuide.xml:
 - add channel sort by and sort order toggles (ID 3 and 4) to PVR guide side menu
 
 SkinSettings.xml:
 - remove deprecated bigger music OSD album art setting
-- add new music/radio fullscreen information first settings
 
 Variables.xml:
 - adjust MusicNextPlaying variables to avoid showing wrong information while shuffle is enabled during playback
@@ -417,7 +411,6 @@ Variables.xml:
 
 Variables_SkinSettings.xml:
 - remove SkinSettingsExplanation variable value of deprecated bigger music OSD album art setting
-- change/add new variables for new music/radio fullscreen information first settings
 
 VideoFullScreen.xml:
 - add new chapter and EDL markers

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -542,11 +542,6 @@ msgctxt "#31114"
 msgid "Wall small"
 msgstr ""
 
-#: /SkinSettings.xml
-msgctxt "#31115"
-msgid "Show information in fullscreen music playback first"
-msgstr ""
-
 #: /Viewtype533.xml
 msgctxt "#31116"
 msgid "Wall small info"
@@ -717,24 +712,9 @@ msgctxt "#31149"
 msgid "Disable music listened to status in library"
 msgstr ""
 
-#: /SkinSettings.xml
-msgctxt "#31150"
-msgid "Show information in fullscreen radio playback first"
-msgstr ""
-
 #: /Custom_Welcome.xml
 msgctxt "#31151"
 msgid "OK"
-msgstr ""
-
-#: /SkinSettings.xml
-msgctxt "#31152"
-msgid "The fullscreen music playback window can either show basic playback information next to the cover/icon art or an album/album artist description. The other information is accessible via the i button in the music player OSD. (default: Basic)[CR]Options available: Basic, Album, Artist"
-msgstr ""
-
-#: /SkinSettings.xml
-msgctxt "#31153"
-msgid "The fullscreen radio playback window can either show basic playback information next to the cover/icon art or the plot of the current/next programme or RDS information. The other information is accessible via the i button in the music player OSD. (default: Basic)[CR]Options available: Basic, Now, Next, RDS"
 msgstr ""
 
 #: /Custom_Welcome.xml

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -183,8 +183,6 @@
 		<onload condition="String.IsEqual(Skin.String(mediaflags),Language)">Skin.SetString(mediaflags,Language first)</onload>
 		<onload condition="String.IsEmpty(Skin.String(MaskingBars))">Skin.SetString(MaskingBars,2.40:1)</onload>
 		<onload condition="String.IsEmpty(Skin.String(DefaultVideosView))">Skin.SetString(DefaultVideosView,List)</onload>
-		<onload condition="String.IsEmpty(Skin.String(musicinformationfirst))">Skin.SetString(musicinformationfirst,Basic)</onload>
-		<onload condition="String.IsEmpty(Skin.String(radioinformationfirst))">Skin.SetString(radioinformationfirst,Basic)</onload>
 	</include>
 	
 	<!-- Default forced views -->

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -3,13 +3,8 @@
 	<!-- visualisation -->
 	<defaultcontrol></defaultcontrol>
 	<onload condition="System.HasAddon(script.artistslideshow)">RunScript(script.artistslideshow)</onload>
-	<onload condition="!Pvr.IsPlayingRadio + String.IsEqual(Skin.String(musicinformationfirst),Basic)">SetProperty(extended,basic,12006)</onload>
-	<onload condition="!Pvr.IsPlayingRadio + String.IsEqual(Skin.String(musicinformationfirst),Album)">SetProperty(extended,album,12006)</onload>
-	<onload condition="!Pvr.IsPlayingRadio + String.IsEqual(Skin.String(musicinformationfirst),Artist)">SetProperty(extended,artist,12006)</onload>
-	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),Basic)">SetProperty(extended,basic,12006)</onload>
-	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),Now)">SetProperty(extended,plotnow,12006)</onload>
-	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),Next)">SetProperty(extended,plotnext,12006)</onload>
-	<onload condition="Pvr.IsPlayingRadio + String.IsEqual(Skin.String(radioinformationfirst),RDS)">SetProperty(extended,rds,12006)</onload>
+	<onload condition="!String.IsEqual(Window(12006).Property(extended),basic)">SetProperty(extended,basic,12006)</onload>
+	<onunload>ClearProperty(extended,12006)</onunload>
 
 	<controls>
 
@@ -34,7 +29,7 @@
 
 			<!-- Now playing (music) -->
 			<control type="grouplist">
-				<visible>String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),Album) + String.IsEmpty(MusicPlayer.Property(Album_Description)) | String.IsEqual(Window(12006).Property(extended),Artist) + String.IsEmpty(MusicPlayer.Property(Artist_Description))</visible>
+				<visible>String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),album) + String.IsEmpty(MusicPlayer.Property(Album_Description)) | String.IsEqual(Window(12006).Property(extended),artist) + String.IsEmpty(MusicPlayer.Property(Artist_Description))</visible>
 				<visible>!Pvr.IsPlayingRadio</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords2</include>
@@ -89,7 +84,7 @@
 				<!-- Track/Title -->
 				<control type="group">
 					<include>MusicVisualisation_coords3</include>
-					<visible>!String.IsEmpty(MusicPlayer.Album)</visible>
+					<visible>!String.IsEmpty(Player.Title)</visible>
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords4</include>
 						<align>right</align>
@@ -100,7 +95,7 @@
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords5</include>
 						<font>Font36</font>
-						<label>$INFO[MusicPlayer.TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[MusicPlayer.Title]</label>
+						<label>$INFO[MusicPlayer.TrackNumber,[LIGHT],.[/LIGHT] ]$INFO[Player.Title]</label>
 					</control>
 				</control>
 				
@@ -162,7 +157,7 @@
 			
 			<!-- Now playing (radio) -->
 			<control type="grouplist">
-				<visible>String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),Now) + String.IsEmpty(VideoPlayer.Plot) | String.IsEqual(Window(12006).Property(extended),Next) + String.IsEmpty(VideoPlayer.NextPlot) | String.IsEqual(Window(12006).Property(extended),rds) + !RDS.HasRadioTextPlus</visible>
+				<visible>String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),now) + String.IsEmpty(VideoPlayer.Plot) | String.IsEqual(Window(12006).Property(extended),next) + String.IsEmpty(VideoPlayer.NextPlot) | String.IsEqual(Window(12006).Property(extended),rds) + !RDS.HasRadioTextPlus</visible>
 				<visible>Pvr.IsPlayingRadio</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords2</include>
@@ -176,7 +171,6 @@
 					<font>Font36</font>
 					<label>$LOCALIZE[19030]</label>
 					<textcolor>$VAR[TextColor2]</textcolor>
-					<visible>VideoPlayer.HasEpg</visible>
 				</control>
 				
 				<!-- Radio channel -->
@@ -199,7 +193,7 @@
 				<!-- Radio show title (EPG) -->
 				<control type="group">
 					<include>MusicVisualisation_coords3</include>
-					<visible>VideoPlayer.HasEpg</visible>
+					<visible>VideoPlayer.HasEpg + !String.IsEmpty(Player.Title)</visible>
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords4</include>
 						<align>right</align>
@@ -210,14 +204,14 @@
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords5</include>
 						<font>Font36</font>
-						<label>$INFO[MusicPlayer.Title] [LIGHT]($INFO[VideoPlayer.StartTime] - $INFO[VideoPlayer.EndTime])[/LIGHT]</label>
+						<label>$INFO[Player.Title] [LIGHT]($INFO[VideoPlayer.StartTime] - $INFO[VideoPlayer.EndTime])[/LIGHT]</label>
 					</control>
 				</control>
 				
 				<!-- Radio show title (non-EPG) -->
 				<control type="group">
 					<include>MusicVisualisation_coords3</include>
-					<visible>!VideoPlayer.HasEpg + !String.IsEqual(MusicPlayer.ChannelName,MusicPlayer.Title)</visible>
+					<visible>!VideoPlayer.HasEpg + !String.IsEqual(MusicPlayer.ChannelName,Player.Title) + !String.IsEmpty(Player.Title)</visible>
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords4</include>
 						<align>right</align>
@@ -228,7 +222,7 @@
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords5</include>
 						<font>Font36</font>
-						<label>$INFO[MusicPlayer.Title]</label>
+						<label>$INFO[Player.Title]</label>
 					</control>
 				</control>
 				
@@ -308,7 +302,7 @@
 
 			<!-- Next playing -->
 			<control type="grouplist">
-				<visible>String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),Album) + String.IsEmpty(MusicPlayer.Property(Album_Description)) | String.IsEqual(Window(12006).Property(extended),Artist) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) | String.IsEqual(Window(12006).Property(extended),Now) + String.IsEmpty(VideoPlayer.Plot) | String.IsEqual(Window(12006).Property(extended),Next) + String.IsEmpty(VideoPlayer.NextPlot)</visible>
+				<visible>String.IsEqual(Window(12006).Property(extended),Basic) | String.IsEqual(Window(12006).Property(extended),album) + String.IsEmpty(MusicPlayer.Property(Album_Description)) | String.IsEqual(Window(12006).Property(extended),artist) + String.IsEmpty(MusicPlayer.Property(Artist_Description)) | String.IsEqual(Window(12006).Property(extended),now) + String.IsEmpty(VideoPlayer.Plot) | String.IsEqual(Window(12006).Property(extended),next) + String.IsEmpty(VideoPlayer.NextPlot) | String.IsEqual(Window(12006).Property(extended),rds) + !RDS.HasRadioTextPlus</visible>
 				<visible>MusicPlayer.HasNext | Pvr.IsPlayingRadio + VideoPlayer.HasEpg</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords6</include>
@@ -378,7 +372,7 @@
 			
 			<!-- Album description -->
 			<control type="group">
-				<visible>String.IsEqual(Window(12006).Property(extended),Album) + !String.IsEmpty(MusicPlayer.Property(Album_Description))</visible>
+				<visible>String.IsEqual(Window(12006).Property(extended),album) + !String.IsEmpty(MusicPlayer.Property(Album_Description))</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords7</include>
 				
@@ -422,7 +416,7 @@
 			
 			<!-- Album artist description -->
 			<control type="group">
-				<visible>String.IsEqual(Window(12006).Property(extended),Artist) + !String.IsEmpty(MusicPlayer.Property(Artist_Description))</visible>
+				<visible>String.IsEqual(Window(12006).Property(extended),artist) + !String.IsEmpty(MusicPlayer.Property(Artist_Description))</visible>
 				<include>VisibleFadeAnimation</include>
 				<include>MusicVisualisation_coords7</include>
 				
@@ -698,7 +692,7 @@
 				<!-- Style -->
 				<control type="group">
 					<include>MusicVisualisation_coords3</include>
-					<visible>!String.IsEmpty(RDS.RadioStyle)</visible>
+					<visible>!String.IsEmpty(RDS.ProgStyle)</visible>
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords4</include>
 						<align>right</align>
@@ -709,7 +703,7 @@
 					<control type="fadelabel">
 						<include>MusicVisualisation_coords5</include>
 						<font>Font36</font>
-						<label>$INFO[RDS.RadioStyle]</label>
+						<label>$INFO[RDS.ProgStyle]</label>
 					</control>
 				</control>
 				

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -764,33 +764,8 @@
 					<textcolor>$VAR[TextColor2]</textcolor>
 					<visible>Skin.HasSetting(AutoMusicVisPlayback)</visible>
 				</control>
-				<!-- Show additional information first (music) -->
-				<control type="button" id="420">
-					<include>SkinSettings_coords16</include>
-					<font>Font33</font>
-					<label>$LOCALIZE[31115]</label>
-					<label2>$INFO[Skin.String(musicinformationfirst)]</label2>
-					<onclick condition="String.IsEqual(Skin.String(musicinformationfirst),Album)">Skin.SetString(musicinformationfirst,Basic)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(musicinformationfirst),Basic)">Skin.SetString(musicinformationfirst,Artist)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(musicinformationfirst),Artist)">Skin.SetString(musicinformationfirst,Album)</onclick>
-					<focusedcolor>$VAR[TextColor1]</focusedcolor>
-					<textcolor>$VAR[TextColor2]</textcolor>
-				</control>
-				<!-- Show additional information first (radio) -->
-				<control type="button" id="421">
-					<include>SkinSettings_coords16</include>
-					<font>Font33</font>
-					<label>$LOCALIZE[31150]</label>
-					<label2>$INFO[Skin.String(radioinformationfirst)]</label2>
-					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),RDS)">Skin.SetString(radioinformationfirst,Basic)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),Basic)">Skin.SetString(radioinformationfirst,Now)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),Now)">Skin.SetString(radioinformationfirst,Next)</onclick>
-					<onclick condition="String.IsEqual(Skin.String(radioinformationfirst),Next)">Skin.SetString(radioinformationfirst,RDS)</onclick>
-					<focusedcolor>$VAR[TextColor1]</focusedcolor>
-					<textcolor>$VAR[TextColor2]</textcolor>
-				</control>
 				<!-- Never hide music OSD -->
-				<control type="radiobutton" id="422">
+				<control type="radiobutton" id="420">
 					<include>SkinSettings_coords16</include>
 					<font>Font33</font>
 					<label>31040</label>

--- a/xml/Variables_SkinSettings.xml
+++ b/xml/Variables_SkinSettings.xml
@@ -125,9 +125,7 @@
 		<value condition="Control.HasFocus(415)">$LOCALIZE[31315]</value>
 		<value condition="Control.HasFocus(418)">$LOCALIZE[31316]</value>
 		<value condition="Control.HasFocus(419)">$LOCALIZE[31317]</value>
-		<value condition="Control.HasFocus(420)">$LOCALIZE[31152]</value>
-		<value condition="Control.HasFocus(421)">$LOCALIZE[31153]</value>
-		<value condition="Control.HasFocus(422)">$LOCALIZE[31318]</value>
+		<value condition="Control.HasFocus(420)">$LOCALIZE[31318]</value>
 		<value condition="Container(9000).HasFocus(5) + !ControlGroup(10000).HasFocus">$LOCALIZE[31320]</value>
 		<value condition="Control.HasFocus(501)">$LOCALIZE[31321]</value>
 		<value condition="Control.HasFocus(502)">$LOCALIZE[31322]</value>


### PR DESCRIPTION
strings.po:
- remove deprecated localizes (31115, 31150, 31152, 31153)

Includes.xml:
- remove deprecated onload conditions

MusicVisualisation.xml:
- remove deprecated onload conditions
- rework visibility conditions of information grouplists for removed fullscreen music player information settings
- fix RDS style label

SkinSettings.xml:
- remove deprecated fullscreen music player information settings

Variables_SkinSettings.xml:
- remove skin settings explanation variables for removed fullscreen music player information settings

Changelog.md:
- update changelog