### PR TITLE
Improve behaviour of OSD bookmarks dialog, general OSD improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@
 _New_
 - add new video/music OSD seek slider button functionality (also adds frame advance feature)
 
+_Improved_
+- improve behaviour of OSD bookmarks dialog while other OSD dialogs are open (similar to previous OSD animation improvements)
+
 _Fixed_
 - fix initial focus in all windows and dialogs
 
@@ -410,6 +413,13 @@ Coordinates_MusicVisualisation.xml:
 Coordinates_VideoFullScreen.xml:
 - add new coordinates for seek button indicators
 
+DialogFullScreenInfo.xml:
+- add new onloads for other OSD animations to rely on
+
+DialogSeekBar.xml:
+- add new onloads for other OSD animations to rely on
+- add new OSD bookmarks dialog related animations
+
 Includes_Windows_Dialog.xml:
 - add new WindowDialogFocus include for window and dialog focus fix
 
@@ -422,10 +432,17 @@ MusicVisualisation.xml:
 
 VideoFullScreen.xml:
 - add new seek slider controls for new video OSD seek slider button
+- add new onloads for other OSD animations to rely on
+- add new OSD bookmarks dialog related animations
+- add visible condition to now playing information to be hidden while OSD bookmarks are open
 
 VideoOSD.xml:
 - add new onload/onunload for new video OSD seek slider button
 - change controls onup tags to navigate to new video OSD seek slider button
+
+VideoOSDBookmarks.xml:
+- add new onloads for other OSD animations to rely on
+- add delayed window open animations for correct behaviour with other OSD dialogs
 
 addon.xml:
 - bump version to 19.1.1

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new video/music OSD seek slider button functionality (also adds frame advance feature)[CR][CR][B]Fixed[/B][CR]- fix initial focus in all windows and dialogs</news>
+		<news>[B]New[/B][CR]- add new video/music OSD seek slider button functionality (also adds frame advance feature)[CR][CR][B]Improved[/B][CR]- improve behaviour of OSD bookmarks dialog while other OSD dialogs are open (similar to previous OSD animation improvements)[CR][CR][B]Fixed[/B][CR]- fix initial focus in all windows and dialogs</news>
 	</extension>
 </addon>

--- a/xml/Coordinates_VideoOSDBookmarks.xml
+++ b/xml/Coordinates_VideoOSDBookmarks.xml
@@ -60,6 +60,7 @@
 				<height>44</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+				<font>Font33</font>
 			</control>
 		</itemlayout>
 	</include>
@@ -85,6 +86,7 @@
 				<height>44</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+				<font>Font33</font>
 			</control>
 		</itemlayout>
 	</include>
@@ -110,6 +112,7 @@
 				<height>44</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+				<font>Font33</font>
 			</control>
 		</itemlayout>
 	</include>
@@ -135,6 +138,7 @@
 				<height>44</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+				<font>Font33</font>
 			</control>
 		</itemlayout>
 	</include>
@@ -160,27 +164,27 @@
 				<aspectratio align="center" aligny="center">keep</aspectratio>
 				<texture background="true">$INFO[ListItem.Icon]</texture>
 			</control>
-			<control type="label">
-				<left>10</left>
-				<top>190</top>
-				<width>304</width>
-				<height>44</height>
-				<scroll>True</scroll>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+			<control type="group">
 				<include content="NonFocusFadeAnimation">
 					<param name="id">11</param>
 				</include>
-			</control>
-			<control type="image">
-				<left>10</left>
-				<top>196</top>
-				<width>304</width>
-				<height>44</height>
-				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
-				<include content="NonFocusFadeAnimation">
-					<param name="id">11</param>
-				</include>
+				<control type="label">
+					<left>10</left>
+					<top>190</top>
+					<width>304</width>
+					<height>44</height>
+					<scroll>True</scroll>
+					<textcolor>$VAR[TextColorFO]</textcolor>
+					<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+					<font>Font33</font>
+				</control>
+				<control type="image">
+					<left>10</left>
+					<top>196</top>
+					<width>304</width>
+					<height>44</height>
+					<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
+				</control>
 			</control>
 		</focusedlayout>
 	</include>
@@ -199,27 +203,27 @@
 				<aspectratio align="center" aligny="center">keep</aspectratio>
 				<texture background="true">$INFO[ListItem.Icon]</texture>
 			</control>
-			<control type="label">
-				<left>9</left>
-				<top>190</top>
-				<width>304</width>
-				<height>44</height>
-				<scroll>True</scroll>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+			<control type="group">
 				<include content="NonFocusFadeAnimation">
 					<param name="id">11</param>
 				</include>
-			</control>
-			<control type="image">
-				<left>9</left>
-				<top>196</top>
-				<width>304</width>
-				<height>44</height>
-				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
-				<include content="NonFocusFadeAnimation">
-					<param name="id">11</param>
-				</include>
+				<control type="label">
+					<left>9</left>
+					<top>190</top>
+					<width>304</width>
+					<height>44</height>
+					<scroll>True</scroll>
+					<textcolor>$VAR[TextColorFO]</textcolor>
+					<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+					<font>Font33</font>
+				</control>
+				<control type="image">
+					<left>9</left>
+					<top>196</top>
+					<width>304</width>
+					<height>44</height>
+					<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
+				</control>
 			</control>
 		</focusedlayout>
 	</include>
@@ -238,27 +242,27 @@
 				<aspectratio align="center" aligny="center">keep</aspectratio>
 				<texture background="true">$INFO[ListItem.Icon]</texture>
 			</control>
-			<control type="label">
-				<left>9</left>
-				<top>190</top>
-				<width>304</width>
-				<height>44</height>
-				<scroll>True</scroll>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+			<control type="group">
 				<include content="NonFocusFadeAnimation">
 					<param name="id">11</param>
 				</include>
-			</control>
-			<control type="image">
-				<left>9</left>
-				<top>196</top>
-				<width>304</width>
-				<height>44</height>
-				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
-				<include content="NonFocusFadeAnimation">
-					<param name="id">11</param>
-				</include>
+				<control type="label">
+					<left>9</left>
+					<top>190</top>
+					<width>304</width>
+					<height>44</height>
+					<scroll>True</scroll>
+					<textcolor>$VAR[TextColorFO]</textcolor>
+					<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+					<font>Font33</font>
+				</control>
+				<control type="image">
+					<left>9</left>
+					<top>196</top>
+					<width>304</width>
+					<height>44</height>
+					<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
+				</control>
 			</control>
 		</focusedlayout>
 	</include>
@@ -277,27 +281,27 @@
 				<aspectratio align="center" aligny="center">keep</aspectratio>
 				<texture background="true">$INFO[ListItem.Icon]</texture>
 			</control>
-			<control type="label">
-				<left>38</left>
-				<top>190</top>
-				<width>304</width>
-				<height>44</height>
-				<scroll>True</scroll>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+			<control type="group">
 				<include content="NonFocusFadeAnimation">
 					<param name="id">11</param>
 				</include>
-			</control>
-			<control type="image">
-				<left>38</left>
-				<top>196</top>
-				<width>304</width>
-				<height>44</height>
-				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
-				<include content="NonFocusFadeAnimation">
-					<param name="id">11</param>
-				</include>
+				<control type="label">
+					<left>38</left>
+					<top>190</top>
+					<width>304</width>
+					<height>44</height>
+					<scroll>True</scroll>
+					<textcolor>$VAR[TextColorFO]</textcolor>
+					<label>($INFO[ListItem.Label2]) - $INFO[ListItem.Label]</label>
+					<font>Font33</font>
+				</control>
+				<control type="image">
+					<left>38</left>
+					<top>196</top>
+					<width>304</width>
+					<height>44</height>
+					<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus44]</texture>
+				</control>
 			</control>
 		</focusedlayout>
 	</include>
@@ -393,16 +397,16 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">VideoOSDBookmarks_coords7_4:3</include>
 	</include>
 	<include name="VideoOSDBookmarks_coords7_16:9">
-		<width>520</width>
+		<width>385</width>
 	</include>
 	<include name="VideoOSDBookmarks_coords7_21:9">
-		<width>733</width>
+		<width>545</width>
 	</include>
 	<include name="VideoOSDBookmarks_coords7_21:9_masked">
-		<width>733</width>
+		<width>545</width>
 	</include>
 	<include name="VideoOSDBookmarks_coords7_4:3">
-		<width>360</width>
+		<width>265</width>
 	</include>
 
 </includes>

--- a/xml/DialogFullScreenInfo.xml
+++ b/xml/DialogFullScreenInfo.xml
@@ -5,6 +5,9 @@
 	<include content="WindowDialogFocus">
 		<param name="id">100</param>
 	</include>
+	<onload>ClearProperty(FullScreenInfo,True,12005)</onload>
+	<onload>SetProperty(FullScreenInfo,True,12005)</onload>
+	<onunload>ClearProperty(FullScreenInfo,12005)</onunload>
 
 	<controls>
 	

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -903,7 +903,6 @@
 				<control type="button" id="13">
 					<width>auto</width>
 					<font>Font36</font>
-					<align>center</align>
 					<onclick condition="Window.IsVisible(10135)">Dialog.Close(10135)</onclick>
 					<onclick condition="Window.IsVisible(12001)">Dialog.Close(12001)</onclick>
 					<label>$LOCALIZE[15067]</label>

--- a/xml/DialogSeekBar.xml
+++ b/xml/DialogSeekBar.xml
@@ -5,18 +5,23 @@
 	<visible>[Player.Seeking | Player.DisplayAfterSeek + !Player.Paused | Player.Forwarding | Player.Rewinding | Player.IsTempo | !String.IsEmpty(Player.SeekNumeric) | Player.Paused + String.IsEqual(Skin.String(HideOSD),Always) | Player.Paused + !System.IdleTime(5) + String.IsEqual(Skin.String(HideOSD),5s) | Player.Paused + !System.IdleTime(10) + String.IsEqual(Skin.String(HideOSD),10s) | Player.Paused + !System.IdleTime(20) + String.IsEqual(Skin.String(HideOSD),20s) | Player.Paused + !System.IdleTime(30) + String.IsEqual(Skin.String(HideOSD),30s) | Player.Paused + !System.IdleTime(60) + String.IsEqual(Skin.String(HideOSD),1 min) | Player.Paused + !System.IdleTime(120) + String.IsEqual(Skin.String(HideOSD),2 min) | Player.Paused + !System.IdleTime(180) + String.IsEqual(Skin.String(HideOSD),3 min) | Player.Paused + !System.IdleTime(300) + String.IsEqual(Skin.String(HideOSD),5 min)] + !Window.IsVisible(subtitlesearch) + !Window.IsVisible(gamevideofilter) + !Window.IsVisible(gamestretchmode) + !Window.IsVisible(gamevideorotation) + !Window.IsVisible(gameosd)</visible>
 	<visible>VideoPlayer.IsFullscreen | Window.IsVisible(visualisation)</visible>
 	<zorder>0</zorder>
+	<onload>ClearProperty(SeekBar,True,12005)</onload>
+	<onload>SetProperty(SeekBar,True,12005)</onload>
+	<onunload>ClearProperty(SeekBar,12005)</onunload>
 
 	<controls>
-
+		
 		<control type="group">
 			<include>DialogDepth</include>
 			<include>DialogSeekBar_coords1</include>
 				
 			<control type="group">
 				<include>DialogSeekBar_coords2</include>
-				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDFresh)">Conditional</animation>
-				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDFresh)">Conditional</animation>
+				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDFresh) | Window.IsVisible(videobookmarks) + !Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDBookmarksFresh)">Conditional</animation>
+				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDFresh) | Window.IsVisible(videobookmarks) + !Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksFresh)">Conditional</animation>
 				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(VideoOSD)">Conditional</animation>
+				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(videobookmarks) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksVideoInfo)">Conditional</animation>
+				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(videobookmarks) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksSeekBar)">Conditional</animation>
 				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(MusicOSD) + String.IsEmpty(Window(12006).Property(MusicOSDFresh)">Conditional</animation>
 				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(MusicOSD) + !String.IsEmpty(Window(12006).Property(MusicOSDFresh)">Conditional</animation>
 				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(MusicOSD)">Conditional</animation>

--- a/xml/VideoFullScreen.xml
+++ b/xml/VideoFullScreen.xml
@@ -3,6 +3,10 @@
 	<!-- fullscreenvideo -->
 	<defaultcontrol></defaultcontrol>
 	<onload>ClearProperty(VideoOSDFresh,12005)</onload>
+	<onload>ClearProperty(VideoOSDBookmarksFresh,12005)</onload>
+	<onunload>ClearProperty(SeekBar,12005)</onunload>
+	<onload>ClearProperty(VideoOSDBookmarksSeekBar,12005)</onload>
+	<onload>ClearProperty(FullScreenInfo,True,12005)</onload>
 	<onload condition="!String.IsEmpty(Window(12005).Property(shownext))">ClearProperty(shownext,12005)</onload>
 	<onload condition="!String.IsEmpty(Window(12005).Property(videoinfostart))">ClearProperty(videoinfostart,12005)</onload>
 	<onload condition="Skin.HasSetting(videoinfostart) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfostartmovies) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfostarttvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfostartmusicvideo) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfostartfiles) | VideoPlayer.Content(livetv) + Skin.HasSetting(videoinfostartlivetv)]">SetProperty(videoinfostart,True,12005)</onload>
@@ -12,6 +16,11 @@
 	<onload condition="Skin.HasSetting(videoinfostart) + String.IsEqual(Skin.String(videoinfostartduration),20s)">AlarmClock(videoplaybackinfo,ClearProperty(videoinfostart,12005),00:20,silent)</onload>
 	<onunload>ClearProperty(videoinfostart,12005)</onunload>
 	<onunload>ClearProperty(VideoOSDFresh,12005)</onunload>
+	<onunload>ClearProperty(VideoOSDBookmarksFresh,12005)</onunload>
+	<onunload>ClearProperty(SeekBar,12005)</onunload>
+	<onunload>ClearProperty(FullScreenInfo,12005)</onunload>
+	<onunload>ClearProperty(VideoOSDBookmarksSeekBar,12005)</onunload>
+	<onunload>ClearProperty(VideoOSDBookmarksVideoInfo,12005)</onunload>
 
 	<controls>
 		
@@ -54,10 +63,12 @@
 			<!-- Playback progress information -->
 			<control type="group" id="1">
 				<include>VideoFullScreen_coords6</include>
-				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDFresh)">Conditional</animation>
-				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDFresh)">Conditional</animation>
+				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDFresh) | Window.IsVisible(videobookmarks) + !Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDBookmarksFresh)">Conditional</animation>
+				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDFresh) | Window.IsVisible(videobookmarks) + !Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksFresh)">Conditional</animation>
 				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(VideoOSD)">Conditional</animation>
-				<visible>Window.IsActive(seekbar) | Window.IsActive(fullscreeninfo) | Window.IsActive(VideoOSD)</visible>
+				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(videobookmarks) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksVideoInfo)">Conditional</animation>
+				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(videobookmarks) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksSeekBar)">Conditional</animation>
+				<visible>Window.IsActive(seekbar) | Window.IsActive(fullscreeninfo) | Window.IsActive(VideoOSD) | Window.IsActive(videobookmarks)</visible>
 				<visible>!Window.IsActive(playerprocessinfo) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(teletext) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(1105) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
 				<include>OSDVisibleHiddenAnimation</include>
 				<include>WindowFadeAnimation</include>
@@ -356,7 +367,7 @@
 			<control type="group" id="1">
 				<include>VideoFullScreen_coords25</include>
 				<visible>Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(12005).Property(videoinfostart)) | [!Pvr.IsPlayingTv + [[Integer.IsLessOrEqual(Player.TimeRemaining(secs),20) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfoendmovie) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfoendtvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfoendmusicvideo) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfoendfiles)] + Skin.HasSetting(videoinfoend) + String.IsEqual(Skin.String(videoinfoendduration),20s)] | [Integer.IsLessOrEqual(Player.TimeRemaining(secs),15) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfoendmovie) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfoendtvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfoendmusicvideo) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfoendfiles)] + Skin.HasSetting(videoinfoend) + String.IsEqual(Skin.String(videoinfoendduration),15s)] | [Integer.IsLessOrEqual(Player.TimeRemaining(secs),10) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfoendmovie) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfoendtvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfoendmusicvideo) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfoendfiles)] + Skin.HasSetting(videoinfoend) + String.IsEqual(Skin.String(videoinfoendduration),10s)] | [Integer.IsLessOrEqual(Player.TimeRemaining(secs),5) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfoendmovie) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfoendtvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfoendmusicvideo) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfoendfiles)] + Skin.HasSetting(videoinfoend) + String.IsEqual(Skin.String(videoinfoendduration),5s)] | [Integer.IsLessOrEqual(Player.Time(secs),20) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfostartmovies) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfostarttvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfostartmusicvideo) | Pvr.IsPlayingTv + Skin.HasSetting(videoinfostartlivetv) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfostartfiles)] + Skin.HasSetting(videoinfostart) + String.IsEqual(Skin.String(videoinfostartduration),20s)] | [Integer.IsLessOrEqual(Player.Time(secs),15) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfostartmovies) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfostarttvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfostartmusicvideo) | Pvr.IsPlayingTv + Skin.HasSetting(videoinfostartlivetv) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfostartfiles)] + Skin.HasSetting(videoinfostart) + String.IsEqual(Skin.String(videoinfostartduration),15s)] | [Integer.IsLessOrEqual(Player.Time(secs),10) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfostartmovies) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfostarttvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfostartmusicvideo) | Pvr.IsPlayingTv + Skin.HasSetting(videoinfostartlivetv) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfostartfiles)] + Skin.HasSetting(videoinfostart) + String.IsEqual(Skin.String(videoinfostartduration),10s)] | [Integer.IsLessOrEqual(Player.Time(secs),5) + [VideoPlayer.Content(movies) + Skin.HasSetting(videoinfostartmovies) | VideoPlayer.Content(episodes) + Skin.HasSetting(videoinfostarttvshow) | VideoPlayer.Content(musicvideos) + Skin.HasSetting(videoinfostartmusicvideo) | Pvr.IsPlayingTv + Skin.HasSetting(videoinfostartlivetv) | VideoPlayer.Content(files) + Skin.HasSetting(videoinfostartfiles)] + Skin.HasSetting(videoinfostart) + String.IsEqual(Skin.String(videoinfostartduration),5s)]]]</visible>
-				<visible>!Window.IsActive(playerprocessinfo) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(teletext) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(1105) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
+				<visible>!Window.IsVisible(videobookmarks) + !Window.IsActive(playerprocessinfo) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(teletext) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(1105) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
 				<include>OSDVisibleHiddenAnimation</include>
 				<include>WindowFadeAnimation</include>
 

--- a/xml/VideoOSD.xml
+++ b/xml/VideoOSD.xml
@@ -291,7 +291,8 @@
 					<include>VideoOSD_coords8</include>
 					<texturefocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDInfoNF.png</texturefocus>
 					<texturenofocus colordiffuse="$VAR[OverlayColorNF]">osd/OSDInfoNF.png</texturenofocus>
-					<onclick>Info</onclick>
+					<onclick condition="!Window.IsVisible(fullscreeninfo)">Info</onclick>
+					<onclick condition="Window.IsVisible(fullscreeninfo)">Dialog.Close(fullscreeninfo)</onclick>
 				</control>
 				
 				<!-- Bookmarks -->

--- a/xml/VideoOSDBookmarks.xml
+++ b/xml/VideoOSDBookmarks.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
 	<!-- videobookmarks -->
-	<defaultcontrol always="true">2</defaultcontrol>
+	<defaultcontrol always="true">1</defaultcontrol>
 	<include content="WindowDialogFocus">
-		<param name="id">2</param>
+		<param name="id">1</param>
 	</include>
+	<onload>ClearProperty(VideoOSDBookmarksFresh,12005)</onload>
+	<onload>ClearProperty(VideoOSDBookmarksSeekBar,12005)</onload>
+	<onload>ClearProperty(VideoOSDBookmarksVideoInfo,12005)</onload>
+	<onload condition="!Window.IsVisible(seekbar) + !Window.IsVisible(fullscreeninfo)">SetProperty(VideoOSDBookmarksFresh,True,12005)</onload>
+	<onunload>ClearProperty(VideoOSDBookmarksFresh,12005)</onunload>
+	<onunload condition="Window.IsVisible(seekbar)">SetProperty(VideoOSDBookmarksSeekBar,12005)</onunload>
+	<onunload condition="Window.IsVisible(seekbar)">AlarmClock(VideoOSDBookmarksSeekBar,ClearProperty(VideoOSDBookmarksSeekBar,12005),00:01,silent)</onunload>
+	<onunload condition="Window.IsVisible(fullscreeninfo)">SetProperty(VideoOSDBookmarksVideoInfo,True,12005)</onunload>
+	<onunload condition="Window.IsVisible(fullscreeninfo)">AlarmClock(VideoOSDBookmarksVideoInfo,ClearProperty(VideoOSDBookmarksVideoInfo,12005),00:01,silent)</onunload>
 
 	<controls>
 		
+		<!-- Bookmark icon list -->
 		<control type="list" id="11">
 			<include>DialogDepth</include>
 			<include>VideoOSDBookmarks_coords1</include>
@@ -15,12 +25,19 @@
 			<onright>noop</onright>
 			<ondown>9001</ondown>
 			<onup>noop</onup>
+			<oninfo>noop</oninfo>
 			<orientation>horizontal</orientation>
 			<viewtype label="535">list</viewtype>
 			<scrolltime tween="sine" easing="out">240</scrolltime>
-			<animation type="WindowOpen">
-				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
-				<effect type="fade" start="0" end="100" time="200"/>
+			<visible>!Window.IsActive(playerprocessinfo) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(teletext) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(1105) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
+			<include>OSDVisibleHiddenAnimation</include>
+			<animation type="WindowOpen" condition="Window.IsVisible(VideoOSD) | !String.IsEmpty(Window(12005).Property(SeekBar) | !String.IsEmpty(Window(12005).Property(FullScreenInfo)">
+				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200" delay="200" />
+				<effect type="fade" start="0" end="100" time="200" delay="200" />
+			</animation>
+			<animation type="WindowOpen" condition="!Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(SeekBar) + String.IsEmpty(Window(12005).Property(FullScreenInfo)">
+				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200" />
+				<effect type="fade" start="0" end="100" time="200" />
 			</animation>
 			<animation type="WindowClose">
 				<effect type="zoom" start="100" end="90" center="auto" easing="in" time="200"/>
@@ -32,13 +49,20 @@
 			<include>VideoOSDBookmarks_coords3</include>
 
 		</control>
-
+		
+		<!-- Buttons -->
 		<control type="group">
 			<include>DialogDepth</include>
 			<include>VideoOSDBookmarks_coords4</include>
-			<animation type="WindowOpen">
-				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200"/>
-				<effect type="fade" start="0" end="100" time="200"/>
+			<visible>!Window.IsActive(playerprocessinfo) + !Window.IsVisible(DialogSettings.xml) + !Window.IsVisible(PVRChannelGuide) + !Window.IsVisible(pvrosdchannels) + !Window.IsVisible(teletext) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(DialogPVRInfo.xml) + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(1105) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
+			<include>OSDVisibleHiddenAnimation</include>
+			<animation type="WindowOpen" condition="Window.IsVisible(VideoOSD) | !String.IsEmpty(Window(12005).Property(SeekBar) | !String.IsEmpty(Window(12005).Property(FullScreenInfo)">
+				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200" delay="200" />
+				<effect type="fade" start="0" end="100" time="200" delay="200" />
+			</animation>
+			<animation type="WindowOpen" condition="!Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(SeekBar) + String.IsEmpty(Window(12005).Property(FullScreenInfo)">
+				<effect type="zoom" start="90" end="100" center="auto" tween="back" easing="out" time="200" />
+				<effect type="fade" start="0" end="100" time="200" />
 			</animation>
 			<animation type="WindowClose">
 				<effect type="zoom" start="100" end="90" center="auto" easing="in" time="200"/>
@@ -55,28 +79,43 @@
 			<control type="grouplist" id="9001">
 				<include>VideoOSDBookmarks_coords6</include>
 				<itemgap>20</itemgap>
-				<onleft>noop</onleft>
-				<onright>noop</onright>
+				<onleft>9001</onleft>
+				<onright>9001</onright>
 				<onup>11</onup>
 				<ondown>close</ondown>
 				<orientation>horizontal</orientation>
+				
+				<!-- Close -->
+				<control type="button" id="1">
+					<include>VideoOSDBookmarks_coords7</include>
+					<label>15067</label>
+					<font>Font33</font>
+					<onclick>Dialog.Close(videobookmarks)</onclick>
+					<oninfo>noop</oninfo>
+				</control>
 
 				<!-- Create Bookmark button -->
 				<control type="button" id="2">
 					<include>VideoOSDBookmarks_coords7</include>
 					<label>294</label>
+					<font>Font33</font>
+					<oninfo>noop</oninfo>
 				</control>
 
 				<!-- Clear Bookmark button -->
 				<control type="button" id="3">
 					<include>VideoOSDBookmarks_coords7</include>
 					<label>296</label>
+					<font>Font33</font>
+					<oninfo>noop</oninfo>
 				</control>
 
 				<!-- Use current for episode thumb -->
 				<control type="button" id="4">
 					<include>VideoOSDBookmarks_coords7</include>
 					<label>20406</label>
+					<font>Font33</font>
+					<oninfo>noop</oninfo>
 				</control>
 
 			</control>


### PR DESCRIPTION
Coordinates_VideoOSDBookmarks.xml:
- code restructure and fixup

DialogFullScreenInfo.xml:
- add new onloads for other OSD animations to rely on

DialogMusicInfo.xml:
- fix close button alignment

DialogSeekBar.xml:
- add new onloads for other OSD animations to rely on
- add new OSD bookmarks dialog related animations

VideoFullScreen.xml:
- add new onloads for other OSD animations to rely on
- add new OSD bookmarks dialog related animations
- add visible condition to now playing information to be hidden while OSD bookmarks are open

VideoOSD.xml:
- fix information button to work under all circumstances

VideoOSDBookmarks.xml:
- fix defaultcontrol for added close button
- add new onloads for other OSD animations to rely on
- add delayed window open animations for correct behaviour with other OSD dialogs
- add new close button
- prevent info button to open a non-closable video fullscreen playback info dialog

addon.xml:
- update changelog

Changelog.md:
- update changelog