### PR TITLE
Properly show international titles

### DIFF
--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -191,7 +191,7 @@
 						</control>
 						<control type="fadelabel">
 							<include>DialogVideoInfo_coords7</include>
-							<font>Font36</font>
+							<font>International</font>
 							<label>$INFO[ListItem.OriginalTitle]</label>
 							<textcolor>$VAR[TextColor1]</textcolor>
 						</control>

--- a/xml/Font.xml
+++ b/xml/Font.xml
@@ -242,6 +242,15 @@
 			<linespacing>1.3</linespacing>
 			<style>italics</style>
 		</font>
+		
+		<!-- Original Title -->
+		<font>
+			<name>International</name>
+			<filename>Arial.ttf</filename>
+			<size>31</size>
+			<linespacing>1.3</linespacing>
+			<aspect>0.92</aspect>
+		</font>
 
 		<!-- System Info fixed width -->
 		<font>
@@ -538,6 +547,15 @@
 			<size>20</size>
 			<linespacing>1.3</linespacing>
 			<style>italics</style>
+			<aspect>0.92</aspect>
+		</font>
+		
+		<!-- Original Title -->
+		<font>
+			<name>International</name>
+			<filename>Arial.ttf</filename>
+			<size>31</size>
+			<linespacing>1.3</linespacing>
 			<aspect>0.92</aspect>
 		</font>
 


### PR DESCRIPTION
DialogVideoInfo.xml:
- use new International font for the original title label

Font.xml:
- add new International font for original title label