### PR TITLE
Improvements and fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,15 @@
 
 _New_
 - add ENABLE option for new skinshortcuts version
+- add playback mode (shuffle and repeat) buttons to video OSD
+- add comment tag line to music visualisation
 
 _Improved_
 - improve background overlay colour management of new skin design
 - streamline secondary information and widget detail labels
 - improve weather widget
+- add warning to add-ons currently not available from Kodi repo
+- allow jumping from top to bottom of video playback settings dialog
 
 _Fixed_
 - fix skinshortcuts management dialog
@@ -383,6 +387,7 @@ strings.po:
 - rework skin settings colour localizes (31288, 31290, 31291, 31295)
 - remove deprecated skin settings colour localizes (31292, 31296)
 - rework skin settings localizes (31332, 31412)
+- add warning to add-on descripton of add-ons currently not available from Kodi repo (31340, 31341, 31342, 31347)
 
 Textures.xbt:
 - update textures file with new background overlay media files, reworked OSD ranges image as well as removed deprecated background overlay and dialog media files/folders
@@ -392,6 +397,10 @@ Coordinates_script-skinshortcuts.xml:
 - fix visibility condition of left list button hightlights
 - fix height of right list controls
 
+Coordinates_VideoOSD.xml:
+- adjust width of OSD options for new playback mode buttons
+- add new coordinates for repeat button images
+
 DialogPVRInfo.xml:
 - streamline the way the channel number label is formatted
 
@@ -400,6 +409,9 @@ DialogVideoInfo.xml:
 
 Includes.xml:
 - remove deprecated overlay and skin settings onloads
+
+Includes_DialogSettings.xml:
+- allow jumping from top to bottom of video playback settings dialog
 
 Includes_Time_NowPlaying.xml
 - streamline the way the channel number label is formatted
@@ -411,6 +423,7 @@ MusicVisualisation.xml:
 - streamline the way the channel number label is formatted
 - rework next playing information
 - fix description and plot font
+- add new comment tag line
 
 MyPlaylist.xml:
 - remove deprecated options code
@@ -442,6 +455,9 @@ Variables_SkinSettings.xml:
 VideoFullScreen.xml:
 - fix description and plot font
 - use better localizes for audio and subtitle stream information
+
+VideoOSD.xml:
+- add playback mode (shuffle and repeat) buttons to video OSD
 
 overrides.xml:
 - add new ENABLE option (for new skinshortcuts version)

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR][CR]- add ENABLE option for new skinshortcuts version[CR][B]Improved[/B][CR]- improve background overlay colour management of new skin design[CR]- streamline secondary information and widget detail labels[CR]- improve weather widget[CR][CR][B]Fixed[/B][CR]- fix skinshortcuts management dialog</news>
+		<news>[B]New[/B][CR]- add ENABLE option for new skinshortcuts version[CR]- add playback mode (shuffle and repeat) buttons to video OSD[CR]- add comment tag line to music visualisation[CR][CR][B]Improved[/B][CR]- improve background overlay colour management of new skin design[CR]- streamline secondary information and widget detail labels[CR]- improve weather widget[CR]- add warning to add-ons currently not available from Kodi repo[CR]- allow jumping from top to bottom of video playback settings dialog[CR][CR][B]Fixed[/B][CR]- fix skinshortcuts management dialog</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -715,7 +715,7 @@ msgid "Disable music listened to status in library"
 msgstr ""
 
 #: /SkinSettings.xml
-msgctxt "#31050"
+msgctxt "#31150"
 msgid "Masking colour"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31267"
-msgid "In order to be able to customize the main menu a few add-ons have to be installed first."
+msgid "In order to be able to customize the main menu an add-on has to be installed first."
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1631,17 +1631,17 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31340"
-msgid "Additional customization functions[CR]Required for the following two add-ons"
+msgid "WARNING: This add-on is currently only available from 'Marcelveldt's BETA repository' which has to be installed manually.[CR][CR]Additional customization functions[CR]Required for the following two add-ons"
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31341"
-msgid "Provides extra widgets to customize the main menu"
+msgid "WARNING: This add-on is currently only available from 'Marcelveldt's BETA repository' which has to be installed manually.[CR][CR]Provides extra widgets to customize the main menu"
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31342"
-msgid "Lets you backup and restore your skin settings"
+msgid "WARNING: This add-on is currently only available from 'Marcelveldt's BETA repository' which has to be installed manually.[CR][CR]Lets you backup and restore your skin settings"
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1666,7 +1666,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31347"
-msgid "Backup and restore skin settings"
+msgid "WARNING: The add-on required for this is currently only available from 'Marcelveldt's BETA repository' which has to be installed manually.[CR][CR]Backup and restore skin settings"
 msgstr ""
 
 #: /SkinSettings.xml

--- a/xml/Coordinates_VideoOSD.xml
+++ b/xml/Coordinates_VideoOSD.xml
@@ -217,22 +217,22 @@
 	</include>
 	<include name="VideoOSD_coords9_16:9">
 		<right>0</right>
-		<width>540</width>
+		<width>660</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords9_21:9">
 		<right>0</right>
-		<width>540</width>
+		<width>660</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords9_21:9_masked">
 		<right>0</right>
-		<width>540</width>
+		<width>660</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords9_4:3">
 		<right>0</right>
-		<width>540</width>
+		<width>660</width>
 		<height>60</height>
 	</include>
 	
@@ -243,21 +243,48 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">VideoOSD_coords10_4:3</include>
 	</include>
 	<include name="VideoOSD_coords10_16:9">
-		<right>0</right>
+		<right>660</right>
 		<width>60</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords10_21:9">
-		<right>0</right>
+		<right>660</right>
 		<width>60</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords10_21:9_masked">
-		<right>0</right>
+		<right>660</right>
 		<width>60</width>
 		<height>60</height>
 	</include>
 	<include name="VideoOSD_coords10_4:3">
+		<right>660</right>
+		<width>60</width>
+		<height>60</height>
+	</include>
+	
+	<include name="VideoOSD_coords11">
+		<include condition="$EXP[NonMaskedCoordinates]">VideoOSD_coords11_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">VideoOSD_coords11_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">VideoOSD_coords11_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">VideoOSD_coords11_4:3</include>
+	</include>
+	<include name="VideoOSD_coords11_16:9">
+		<right>0</right>
+		<width>60</width>
+		<height>60</height>
+	</include>
+	<include name="VideoOSD_coords11_21:9">
+		<right>0</right>
+		<width>60</width>
+		<height>60</height>
+	</include>
+	<include name="VideoOSD_coords11_21:9_masked">
+		<right>0</right>
+		<width>60</width>
+		<height>60</height>
+	</include>
+	<include name="VideoOSD_coords11_4:3">
 		<right>0</right>
 		<width>60</width>
 		<height>60</height>

--- a/xml/Includes_DialogSettings.xml
+++ b/xml/Includes_DialogSettings.xml
@@ -152,7 +152,7 @@
 					<itemgap>0</itemgap>
 					<onleft>noop</onleft>
 					<onright>noop</onright>
-					<onup>noop</onup>
+					<onup>5</onup>
 					<ondown>9001</ondown>
 					<orientation>vertical</orientation>
 					<scrolltime tween="sine" easing="out">240</scrolltime>

--- a/xml/MusicOSD.xml
+++ b/xml/MusicOSD.xml
@@ -201,10 +201,12 @@
 					<include>MusicOSD_coords7</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDRandomOffNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDRandomOffNF.png</texturenofocus>
+					<usealttexture>Playlist.IsRandom</usealttexture>
 					<alttexturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDRandomOnNF.png</alttexturefocus>
 					<alttexturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDRandomOnNF.png</alttexturenofocus>
 					<onclick>PlayerControl(Random)</onclick>
 					<visible>!Pvr.IsPlayingRadio</visible>
+					<visible>Integer.IsGreater(MusicPlayer.PlaylistLength,1)</visible>
 				</control>
 				
 				<!-- More information -->
@@ -305,7 +307,7 @@
 					<include>MusicOSD_coords7</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDVizPreNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDVizPreNF.png</texturenofocus>
-					<onclick>ActivateWindow(122)</onclick>
+					<onclick>ActivateWindow(VisualisationPresetlist)</onclick>
 					<visible>Visualisation.Enabled + Visualisation.HasPresets</visible>
 				</control>
 
@@ -315,10 +317,10 @@
 			<control type="group">
 				<include>MusicOSD_coords9</include>
 				<visible>!Pvr.IsPlayingRadio</visible>
-				<animation effect="slide" end="60,0" time="0" condition="!Integer.IsGreater(MusicPlayer.PlaylistLength,1)">Conditional</animation>
+				<animation effect="slide" end="120,0" time="0" condition="!Integer.IsGreater(MusicPlayer.PlaylistLength,1)">Conditional</animation>
 				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(14)">Conditional</animation>
-				<animation effect="slide" end="60,0" time="0" condition="Control.IsVisible(19) + !Control.IsVisible(20)">Conditional</animation>
-				<animation effect="slide" end="120,0" time="0" condition="!Control.IsVisible(19)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(19)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(20)">Conditional</animation>
 
 				<control type="image">
 					<include>MusicOSD_coords7</include>

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -120,6 +120,24 @@
 						</control>
 					</control>
 					
+					<!-- Comment -->
+					<control type="group">
+						<include>MusicVisualisation_coords3</include>
+						<visible>!String.IsEmpty(MusicPlayer.Comment)</visible>
+						<control type="fadelabel">
+							<include>MusicVisualisation_coords4</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>$LOCALIZE[569]</label>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<control type="fadelabel">
+							<include>MusicVisualisation_coords5</include>
+							<font>Font36</font>
+							<label>$INFO[MusicPlayer.Comment]</label>
+						</control>
+					</control>
+					
 					<!-- File information (non-DSD) -->
 					<control type="group">
 						<include>MusicVisualisation_coords3</include>

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -146,7 +146,7 @@
 						<label>31049</label>
 						<font>Font33</font>
 						<onclick>RunScript(script.skinshortcuts,type=manage&amp;group=mainmenu)</onclick>
-						<visible>System.HasAddon(script.skinshortcuts) + System.AddonIsEnabled(script.skinshortcuts)<!--  + System.HasAddon(script.skin.helper.service) + System.AddonIsEnabled(script.skin.helper.service) --></visible>
+						<visible>System.HasAddon(script.skinshortcuts) + System.AddonIsEnabled(script.skinshortcuts)</visible>
 						<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 					</control>
@@ -155,10 +155,8 @@
 						<label>$LOCALIZE[31030]</label>
 						<font>Font33</font>
 						<onclick>InstallAddon(script.skinshortcuts)</onclick>
-						<!-- <onclick>InstallAddon(script.skin.helper.service)</onclick> -->
 						<onclick condition="System.HasAddon(script.skinshortcuts) + !System.AddonIsEnabled(script.skinshortcuts)">EnableAddon(script.skinshortcuts)</onclick>
-						<!-- <onclick condition="System.HasAddon(script.skin.helper.service) + !System.AddonIsEnabled(script.skin.helper.service)">EnableAddon(script.skin.helper.service)</onclick> -->
-						<visible>!System.AddonIsEnabled(script.skinshortcuts)<!--  | !System.AddonIsEnabled(script.skin.helper.service) --></visible>
+						<visible>!System.AddonIsEnabled(script.skinshortcuts)</visible>
 						<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 					</control>
@@ -577,11 +575,11 @@
 					<control type="button" id="322">
 						<include>SkinSettings_coords19</include>
 						<font>Font33</font>
-						<label>$LOCALIZE[31050]</label>
+						<label>$LOCALIZE[31150]</label>
 						<label2>$VAR[MaskingColor-Name]</label2>
 						<onclick condition="!System.HasAddon(script.skin.helper.colorpicker)">InstallAddon(script.skin.helper.colorpicker)</onclick>
 						<onclick condition="System.HasAddon(script.skin.helper.colorpicker) + !System.AddonIsEnabled(script.skin.helper.colorpicker)">EnableAddon(script.skin.helper.colorpicker)</onclick>
-						<onclick condition="System.HasAddon(script.skin.helper.colorpicker) + System.AddonIsEnabled(script.skin.helper.colorpicker)">RunScript(script.skin.helper.colorpicker,skinstring=color.masking,header=$LOCALIZE[31050],palette=rainbow)</onclick>
+						<onclick condition="System.HasAddon(script.skin.helper.colorpicker) + System.AddonIsEnabled(script.skin.helper.colorpicker)">RunScript(script.skin.helper.colorpicker,skinstring=color.masking,header=$LOCALIZE[31150],palette=rainbow)</onclick>
 						<visible>String.IsEqual(Skin.String(DefaultColors),no) + $EXP[Masking]</visible>
 						<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 						<textcolor>$VAR[TextColorNF]</textcolor>

--- a/xml/VideoOSD.xml
+++ b/xml/VideoOSD.xml
@@ -31,7 +31,7 @@
 			<control type="grouplist">
 				<include>VideoOSD_coords4</include>
 				<itemgap>0</itemgap>
-				<onleft>24</onleft>
+				<onleft>26</onleft>
 				<onright>12</onright>
 				<onup>30</onup>
 				<ondown>30</ondown>
@@ -196,9 +196,31 @@
 				<ondown>5</ondown>
 				<onback condition="Player.ShowInfo">Info</onback>
 				<orientation>horizontal</orientation>
-
-				<!-- 3D mode -->
+				
+				<!-- Repeat -->
 				<control type="button" id="12">
+					<include>MusicOSD_coords7</include>
+					<texturefocus></texturefocus>
+					<texturenofocus></texturenofocus>
+					<onclick>PlayerControl(Repeat)</onclick>
+					<visible>!Pvr.IsPlayingTv</visible>
+				</control>
+				
+				<!-- Random -->
+				<control type="togglebutton" id="13">
+					<include>MusicOSD_coords7</include>
+					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDRandomOffNF.png</texturefocus>
+					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDRandomOffNF.png</texturenofocus>
+					<usealttexture>Playlist.IsRandom</usealttexture>
+					<alttexturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDRandomOnNF.png</alttexturefocus>
+					<alttexturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDRandomOnNF.png</alttexturenofocus>
+					<onclick>PlayerControl(Random)</onclick>
+					<visible>!Pvr.IsPlayingTv</visible>
+					<visible>Integer.IsGreater(VideoPlayer.PlaylistLength,1)</visible>
+				</control>
+				
+				<!-- 3D mode -->
+				<control type="button" id="14">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSD3DNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSD3DNF.png</texturenofocus>
@@ -207,7 +229,7 @@
 				</control>
 				
 				<!-- Video Settings -->
-				<control type="button" id="13">
+				<control type="button" id="15">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDVideoNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDVideoNF.png</texturenofocus>
@@ -215,7 +237,7 @@
 				</control>
 				
 				<!-- Audio Settings -->
-				<control type="button" id="14">
+				<control type="button" id="16">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDAudioNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDAudioNF.png</texturenofocus>
@@ -223,7 +245,7 @@
 				</control>
 				
 				<!-- Subtitles -->
-				<control type="button" id="15">
+				<control type="button" id="17">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSubtitlesNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDSubtitlesNF.png</texturenofocus>
@@ -231,7 +253,7 @@
 				</control>
 				
 				<!-- Information -->
-				<control type="button" id="16">
+				<control type="button" id="18">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDInfoNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDInfoNF.png</texturenofocus>
@@ -239,7 +261,7 @@
 				</control>
 				
 				<!-- Bookmarks -->
-				<control type="button" id="17">
+				<control type="button" id="19">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDBookmarksNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDBookmarksNF.png</texturenofocus>
@@ -248,7 +270,7 @@
 				</control>
 				
 				<!-- Playlist -->
-				<control type="button" id="18">
+				<control type="button" id="20">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDPlaylistNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDPlaylistNF.png</texturenofocus>
@@ -258,7 +280,7 @@
 				</control>
 				
 				<!-- Channels -->
-				<control type="button" id="19">
+				<control type="button" id="21">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDChannelNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDChannelNF.png</texturenofocus>
@@ -267,7 +289,7 @@
 				</control>
 				
 				<!-- Channel EPG -->
-				<control type="button" id="20">
+				<control type="button" id="22">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDEPGNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDEPGNF.png</texturenofocus>
@@ -276,7 +298,7 @@
 				</control>
 				
 				<!-- Teletext -->
-				<control type="button" id="21">
+				<control type="button" id="23">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDTextNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDTextNF.png</texturenofocus>
@@ -285,7 +307,7 @@
 				</control>
 				
 				<!-- DVD menu -->
-				<control type="button" id="22">
+				<control type="button" id="24">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDDvdNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDDvdNF.png</texturenofocus>
@@ -294,7 +316,7 @@
 				</control>
 				
 				<!-- Resolution select -->
-				<control type="button" id="23">
+				<control type="button" id="25">
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDResNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDResNF.png</texturenofocus>
@@ -303,7 +325,7 @@
 				</control>
 
 				<!-- Masking -->
-				<control type="button" id="24">
+				<control type="button" id="26">
 					<include>VideoOSD_coords8</include>
 					<texturefocus></texturefocus>
 					<texturenofocus></texturenofocus>
@@ -313,82 +335,131 @@
 
 			</control>
 			
-			<!-- Masking images -->
+			<!-- Repeat images -->
 			<control type="group">
 				<include>VideoOSD_coords10</include>
-				<visible>Control.IsVisible(24)</visible>
+				<visible>!Pvr.IsPlayingTv</visible>
+				<animation effect="slide" end="120,0" time="0" condition="!Integer.IsGreater(VideoPlayer.PlaylistLength,1)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(26)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(25)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(24)">Conditional</animation>
+				<animation effect="slide" end="60,0" time="0" condition="!Control.IsVisible(14)">Conditional</animation>
+
+				<control type="image">
+					<include>VideoOSD_coords8</include>
+					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDRepeatNF.png</texture>
+					<visible>!Playlist.IsRepeat + !Playlist.IsRepeatOne</visible>
+					<visible>!Control.HasFocus(12)</visible>
+				</control>
+				<control type="image">
+					<include>VideoOSD_coords8</include>
+					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDRepeatNF.png</texture>
+					<visible>!Playlist.IsRepeat + !Playlist.IsRepeatOne</visible>
+					<visible>Control.HasFocus(12)</visible>
+				</control>
+				<control type="image">
+					<include>VideoOSD_coords8</include>
+					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDRepeatOneNF.png</texture>
+					<visible>Playlist.IsRepeatOne</visible>
+					<visible>!Control.HasFocus(12)</visible>
+				</control>
+				<control type="image">
+					<include>VideoOSD_coords8</include>
+					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDRepeatOneNF.png</texture>
+					<visible>Playlist.IsRepeatOne</visible>
+					<visible>Control.HasFocus(12)</visible>
+				</control>
+				<control type="image">
+					<include>VideoOSD_coords8</include>
+					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDRepeatAllNF.png</texture>
+					<visible>Playlist.IsRepeat</visible>
+					<visible>!Control.HasFocus(12)</visible>
+				</control>
+				<control type="image">
+					<include>VideoOSD_coords8</include>
+					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDRepeatAllNF.png</texture>
+					<visible>Playlist.IsRepeat</visible>
+					<visible>Control.HasFocus(12)</visible>
+				</control>
+
+			</control>
+			
+			<!-- Masking images -->
+			<control type="group">
+				<include>VideoOSD_coords11</include>
+				<visible>Control.IsVisible(26)</visible>
 
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDMask240NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.40:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(24)</visible>
+					<visible>!Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDMask240NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.40:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(24)</visible>
+					<visible>Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDMask235NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.35:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(24)</visible>
+					<visible>!Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDMask235NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.35:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(24)</visible>
+					<visible>Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDMask233NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.33:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(24)</visible>
+					<visible>!Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDMask233NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.33:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(24)</visible>
+					<visible>Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDMask200NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.00:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(24)</visible>
+					<visible>!Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDMask200NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),2.00:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(24)</visible>
+					<visible>Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDMask178NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),1.78:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(24)</visible>
+					<visible>!Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDMask178NF.png</texture>
 					<visible>String.IsEqual(Skin.String(MaskingBars),1.78:1) + [!Skin.HasSetting(AutomaticMasking) | Skin.HasSetting(AutomaticMasking) + !String.Contains(Player.FileName,-AR178-) + !String.Contains(Player.FileName,-AR178.) + !String.Contains(Player.FileName,-AR178_) + !String.Contains(Player.FileName,.AR178-) + !String.Contains(Player.FileName,.AR178.) + !String.Contains(Player.FileName,.AR178_) + !String.Contains(Player.FileName,_AR178-) + !String.Contains(Player.FileName,_AR178.) + !String.Contains(Player.FileName,_AR178_) + !String.Contains(Player.FileName,-AR200-) + !String.Contains(Player.FileName,-AR200.) + !String.Contains(Player.FileName,-AR200_) + !String.Contains(Player.FileName,.AR200-) + !String.Contains(Player.FileName,.AR200.) + !String.Contains(Player.FileName,.AR200_) + !String.Contains(Player.FileName,_AR200-) + !String.Contains(Player.FileName,_AR200.) + !String.Contains(Player.FileName,_AR200_) + !String.Contains(Player.FileName,-AR233-) + !String.Contains(Player.FileName,-AR233.) + !String.Contains(Player.FileName,-AR233_) + !String.Contains(Player.FileName,.AR233-) + !String.Contains(Player.FileName,.AR233.) + !String.Contains(Player.FileName,.AR233_) + !String.Contains(Player.FileName,_AR233-) + !String.Contains(Player.FileName,_AR233.) + !String.Contains(Player.FileName,_AR233_) + !String.Contains(Player.FileName,-AR235-) + !String.Contains(Player.FileName,-AR235.) + !String.Contains(Player.FileName,-AR235_) + !String.Contains(Player.FileName,.AR235-) + !String.Contains(Player.FileName,.AR235.) + !String.Contains(Player.FileName,.AR235_) + !String.Contains(Player.FileName,_AR235-) + !String.Contains(Player.FileName,_AR235.) + !String.Contains(Player.FileName,_AR235_) + !String.Contains(Player.FileName,-AR240-) + !String.Contains(Player.FileName,-AR240.) + !String.Contains(Player.FileName,-AR240_) + !String.Contains(Player.FileName,.AR240-) + !String.Contains(Player.FileName,.AR240.) + !String.Contains(Player.FileName,.AR240_) + !String.Contains(Player.FileName,_AR240-) + !String.Contains(Player.FileName,_AR240.) + !String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(24)</visible>
+					<visible>Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorNF]">osd/OSDMaskAutoNF.png</texture>
 					<visible>Skin.HasSetting(AutomaticMasking) + [String.Contains(Player.FileName,-AR178-) | String.Contains(Player.FileName,-AR178.) | String.Contains(Player.FileName,-AR178_) | String.Contains(Player.FileName,.AR178-) | String.Contains(Player.FileName,.AR178.) | String.Contains(Player.FileName,.AR178_) | String.Contains(Player.FileName,_AR178-) | String.Contains(Player.FileName,_AR178.) | String.Contains(Player.FileName,_AR178_) | String.Contains(Player.FileName,-AR235-) | String.Contains(Player.FileName,-AR235.) | String.Contains(Player.FileName,-AR235_) | String.Contains(Player.FileName,.AR235-) | String.Contains(Player.FileName,.AR235.) | String.Contains(Player.FileName,.AR235_) | String.Contains(Player.FileName,_AR235-) | String.Contains(Player.FileName,_AR235.) | String.Contains(Player.FileName,_AR235_) | String.Contains(Player.FileName,-AR233-) | String.Contains(Player.FileName,-AR233.) | String.Contains(Player.FileName,-AR233_) | String.Contains(Player.FileName,.AR233-) | String.Contains(Player.FileName,.AR233.) | String.Contains(Player.FileName,.AR233_) | String.Contains(Player.FileName,_AR233-) | String.Contains(Player.FileName,_AR233.) | String.Contains(Player.FileName,_AR233_) | String.Contains(Player.FileName,-AR200-) | String.Contains(Player.FileName,-AR200.) | String.Contains(Player.FileName,-AR200_) | String.Contains(Player.FileName,.AR200-) | String.Contains(Player.FileName,.AR200.) | String.Contains(Player.FileName,.AR200_) | String.Contains(Player.FileName,_AR200-) | String.Contains(Player.FileName,_AR200.) | String.Contains(Player.FileName,_AR200_) | String.Contains(Player.FileName,-AR240-) | String.Contains(Player.FileName,-AR240.) | String.Contains(Player.FileName,-AR240_) | String.Contains(Player.FileName,.AR240-) | String.Contains(Player.FileName,.AR240.) | String.Contains(Player.FileName,.AR240_) | String.Contains(Player.FileName,_AR240-) | String.Contains(Player.FileName,_AR240.) | String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>!Control.HasFocus(24)</visible>
+					<visible>!Control.HasFocus(26)</visible>
 				</control>
 				<control type="image">
 					<include>VideoOSD_coords8</include>
 					<texture colordiffuse="$VAR[OverlayColorFO]">osd/OSDMaskAutoNF.png</texture>
 					<visible>Skin.HasSetting(AutomaticMasking) + [String.Contains(Player.FileName,-AR178-) | String.Contains(Player.FileName,-AR178.) | String.Contains(Player.FileName,-AR178_) | String.Contains(Player.FileName,.AR178-) | String.Contains(Player.FileName,.AR178.) | String.Contains(Player.FileName,.AR178_) | String.Contains(Player.FileName,_AR178-) | String.Contains(Player.FileName,_AR178.) | String.Contains(Player.FileName,_AR178_) | String.Contains(Player.FileName,-AR235-) | String.Contains(Player.FileName,-AR235.) | String.Contains(Player.FileName,-AR235_) | String.Contains(Player.FileName,.AR235-) | String.Contains(Player.FileName,.AR235.) | String.Contains(Player.FileName,.AR235_) | String.Contains(Player.FileName,_AR235-) | String.Contains(Player.FileName,_AR235.) | String.Contains(Player.FileName,_AR235_) | String.Contains(Player.FileName,-AR233-) | String.Contains(Player.FileName,-AR233.) | String.Contains(Player.FileName,-AR233_) | String.Contains(Player.FileName,.AR233-) | String.Contains(Player.FileName,.AR233.) | String.Contains(Player.FileName,.AR233_) | String.Contains(Player.FileName,_AR233-) | String.Contains(Player.FileName,_AR233.) | String.Contains(Player.FileName,_AR233_) | String.Contains(Player.FileName,-AR200-) | String.Contains(Player.FileName,-AR200.) | String.Contains(Player.FileName,-AR200_) | String.Contains(Player.FileName,.AR200-) | String.Contains(Player.FileName,.AR200.) | String.Contains(Player.FileName,.AR200_) | String.Contains(Player.FileName,_AR200-) | String.Contains(Player.FileName,_AR200.) | String.Contains(Player.FileName,_AR200_) | String.Contains(Player.FileName,-AR240-) | String.Contains(Player.FileName,-AR240.) | String.Contains(Player.FileName,-AR240_) | String.Contains(Player.FileName,.AR240-) | String.Contains(Player.FileName,.AR240.) | String.Contains(Player.FileName,.AR240_) | String.Contains(Player.FileName,_AR240-) | String.Contains(Player.FileName,_AR240.) | String.Contains(Player.FileName,_AR240_)]</visible>
-					<visible>Control.HasFocus(24)</visible>
+					<visible>Control.HasFocus(26)</visible>
 				</control>
 
 			</control>

--- a/xml/script-skinshortcuts.xml
+++ b/xml/script-skinshortcuts.xml
@@ -285,12 +285,13 @@
 				</control>
 
 				<!-- Change label-->
-				<!-- <control type="button" id="604">
+				<control type="button" id="604">
 					<include>script-skinshortcuts_coords7</include>
 					<label>  -  $LOCALIZE[528]</label>
                     <onclick>RunScript(script.skin.helper.service,action=setskinshortcutsproperty,header=$LOCALIZE[528],property=widgetName)</onclick>
                     <visible>String.EndsWith(Window.Property(groupname),.1)</visible>
-				</control> -->
+					<visible>System.HasAddon(script.skin.helper.service)</visible>
+				</control>
 				
 				<!-- Change layout -->
 				<control type="button" id="601">


### PR DESCRIPTION
strings.po:
- fix localize ID (31050 -> 31150)
- remove hint to Skin Helper Service script from home menu customization option (31267)
- add warning to add-on descripton of add-ons currently not available from Kodi repo (31340, 31341, 31342, 31347)

Coordinates_VideoOSD.xml:
- adjust width of OSD options for new playback mode buttons
- add new coordinates for repeat button images

Includes_DialogSettings.xml:
- allow jumping from top to bottom of video playback settings dialog

MusicOSD.xml:
- fix behaviour of random playback mode button to change correct texture when random mode is toggled outside the music OSD
- update visualisation presets list button to use text window ID
- improve repeat images animations

MusicVisualisation.xml:
- add new comment tag line

script-skinshortcuts.xml:
- add back change label button, if Skin Helper Service script is installed

SkinSettings.xml:
- remove Skin Helper Service Script as requirement for home menu customization entirely
- fix localize used for custom masking colour option

VideoOSD.xml:
- add playback mode (shuffle and repeat) buttons to video OSD

addon.xml:
- update changelog

Changelog.md:
- update changelog