### PR TITLE
Improve addon settings and skinshortcuts customization dialogs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,11 @@
 
 _New_
 - add new video/music OSD seek slider button functionality (also adds frame advance feature)
+- add settings level button and settings description to addon settings dialog
 
 _Improved_
 - improve behaviour of OSD bookmarks dialog while other OSD dialogs are open (similar to previous OSD animation improvements)
+- streamline addon settings and skinshortcuts customization dialogs
 
 _Fixed_
 - fix initial focus in all windows and dialogs
@@ -404,14 +406,40 @@ Release
 
 _fix inital focus in all windows and dialogs_
 
+strings.po:
+- remove line break from skinshortcuts explanation localizes (31353, 31362, 31367, 31370, 31371, 31372, 31373, 31374, 31375, 31377, 31388)
+
 Textures.xbt:
 - update textures file with differently coloured seek indicator icon
+
+Coordinates_Custom_Skin_Shortcuts_Help.xml:
+- rework coordinates for improved skinshortcuts dialog layout
+- add new settings description label coordinates
+- remove deprecated explanation textbox coordinates
+
+Coordinates_DialogAddonSettings.xml:
+- adjust coordinates to streamline addon settings and skinshortcuts dialog layouts
+- rework and add new coordinates for added settings level button and settings description label
+
+Coordinates_DialogVideoInfo.xml:
+- fix coordinates
 
 Coordinates_MusicVisualisation.xml:
 - add new coordinates for seek button indicators
 
+Coordinates_script-skinshortcuts.xml:
+- adjust coordinates to streamline skinshortcuts and addon settings dialog layouts
+- rework coordinates for adjusted settings description label
+- remove deprecated explanation textbox coordinates
+
 Coordinates_VideoFullScreen.xml:
 - add new coordinates for seek button indicators
+
+Custom_Skin_Shortcuts_Help.xml:
+- remove deprecated explanation textbox and add new settings description label
+
+DialogAddonSettings.xml:
+- add new added settings level button and settings description label
 
 DialogFullScreenInfo.xml:
 - add new onloads for other OSD animations to rely on
@@ -429,6 +457,14 @@ MusicOSD.xml:
 
 MusicVisualisation.xml:
 - add new seek slider controls for new music OSD seek slider button
+
+script-skinshortcuts.xml:
+- add missing right list scrollbar
+- adjust right list focus highlight
+- rework settings description label
+
+Variables.xml:
+- adjust addonsettingsbuttonunfocusdim variable for added settings level button
 
 VideoFullScreen.xml:
 - add new seek slider controls for new video OSD seek slider button

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new video/music OSD seek slider button functionality (also adds frame advance feature)[CR][CR][B]Improved[/B][CR]- improve behaviour of OSD bookmarks dialog while other OSD dialogs are open (similar to previous OSD animation improvements)[CR][CR][B]Fixed[/B][CR]- fix initial focus in all windows and dialogs</news>
+		<news>[B]New[/B][CR]- add new video/music OSD seek slider button functionality (also adds frame advance feature)[CR]- add settings level button and settings description to addon settings dialog[CR][CR][B]Improved[/B][CR]- improve behaviour of OSD bookmarks dialog while other OSD dialogs are open (similar to previous OSD animation improvements)[CR]- streamline addon settings and skinshortcuts customization dialogs[CR][CR][B]Fixed[/B][CR]- fix initial focus in all windows and dialogs</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1741,7 +1741,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31353"
-msgid "The order of the items can be changed by using the up and down arrows next to the list items.[CR]Red coloured items are disabled and not visible in the main menu."
+msgid "The order of the items can be changed by using the up and down arrows next to the list items. Red coloured items are disabled and not visible in the main menu."
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1786,7 +1786,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31362"
-msgid "Deletes the selected main menu item completely[CR]Warning: This can be reverted only for default main menu items!"
+msgid "Deletes the selected main menu item completely. Warning: This can be reverted only for default main menu items!"
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1811,7 +1811,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31367"
-msgid "Deletes the selected submenu item completely[CR]Warning: This can be reverted only for default submenu items!"
+msgid "Deletes the selected submenu item completely. Warning: This can be reverted only for default submenu items!"
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1826,32 +1826,32 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31370"
-msgid "Changes the appearance of the widget[CR]Options available: Tall (2:3 aspect ratio, suitable for portrait icons like movie or TV show cover art), Wide (3:4 aspect ratio, suitable for landscape icons like episode cover art), Square and Square small (3:3/2:2 aspect ratio, suitable for square icons like album fanart or PVR channel icons)"
+msgid "Changes the appearance of the widget. Options available: Tall (2:3 aspect ratio, suitable for portrait icons like movie or TV show cover art), Wide (3:4 aspect ratio, suitable for landscape icons like episode cover art), Square and Square small (3:3/2:2 aspect ratio, suitable for square icons like album fanart or PVR channel icons)"
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31371"
-msgid "Changes the artwork used for the widget items[CR]Available options depend on the widget content."
+msgid "Changes the artwork used for the widget items. Available options depend on the widget content."
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31372"
-msgid "Changes the fallback artwork used for the widget items[CR]Available options depend on the widget content."
+msgid "Changes the fallback artwork used for the widget items. Available options depend on the widget content."
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31373"
-msgid "Changes the sort key of the widget items[CR]Available options depend on the widget content."
+msgid "Changes the sort key of the widget items. Available options depend on the widget content."
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31374"
-msgid "Changes the sort order of the widget items[CR]Available options depend on the widget content."
+msgid "Changes the sort order of the widget items. Available options depend on the widget content."
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31375"
-msgid "Changes the maximum number of items shown by the widget[CR]Options available: 10, 15, 20, 25, 30, 50, 100, None (all items available)"
+msgid "Changes the maximum number of items shown by the widget. Options available: 10, 15, 20, 25, 30, 50, 100, None (all items available)"
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1861,7 +1861,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31377"
-msgid "Deletes the selected widget completely[CR]Warning: This can be reverted only for default widgets!"
+msgid "Deletes the selected widget completely. Warning: This can be reverted only for default widgets!"
 msgstr ""
 
 #: /SkinSettings.xml
@@ -1916,7 +1916,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31388"
-msgid "The left list shows the widgets visible next to the main menu item selected in the previous dialog.[CR]There's only one widget visible in the main menu per main menu item at the time. To toggle between more than one widget configured for a main menu item, select the widget in the main menu and use the arrow up and down buttons on your remote."
+msgid "The left list shows the widgets visible next to the main menu item selected in the previous dialog. There's only one widget visible in the main menu per main menu item at the time. To toggle between more than one widget configured for a main menu item, select the widget in the main menu and use the arrow up and down buttons on your remote."
 msgstr ""
 
 #: /SkinSettings.xml

--- a/xml/Coordinates_Custom_Skin_Shortcuts_Help.xml
+++ b/xml/Coordinates_Custom_Skin_Shortcuts_Help.xml
@@ -9,27 +9,27 @@
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords1_16:9">
 		<left>0</left>
-		<width>125</width>
+		<width>100</width>
 		<top>210</top>
-		<bottom>210</bottom>
+		<bottom>190</bottom>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords1_21:9">
 		<left>0</left>
-		<width>125</width>
+		<width>100</width>
 		<top>210</top>
-		<bottom>210</bottom>
+		<bottom>190</bottom>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords1_21:9_masked">
 		<left>0</left>
-		<width>125</width>
+		<width>100</width>
 		<top>390</top>
-		<bottom>390</bottom>
+		<bottom>370</bottom>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords1_4:3">
 		<left>0</left>
-		<width>125</width>
+		<width>100</width>
 		<top>210</top>
-		<bottom>210</bottom>
+		<bottom>190</bottom>
 	</include>
 	
 	<include name="Custom_Skin_Shortcuts_Help_coords2">
@@ -48,13 +48,13 @@
 		<left>0</left>
 		<right>0</right>
 		<top>0</top>
-		<height>210</height>
+		<height>390</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords2_21:9_masked">
 		<left>0</left>
 		<right>0</right>
 		<top>0</top>
-		<height>390</height>
+		<height>370</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords2_4:3">
 		<left>0</left>
@@ -73,25 +73,25 @@
 		<left>0</left>
 		<right>0</right>
 		<bottom>175</bottom>
-		<height>35</height>
+		<height>15</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords3_21:9">
 		<left>0</left>
 		<right>0</right>
 		<bottom>175</bottom>
-		<height>35</height>
+		<height>15</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords3_21:9_masked">
 		<left>0</left>
 		<right>0</right>
 		<bottom>355</bottom>
-		<height>35</height>
+		<height>15</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords3_4:3">
 		<left>0</left>
 		<right>0</right>
 		<bottom>175</bottom>
-		<height>35</height>
+		<height>15</height>
 	</include>
 	
 	<include name="Custom_Skin_Shortcuts_Help_coords4">
@@ -102,27 +102,27 @@
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords4_16:9">
 		<right>0</right>
-		<left>525</left>
+		<left>530</left>
 		<top>210</top>
-		<bottom>210</bottom>
+		<bottom>190</bottom>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords4_21:9">
 		<right>0</right>
-		<left>525</left>
+		<left>530</left>
 		<top>210</top>
-		<bottom>210</bottom>
+		<bottom>190</bottom>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords4_21:9_masked">
 		<right>0</right>
-		<left>525</left>
+		<left>530</left>
 		<top>390</top>
-		<bottom>390</bottom>
+		<bottom>370</bottom>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords4_4:3">
 		<right>0</right>
-		<left>525</left>
+		<left>530</left>
 		<top>210</top>
-		<bottom>210</bottom>
+		<bottom>190</bottom>
 	</include>
 	
 	<include name="Custom_Skin_Shortcuts_Help_coords5">
@@ -134,26 +134,26 @@
 	<include name="Custom_Skin_Shortcuts_Help_coords5_16:9">
 		<left>0</left>
 		<top>210</top>
-		<bottom>360</bottom>
-		<width>525</width>
+		<bottom>236</bottom>
+		<width>550</width>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords5_21:9">
 		<left>0</left>
 		<top>210</top>
-		<bottom>360</bottom>
-		<width>525</width>
+		<bottom>236</bottom>
+		<width>550</width>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords5_21:9_masked">
 		<left>0</left>
 		<top>390</top>
-		<bottom>540</bottom>
-		<width>525</width>
+		<bottom>416</bottom>
+		<width>550</width>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords5_4:3">
 		<left>0</left>
 		<top>210</top>
-		<bottom>360</bottom>
-		<width>525</width>
+		<bottom>236</bottom>
+		<width>550</width>
 	</include>
 	
 	<include name="Custom_Skin_Shortcuts_Help_coords6">
@@ -197,25 +197,25 @@
 		<left>0</left>
 		<right>0</right>
 		<bottom>175</bottom>
-		<height>185</height>
+		<height>61</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords7_21:9">
 		<left>0</left>
 		<right>0</right>
 		<bottom>175</bottom>
-		<height>185</height>
+		<height>61</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords7_21:9_masked">
 		<left>0</left>
 		<right>0</right>
 		<bottom>355</bottom>
-		<height>185</height>
+		<height>61</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords7_4:3">
 		<left>0</left>
 		<right>0</right>
 		<bottom>175</bottom>
-		<height>185</height>
+		<height>61</height>
 	</include>
 	
 	<include name="Custom_Skin_Shortcuts_Help_coords8">
@@ -226,27 +226,27 @@
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords8_16:9">
 		<right>0</right>
-		<bottom>360</bottom>
+		<bottom>236</bottom>
 		<top>210</top>
-		<width>125</width>
+		<width>130</width>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords8_21:9">
 		<right>0</right>
-		<bottom>360</bottom>
+		<bottom>236</bottom>
 		<top>210</top>
-		<width>125</width>
+		<width>130</width>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords8_21:9_masked">
 		<right>0</right>
-		<bottom>540</bottom>
+		<bottom>390</bottom>
 		<top>390</top>
-		<width>125</width>
+		<width>130</width>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords8_4:3">
 		<right>0</right>
-		<bottom>360</bottom>
+		<bottom>236</bottom>
 		<top>210</top>
-		<width>125</width>
+		<width>130</width>
 	</include>
 	
 	<include name="Custom_Skin_Shortcuts_Help_coords9">
@@ -256,90 +256,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Skin_Shortcuts_Help_coords9_4:3</include>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords9_16:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1220</width>
-		<height>94</height>
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>1170</width>
+		<height>36</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords9_21:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1860</width>
-		<height>94</height>
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>1810</width>
+		<height>36</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords9_21:9_masked">
-		<left>550</left>
-		<top>925</top>
-		<width>1860</width>
-		<height>94</height>
+		<left>600</left>
+		<bottom>360</bottom>
+		<width>1810</width>
+		<height>36</height>
 	</include>
 	<include name="Custom_Skin_Shortcuts_Help_coords9_4:3">
-		<left>550</left>
-		<top>745</top>
-		<width>740</width>
-		<height>94</height>
-	</include>
-	
-	<include name="Custom_Skin_Shortcuts_Help_coords10">
-		<include condition="$EXP[NonMaskedCoordinates]">Custom_Skin_Shortcuts_Help_coords10_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Custom_Skin_Shortcuts_Help_coords10_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">Custom_Skin_Shortcuts_Help_coords10_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Skin_Shortcuts_Help_coords10_4:3</include>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords10_16:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1220</width>
-		<height>105</height>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords10_21:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1860</width>
-		<height>105</height>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords10_21:9_masked">
-		<left>550</left>
-		<top>925</top>
-		<width>1860</width>
-		<height>105</height>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords10_4:3">
-		<left>550</left>
-		<top>745</top>
-		<width>740</width>
-		<height>105</height>
-	</include>
-	
-	<include name="Custom_Skin_Shortcuts_Help_coords11">
-		<include condition="$EXP[NonMaskedCoordinates]">Custom_Skin_Shortcuts_Help_coords11_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Custom_Skin_Shortcuts_Help_coords11_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">Custom_Skin_Shortcuts_Help_coords11_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Skin_Shortcuts_Help_coords11_4:3</include>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords11_16:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1220</width>
-		<height>80</height>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords11_21:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1860</width>
-		<height>80</height>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords11_21:9_masked">
-		<left>550</left>
-		<top>925</top>
-		<width>1860</width>
-		<height>80</height>
-	</include>
-	<include name="Custom_Skin_Shortcuts_Help_coords11_4:3">
-		<left>550</left>
-		<top>745</top>
-		<width>740</width>
-		<height>80</height>
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>690</width>
+		<height>36</height>
 	</include>
 
 </includes>

--- a/xml/Coordinates_DialogAddonSettings.xml
+++ b/xml/Coordinates_DialogAddonSettings.xml
@@ -9,27 +9,27 @@
 	</include>
 	<include name="DialogAddonSettings_coords1_16:9">
 		<left>150</left>
-		<top>228</top>
+		<top>210</top>
 		<width>360</width>
-		<height>660</height>
+		<height>594</height>
 	</include>
 	<include name="DialogAddonSettings_coords1_21:9">
 		<left>150</left>
-		<top>228</top>
+		<top>210</top>
 		<width>360</width>
-		<height>660</height>
+		<height>594</height>
 	</include>
 	<include name="DialogAddonSettings_coords1_21:9_masked">
 		<left>150</left>
-		<top>408</top>
+		<top>390</top>
 		<width>360</width>
-		<height>660</height>
+		<height>594</height>
 	</include>
 	<include name="DialogAddonSettings_coords1_4:3">
 		<left>150</left>
-		<top>228</top>
+		<top>210</top>
 		<width>360</width>
-		<height>660</height>
+		<height>594</height>
 	</include>
 	
 	<include name="DialogAddonSettings_coords2">
@@ -63,27 +63,27 @@
 	</include>
 	<include name="DialogAddonSettings_coords3_16:9">
 		<left>120</left>
-		<top>248</top>
+		<top>230</top>
 		<width>20</width>
-		<height>620</height>
+		<height>554</height>
 	</include>
 	<include name="DialogAddonSettings_coords3_21:9">
 		<left>120</left>
-		<top>248</top>
+		<top>230</top>
 		<width>20</width>
-		<height>620</height>
+		<height>554</height>
 	</include>
 	<include name="DialogAddonSettings_coords3_21:9_masked">
 		<left>120</left>
-		<top>428</top>
+		<top>410</top>
 		<width>20</width>
-		<height>620</height>
+		<height>554</height>
 	</include>
 	<include name="DialogAddonSettings_coords3_4:3">
 		<left>120</left>
-		<top>248</top>
+		<top>230</top>
 		<width>20</width>
-		<height>620</height>
+		<height>554</height>
 	</include>
 	
 	<include name="DialogAddonSettings_coords4">
@@ -93,28 +93,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords4_4:3</include>
 	</include>
 	<include name="DialogAddonSettings_coords4_16:9">
-		<left>600</left>
-		<top>228</top>
-		<width>1170</width>
-		<height>660</height>
+		<left>150</left>
+		<top>804</top>
+		<width>360</width>
+		<height>44</height>
 	</include>
 	<include name="DialogAddonSettings_coords4_21:9">
-		<left>600</left>
-		<top>228</top>
-		<width>1810</width>
-		<height>660</height>
+		<left>150</left>
+		<top>804</top>
+		<width>360</width>
+		<height>44</height>
 	</include>
 	<include name="DialogAddonSettings_coords4_21:9_masked">
-		<left>600</left>
-		<top>408</top>
-		<width>1810</width>
-		<height>660</height>
+		<left>150</left>
+		<top>984</top>
+		<width>360</width>
+		<height>44</height>
 	</include>
 	<include name="DialogAddonSettings_coords4_4:3">
-		<left>600</left>
-		<top>228</top>
-		<width>690</width>
-		<height>660</height>
+		<left>150</left>
+		<top>804</top>
+		<width>360</width>
+		<height>44</height>
 	</include>
 	
 	<include name="DialogAddonSettings_coords5">
@@ -124,28 +124,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords5_4:3</include>
 	</include>
 	<include name="DialogAddonSettings_coords5_16:9">
-		<left>570</left>
-		<top>248</top>
-		<width>20</width>
-		<height>620</height>
+		<left>150</left>
+		<top>837</top>
+		<width>360</width>
+		<height>66</height>
 	</include>
 	<include name="DialogAddonSettings_coords5_21:9">
-		<left>570</left>
-		<top>248</top>
-		<width>20</width>
-		<height>620</height>
+		<left>150</left>
+		<top>837</top>
+		<width>360</width>
+		<height>66</height>
 	</include>
 	<include name="DialogAddonSettings_coords5_21:9_masked">
-		<left>570</left>
-		<top>428</top>
-		<width>20</width>
-		<height>620</height>
+		<left>150</left>
+		<top>1017</top>
+		<width>360</width>
+		<height>66</height>
 	</include>
 	<include name="DialogAddonSettings_coords5_4:3">
-		<left>570</left>
-		<top>248</top>
-		<width>20</width>
-		<height>620</height>
+		<left>150</left>
+		<top>837</top>
+		<width>360</width>
+		<height>66</height>
 	</include>
 	
 	<include name="DialogAddonSettings_coords6">
@@ -155,20 +155,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords6_4:3</include>
 	</include>
 	<include name="DialogAddonSettings_coords6_16:9">
+		<left>600</left>
+		<top>210</top>
 		<width>1170</width>
-		<height>66</height>
+		<height>594</height>
 	</include>
 	<include name="DialogAddonSettings_coords6_21:9">
+		<left>600</left>
+		<top>210</top>
 		<width>1810</width>
-		<height>66</height>
+		<height>594</height>
 	</include>
 	<include name="DialogAddonSettings_coords6_21:9_masked">
+		<left>600</left>
+		<top>390</top>
 		<width>1810</width>
-		<height>66</height>
+		<height>594</height>
 	</include>
 	<include name="DialogAddonSettings_coords6_4:3">
+		<left>600</left>
+		<top>210</top>
 		<width>690</width>
-		<height>66</height>
+		<height>594</height>
 	</include>
 	
 	<include name="DialogAddonSettings_coords7">
@@ -178,24 +186,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords7_4:3</include>
 	</include>
 	<include name="DialogAddonSettings_coords7_16:9">
-		<width>1170</width>
-		<height>66</height>
-		<textwidth>1104</textwidth>
+		<left>570</left>
+		<top>248</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	<include name="DialogAddonSettings_coords7_21:9">
-		<width>1810</width>
-		<height>66</height>
-		<textwidth>1744</textwidth>
+		<left>570</left>
+		<top>248</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	<include name="DialogAddonSettings_coords7_21:9_masked">
-		<width>1810</width>
-		<height>66</height>
-		<textwidth>1744</textwidth>
+		<left>570</left>
+		<top>428</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	<include name="DialogAddonSettings_coords7_4:3">
-		<width>690</width>
-		<height>66</height>
-		<textwidth>624</textwidth>
+		<left>570</left>
+		<top>248</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	
 	<include name="DialogAddonSettings_coords8">
@@ -219,6 +231,87 @@
 	<include name="DialogAddonSettings_coords8_4:3">
 		<width>690</width>
 		<height>66</height>
+	</include>
+	
+	<include name="DialogAddonSettings_coords9">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogAddonSettings_coords9_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogAddonSettings_coords9_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogAddonSettings_coords9_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords9_4:3</include>
+	</include>
+	<include name="DialogAddonSettings_coords9_16:9">
+		<width>1170</width>
+		<height>66</height>
+		<textwidth>1104</textwidth>
+	</include>
+	<include name="DialogAddonSettings_coords9_21:9">
+		<width>1810</width>
+		<height>66</height>
+		<textwidth>1744</textwidth>
+	</include>
+	<include name="DialogAddonSettings_coords9_21:9_masked">
+		<width>1810</width>
+		<height>66</height>
+		<textwidth>1744</textwidth>
+	</include>
+	<include name="DialogAddonSettings_coords9_4:3">
+		<width>690</width>
+		<height>66</height>
+		<textwidth>624</textwidth>
+	</include>
+	
+	<include name="DialogAddonSettings_coords10">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogAddonSettings_coords10_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogAddonSettings_coords10_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogAddonSettings_coords10_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords10_4:3</include>
+	</include>
+	<include name="DialogAddonSettings_coords10_16:9">
+		<width>1170</width>
+		<height>66</height>
+	</include>
+	<include name="DialogAddonSettings_coords10_21:9">
+		<width>1810</width>
+		<height>66</height>
+	</include>
+	<include name="DialogAddonSettings_coords10_21:9_masked">
+		<width>1810</width>
+		<height>66</height>
+	</include>
+	<include name="DialogAddonSettings_coords10_4:3">
+		<width>690</width>
+		<height>66</height>
+	</include>
+	
+	<include name="DialogAddonSettings_coords11">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogAddonSettings_coords11_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogAddonSettings_coords11_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogAddonSettings_coords11_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords11_4:3</include>
+	</include>
+	<include name="DialogAddonSettings_coords11_16:9">
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>1170</width>
+		<height>36</height>
+	</include>
+	<include name="DialogAddonSettings_coords11_21:9">
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>1810</width>
+		<height>36</height>
+	</include>
+	<include name="DialogAddonSettings_coords11_21:9_masked">
+		<left>600</left>
+		<bottom>360</bottom>
+		<width>1810</width>
+		<height>36</height>
+	</include>
+	<include name="DialogAddonSettings_coords11_4:3">
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>690</width>
+		<height>36</height>
 	</include>
 
 </includes>

--- a/xml/Coordinates_DialogVideoInfo.xml
+++ b/xml/Coordinates_DialogVideoInfo.xml
@@ -58,9 +58,9 @@
 	</include>
 	<include name="DialogVideoInfo_coords2_4:3">
 		<left>150</left>
-		<top>225</top>
-		<width>405</width>
-		<height>600</height>
+		<bottom>180</bottom>
+		<width>1140</width>
+		<height>36</height>
 	</include>
 	
 	<include name="DialogVideoInfo_coords3">

--- a/xml/Coordinates_SettingsCategory.xml
+++ b/xml/Coordinates_SettingsCategory.xml
@@ -234,27 +234,27 @@
 	</include>
 	<include name="SettingsCategory_coords8_16:9">
 		<left>120</left>
-		<top>944</top>
+		<top>933</top>
 		<width>300</width>
-		<height>52</height>
+		<height>66</height>
 	</include>
 	<include name="SettingsCategory_coords8_21:9">
 		<left>120</left>
-		<top>944</top>
+		<top>933</top>
 		<width>300</width>
-		<height>52</height>
+		<height>66</height>
 	</include>
 	<include name="SettingsCategory_coords8_21:9_masked">
 		<left>120</left>
-		<top>1124</top>
+		<top>1113</top>
 		<width>300</width>
-		<height>52</height>
+		<height>66</height>
 	</include>
 	<include name="SettingsCategory_coords8_4:3">
 		<left>120</left>
-		<top>944</top>
+		<top>933</top>
 		<width>300</width>
-		<height>52</height>
+		<height>66</height>
 	</include>
 	
 	<include name="SettingsCategory_coords9">

--- a/xml/Coordinates_script-skinshortcuts.xml
+++ b/xml/Coordinates_script-skinshortcuts.xml
@@ -10,25 +10,25 @@
 	<include name="script-skinshortcuts_coords1_16:9">
 		<left>150</left>
 		<top>210</top>
-		<width>350</width>
+		<width>360</width>
 		<height>660</height>
 	</include>
 	<include name="script-skinshortcuts_coords1_21:9">
 		<left>150</left>
 		<top>210</top>
-		<width>350</width>
+		<width>360</width>
 		<height>660</height>
 	</include>
 	<include name="script-skinshortcuts_coords1_21:9_masked">
 		<left>150</left>
 		<top>390</top>
-		<width>350</width>
+		<width>360</width>
 		<height>660</height>
 	</include>
 	<include name="script-skinshortcuts_coords1_4:3">
 		<left>150</left>
 		<top>210</top>
-		<width>350</width>
+		<width>360</width>
 		<height>660</height>
 	</include>
 	
@@ -39,9 +39,9 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords2_4:3</include>
 	</include>
 	<include name="script-skinshortcuts_coords2_16:9">
-		<itemlayout width="350" height="66">
+		<itemlayout width="360" height="66">
 			<control type="label">
-				<width>350</width>
+				<width>360</width>
 				<height>66</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>$VAR[skinshortcuts-disableindicator]</label>
@@ -49,9 +49,9 @@
 		</itemlayout>
 	</include>
 	<include name="script-skinshortcuts_coords2_21:9">
-		<itemlayout width="350" height="66">
+		<itemlayout width="360" height="66">
 			<control type="label">
-				<width>350</width>
+				<width>360</width>
 				<height>66</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>$VAR[skinshortcuts-disableindicator]</label>
@@ -59,9 +59,9 @@
 		</itemlayout>
 	</include>
 	<include name="script-skinshortcuts_coords2_21:9_masked">
-		<itemlayout width="350" height="66">
+		<itemlayout width="360" height="66">
 			<control type="label">
-				<width>350</width>
+				<width>360</width>
 				<height>66</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>$VAR[skinshortcuts-disableindicator]</label>
@@ -69,9 +69,9 @@
 		</itemlayout>
 	</include>
 	<include name="script-skinshortcuts_coords2_4:3">
-		<itemlayout width="350" height="66">
+		<itemlayout width="360" height="66">
 			<control type="label">
-				<width>350</width>
+				<width>360</width>
 				<height>66</height>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<label>$VAR[skinshortcuts-disableindicator]</label>
@@ -86,9 +86,9 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords3_4:3</include>
 	</include>
 	<include name="script-skinshortcuts_coords3_16:9">
-		<focusedlayout width="350" height="66">
+		<focusedlayout width="360" height="66">
 			<control type="label">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<scroll>True</scroll>
 				<textcolor>$VAR[TextColorFO]</textcolor>
@@ -96,42 +96,42 @@
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus66]</texture>
 				<visible>!String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="darkred">$VAR[focus66]</texture>
 				<visible>String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownNF.png</texture>
 				<visible>!Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpNF.png</texture>
 				<visible>!Control.HasFocus(303)</visible>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownFO.png</texture>
 				<visible>Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpFO.png</texture>
@@ -140,9 +140,9 @@
 		</focusedlayout>
 	</include>
 	<include name="script-skinshortcuts_coords3_21:9">
-		<focusedlayout width="350" height="66">
+		<focusedlayout width="360" height="66">
 			<control type="label">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<scroll>True</scroll>
 				<textcolor>$VAR[TextColorFO]</textcolor>
@@ -150,42 +150,42 @@
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus66]</texture>
 				<visible>!String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="darkred">$VAR[focus66]</texture>
 				<visible>String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownNF.png</texture>
 				<visible>!Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpNF.png</texture>
 				<visible>!Control.HasFocus(303)</visible>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownFO.png</texture>
 				<visible>Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpFO.png</texture>
@@ -194,9 +194,9 @@
 		</focusedlayout>
 	</include>
 	<include name="script-skinshortcuts_coords3_21:9_masked">
-		<focusedlayout width="350" height="66">
+		<focusedlayout width="360" height="66">
 			<control type="label">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<scroll>True</scroll>
 				<textcolor>$VAR[TextColorFO]</textcolor>
@@ -204,42 +204,42 @@
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus66]</texture>
 				<visible>!String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="darkred">$VAR[focus66]</texture>
 				<visible>String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownNF.png</texture>
 				<visible>!Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpNF.png</texture>
 				<visible>!Control.HasFocus(303)</visible>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownFO.png</texture>
 				<visible>Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpFO.png</texture>
@@ -248,9 +248,9 @@
 		</focusedlayout>
 	</include>
 	<include name="script-skinshortcuts_coords3_4:3">
-		<focusedlayout width="350" height="66">
+		<focusedlayout width="360" height="66">
 			<control type="label">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<scroll>True</scroll>
 				<textcolor>$VAR[TextColorFO]</textcolor>
@@ -258,42 +258,42 @@
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[TextColorFO]">$VAR[focus66]</texture>
 				<visible>!String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<width>275</width>
+				<width>285</width>
 				<height>66</height>
 				<texture colordiffuse="darkred">$VAR[focus66]</texture>
 				<visible>String.IsEqual(ListItem.Property(skinshortcuts-disabled),True)</visible>
 				<animation effect="fade" start="100" end="50" time="200" tween="cubic" easing="out" reversible="false" condition="ControlGroup(9000).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(60)">Conditional</animation>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownNF.png</texture>
 				<visible>!Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpNF.png</texture>
 				<visible>!Control.HasFocus(303)</visible>
 			</control>
 			<control type="image">
-				<left>280</left>
+				<left>290</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownFO.png</texture>
 				<visible>Control.HasFocus(304)</visible>
 			</control>
 			<control type="image">
-				<left>315</left>
+				<left>325</left>
 				<width>35</width>
 				<height>66</height>
 				<texture colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpFO.png</texture>
@@ -340,28 +340,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords5_4:3</include>
 	</include>
 	<include name="script-skinshortcuts_coords5_16:9">
-		<left>550</left>
+		<left>600</left>
 		<top>210</top>
-		<width>1220</width>
-		<height>484</height>
+		<width>1170</width>
+		<height>594</height>
 	</include>
 	<include name="script-skinshortcuts_coords5_21:9">
-		<left>550</left>
+		<left>600</left>
 		<top>210</top>
-		<width>1860</width>
-		<height>484</height>
+		<width>1810</width>
+		<height>594</height>
 	</include>
 	<include name="script-skinshortcuts_coords5_21:9_masked">
-		<left>550</left>
+		<left>600</left>
 		<top>390</top>
-		<width>1860</width>
-		<height>484</height>
+		<width>1810</width>
+		<height>594</height>
 	</include>
 	<include name="script-skinshortcuts_coords5_4:3">
-		<left>550</left>
+		<left>600</left>
 		<top>210</top>
-		<width>740</width>
-		<height>484</height>
+		<width>690</width>
+		<height>594</height>
 	</include>
 	
 	<include name="script-skinshortcuts_coords6">
@@ -371,22 +371,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords6_4:3</include>
 	</include>
 	<include name="script-skinshortcuts_coords6_16:9">
-		<width>1220</width>
-		<height>44</height>
+		<width>1170</width>
+		<height>66</height>
 	</include>
 	<include name="script-skinshortcuts_coords6_21:9">
-		<width>1860</width>
-		<height>44</height>
+		<width>1810</width>
+		<height>66</height>
 	</include>
 	<include name="script-skinshortcuts_coords6_21:9_masked">
-		<width>1860</width>
-		<height>44</height>
+		<width>1810</width>
+		<height>66</height>
 	</include>
 	<include name="script-skinshortcuts_coords6_4:3">
-		<width>740</width>
-		<height>44</height>
+		<width>690</width>
+		<height>66</height>
 	</include>
-
+	
 	<include name="script-skinshortcuts_coords7">
 		<include condition="$EXP[NonMaskedCoordinates]">script-skinshortcuts_coords7_16:9</include>
 		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">script-skinshortcuts_coords7_21:9</include>
@@ -394,28 +394,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords7_4:3</include>
 	</include>
 	<include name="script-skinshortcuts_coords7_16:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1220</width>
-		<height>94</height>
+		<left>570</left>
+		<top>248</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	<include name="script-skinshortcuts_coords7_21:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1860</width>
-		<height>94</height>
+		<left>570</left>
+		<top>248</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	<include name="script-skinshortcuts_coords7_21:9_masked">
-		<left>550</left>
-		<top>925</top>
-		<width>1860</width>
-		<height>94</height>
+		<left>570</left>
+		<top>428</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	<include name="script-skinshortcuts_coords7_4:3">
-		<left>550</left>
-		<top>745</top>
-		<width>740</width>
-		<height>94</height>
+		<left>570</left>
+		<top>248</top>
+		<width>20</width>
+		<height>554</height>
 	</include>
 	
 	<include name="script-skinshortcuts_coords8">
@@ -425,59 +425,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords8_4:3</include>
 	</include>
 	<include name="script-skinshortcuts_coords8_16:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1220</width>
-		<height>105</height>
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>1170</width>
+		<height>36</height>
 	</include>
 	<include name="script-skinshortcuts_coords8_21:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1860</width>
-		<height>105</height>
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>1810</width>
+		<height>36</height>
 	</include>
 	<include name="script-skinshortcuts_coords8_21:9_masked">
-		<left>550</left>
-		<top>925</top>
-		<width>1860</width>
-		<height>105</height>
+		<left>600</left>
+		<bottom>360</bottom>
+		<width>1810</width>
+		<height>36</height>
 	</include>
 	<include name="script-skinshortcuts_coords8_4:3">
-		<left>550</left>
-		<top>745</top>
-		<width>740</width>
-		<height>105</height>
-	</include>
-	
-	<include name="script-skinshortcuts_coords9">
-		<include condition="$EXP[NonMaskedCoordinates]">script-skinshortcuts_coords9_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">script-skinshortcuts_coords9_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">script-skinshortcuts_coords9_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">script-skinshortcuts_coords9_4:3</include>
-	</include>
-	<include name="script-skinshortcuts_coords9_16:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1220</width>
-		<height>80</height>
-	</include>
-	<include name="script-skinshortcuts_coords9_21:9">
-		<left>550</left>
-		<top>745</top>
-		<width>1860</width>
-		<height>80</height>
-	</include>
-	<include name="script-skinshortcuts_coords9_21:9_masked">
-		<left>550</left>
-		<top>925</top>
-		<width>1860</width>
-		<height>80</height>
-	</include>
-	<include name="script-skinshortcuts_coords9_4:3">
-		<left>550</left>
-		<top>745</top>
-		<width>740</width>
-		<height>80</height>
+		<left>600</left>
+		<bottom>180</bottom>
+		<width>690</width>
+		<height>36</height>
 	</include>
 
 </includes>

--- a/xml/Custom_Skin_Shortcuts_Help.xml
+++ b/xml/Custom_Skin_Shortcuts_Help.xml
@@ -62,28 +62,10 @@
 			</control>
 			
 			<!-- Explanation text -->
-			<control type="textbox">
+			<control type="fadelabel">
 				<include>Custom_Skin_Shortcuts_Help_coords9</include>
-				<label>$VAR[SkinShortcutsExplanation2]</label>
-				<textcolor>$VAR[TextColorFO]</textcolor>
 				<font>Font27</font>
-				<visible>Skin.String(PlotFont,S)</visible>
-			</control>
-			
-			<control type="textbox">
-				<include>Custom_Skin_Shortcuts_Help_coords10</include>
 				<label>$VAR[SkinShortcutsExplanation2]</label>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<font>Font30</font>
-				<visible>Skin.String(PlotFont,M)</visible>
-			</control>
-			
-			<control type="textbox">
-				<include>Custom_Skin_Shortcuts_Help_coords11</include>
-				<label>$VAR[SkinShortcutsExplanation2]</label>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<font>Font33</font>
-				<visible>Skin.String(PlotFont,L)</visible>
 			</control>
 
 			<!-- Buttons -->

--- a/xml/DialogAddonSettings.xml
+++ b/xml/DialogAddonSettings.xml
@@ -19,9 +19,14 @@
 			
 			<!-- Heading -->
 			<include content="Time">
-				<param name="heading">$INFO[Window.Property(heading)]</param>
+				<param name="heading">$INFO[Control.GetLabel(2)]</param>
 				<param name="secondary">False</param>
 			</include>
+			
+			<control type="label" id="2">
+				<font></font>
+				<label></label>
+			</control>
 
 			<!-- Left grouplist -->
 			<control type="grouplist" id="3">
@@ -30,7 +35,7 @@
 				<onleft>70</onleft>
 				<onright>80</onright>
 				<onup>3</onup>
-				<ondown>3</ondown>
+				<ondown>20</ondown>
 				<orientation>vertical</orientation>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
 				<pagecontrol>70</pagecontrol>
@@ -61,10 +66,27 @@
 				<textureslidernibfocus></textureslidernibfocus>
 				<visible>!Skin.HasSetting(Scrollbars)</visible>
 			</control>
+			
+			<!-- Settings Level -->
+			<control type="label">
+				<include>DialogAddonSettings_coords4</include>
+				<align>center</align>
+				<label>$LOCALIZE[31016]:</label>
+				<font>Font33</font>
+				<textcolor>$VAR[TextColorNF]</textcolor>
+			</control>
+			<control type="button" id="20">
+				<include>DialogAddonSettings_coords5</include>
+				<align>center</align>
+				<font>Font33</font>
+				<onup>3</onup>
+				<onclick>SettingsLevelChange</onclick>
+				<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus66c.png</texturefocus>
+			</control>
 
 			<!-- Right grouplist -->
 			<control type="grouplist" id="5">
-				<include>DialogAddonSettings_coords4</include>
+				<include>DialogAddonSettings_coords6</include>
 				<itemgap>0</itemgap>
 				<onleft>80</onleft>
 				<onright>9001</onright>
@@ -77,7 +99,7 @@
 			
 			<!-- Scrollbar (Right grouplist) -->
 			<control type="scrollbar" id="80">
-				<include>DialogAddonSettings_coords5</include>
+				<include>DialogAddonSettings_coords7</include>
 				<onright>5</onright>
 				<onleft>3</onleft>
 				<showonepage>false</showonepage>
@@ -93,7 +115,7 @@
 			
 			<!-- Default label -->
 			<control type="label" id="14">
-				<include>DialogAddonSettings_coords6</include>
+				<include>DialogAddonSettings_coords8</include>
 				<font>Font33</font>
 				<align>center</align>
 				<label></label>
@@ -102,7 +124,7 @@
 
 			<!-- Default button -->
 			<control type="button" id="7">
-				<include>DialogAddonSettings_coords6</include>
+				<include>DialogAddonSettings_coords8</include>
 				<font>Font33</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<focusedcolor>$VAR[TextColorFO]</focusedcolor>
@@ -112,7 +134,7 @@
 
 			<!-- Default radiobutton -->
 			<control type="radiobutton" id="8">
-				<include>DialogAddonSettings_coords7</include>
+				<include>DialogAddonSettings_coords9</include>
 				<font>Font33</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<focusedcolor>$VAR[TextColorFO]</focusedcolor>
@@ -121,7 +143,7 @@
 
 			<!-- Default spincontrolex -->
 			<control type="spincontrolex" id="9">
-				<include>DialogAddonSettings_coords7</include>
+				<include>DialogAddonSettings_coords9</include>
 				<font>Font33</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<focusedcolor>$VAR[TextColorFO]</focusedcolor>
@@ -130,22 +152,28 @@
 
 			<!-- Default seperator -->
 			<control type="image" id="11">
-				<include>DialogAddonSettings_coords8</include>
+				<include>DialogAddonSettings_coords10</include>
 				<texture border="2" colordiffuse="$VAR[OverlayColorNF]">common/Divider.png</texture>
 			</control>
 			
 			<!-- Default edit -->
 			<control type="label" id="12">
-				<include>DialogAddonSettings_coords6</include>
+				<include>DialogAddonSettings_coords8</include>
 			</control>
 
 			<!-- Default slider -->
 			<control type="sliderex" id="13">
-				<include>DialogAddonSettings_coords6</include>
+				<include>DialogAddonSettings_coords8</include>
 				<font>Font33</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 				<disabledcolor>$VAR[DisabledColor]</disabledcolor>
+			</control>
+			
+			<!-- Settings description -->
+			<control type="fadelabel" id="6">
+				<include>DialogAddonSettings_coords11</include>
+				<font>Font27</font>
 			</control>
 
 			<!-- Buttons -->

--- a/xml/SettingsCategory.xml
+++ b/xml/SettingsCategory.xml
@@ -96,7 +96,7 @@
 				<font>Font33</font>
 				<onup>3</onup>
 				<onclick>SettingsLevelChange</onclick>
-				<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus52c.png</texturefocus>
+				<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus66c.png</texturefocus>
 			</control>
 
 			<!-- Submenu indicator -->

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -97,7 +97,7 @@
 	</variable>
 	
 	<variable name="addonsettingsbuttonunfocusdim">
-		<value condition="ControlGroup(5).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(70) | Control.HasFocus(80)">$VAR[TextColorNF]</value>
+		<value condition="ControlGroup(5).HasFocus | ControlGroup(9001).HasFocus | Control.HasFocus(70) | Control.HasFocus(80) | Control.HasFocus(20)">$VAR[TextColorNF]</value>
 		<value>$VAR[TextColorFO]</value>
 	</variable>
 	

--- a/xml/script-skinshortcuts.xml
+++ b/xml/script-skinshortcuts.xml
@@ -189,12 +189,13 @@
 			<control type="grouplist" id="9000">
 				<include>script-skinshortcuts_coords5</include>
 				<itemgap>0</itemgap>
-				<onleft>303</onleft>
+				<onleft>80</onleft>
 				<onright>9001</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
 				<orientation>vertical</orientation>
 				<usecontrolcoords>true</usecontrolcoords>
+				<pagecontrol>80</pagecontrol>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
 
 				<!-- Heading -->
@@ -211,7 +212,6 @@
 				<control type="button" id="401">
 					<include>script-skinshortcuts_coords6</include>
 					<label>$ADDON[script.skinshortcuts 32048]</label>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>!String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 				
@@ -219,7 +219,6 @@
 				<control type="button" id="305">
 					<include>script-skinshortcuts_coords6</include>
 					<label>  -  $LOCALIZE[528]</label>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>!String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 				
@@ -228,7 +227,6 @@
 					<include>script-skinshortcuts_coords6</include>
 					<label>  -  $ADDON[script.skinshortcuts 32027]</label>
 					<label2>$INFO[Container(211).ListItem.Property(displaypath)]</label2>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>!String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 				
@@ -238,7 +236,6 @@
 					<label>  -  $ADDON[script.skinshortcuts 32045]</label>
 					<label2>$INFO[Container(211).ListItem.Property(background)]</label2>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.IsEqual(Window.Property(groupname),mainmenu)</visible>
 				</control>
 				
@@ -256,7 +253,6 @@
 					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),20s)">Skin.SetString(IndividualBackgroundFolderDuration,30s)</onclick>
 					<onclick condition="String.IsEqual(Skin.String(IndividualBackgroundFolderDuration),30s)">Skin.SetString(IndividualBackgroundFolderDuration,1 min)</onclick>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.IsEqual(Window.Property(groupname),mainmenu)</visible>
 				</control>
 
@@ -264,7 +260,6 @@
 				<control type="button" id="405">
 					<include>script-skinshortcuts_coords6</include>
 					<label>$ADDON[script.skinshortcuts 32072]</label>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.IsEqual(Window.Property(groupname),mainmenu)</visible>
 				</control>
 
@@ -272,7 +267,6 @@
 				<control type="button" id="406">
 					<include>script-skinshortcuts_coords6</include>
 					<label>$LOCALIZE[31095]</label>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.IsEqual(Window.Property(groupname),mainmenu)</visible>
 				</control>
 				
@@ -290,7 +284,6 @@
 				<control type="button" id="312">
 					<include>script-skinshortcuts_coords6</include>
 					<label>$ADDON[script.skinshortcuts 32044]</label>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 
@@ -299,7 +292,6 @@
 					<include>script-skinshortcuts_coords6</include>
 					<label>  -  $LOCALIZE[528]</label>
                     <onclick>RunScript(script.skin.helper.service,action=setskinshortcutsproperty,header=$LOCALIZE[528],property=widgetName)</onclick>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
                     <visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 					<visible>System.HasAddon(script.skin.helper.service) + System.AddonIsEnabled(script.skin.helper.service)</visible>
 				</control>
@@ -311,7 +303,6 @@
 					<label2>$VAR[skinshortcuts-size]</label2>
 					<enable>!String.IsEmpty(Container(211).ListItem.Property(widget)) + !String.IsEqual(Container(211).ListItem.Property(widget),WeatherWidget)</enable>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 
@@ -322,7 +313,6 @@
 					<label2>$VAR[skinshortcuts-art]</label2>
 					<enable>!String.IsEmpty(Container(211).ListItem.Property(widget)) + !String.IsEqual(Container(211).ListItem.Property(widget),WeatherWidget) + !Container(8000).IsUpdating</enable>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 				
@@ -333,7 +323,6 @@
 					<label2>$VAR[skinshortcuts-fallbackart]</label2>
 					<enable>!String.IsEmpty(Container(211).ListItem.Property(widget)) + !String.IsEqual(Container(211).ListItem.Property(widget),WeatherWidget) + !Container(8000).IsUpdating</enable>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 
@@ -346,7 +335,6 @@
 					<onclick>SetProperty(chooseProperty,widgetSortBy)</onclick>
 					<onclick>SendClick(404)</onclick>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 				
@@ -359,7 +347,6 @@
 					<onclick>SetProperty(chooseProperty,widgetSortDirection)</onclick>
 					<onclick>SendClick(404)</onclick>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 				
@@ -372,7 +359,6 @@
 					<onclick>SetProperty(chooseProperty,widgetLimit)</onclick>
 					<onclick>SendClick(404)</onclick>
 					<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 					<visible>String.EndsWith(Window.Property(groupname),.1)</visible>
 				</control>
 
@@ -381,41 +367,37 @@
 					<include>script-skinshortcuts_coords6</include>
 					<label>$LOCALIZE[31161]</label>
 					<selected>String.IsEqual(Container(211).ListItem.Property(skinshortcuts-disabled),True)</selected>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 				</control>
 
 				<!-- Delete -->
 				<control type="button" id="302">
 					<include>script-skinshortcuts_coords6</include>
 					<label>$ADDON[script.skinshortcuts 32001]</label>
-					<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus44.png</texturefocus>
 				</control>
 				
 			</control>
-
-			<!-- Explanation text -->
-			<control type="textbox">
+			
+			<!-- Scrollbar (Right grouplist) -->
+			<control type="scrollbar" id="80">
 				<include>script-skinshortcuts_coords7</include>
-				<label>$VAR[SkinShortcutsExplanation1]</label>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<font>Font27</font>
-				<visible>Skin.String(PlotFont,S)</visible>
+				<onright>9000</onright>
+				<onleft>303</onleft>
+				<showonepage>false</showonepage>
+				<orientation>vertical</orientation>
+				<colordiffuse>$VAR[OverlayColorNF]</colordiffuse>
+				<texturesliderbackground border="8,1,6,1">common/ScrollBackground.png</texturesliderbackground>
+				<texturesliderbar border="8,1,6,1">common/ScrollbarGripNF.png</texturesliderbar>
+				<texturesliderbarfocus border="8,1,6,1" colordiffuse="$VAR[OverlayColorFO]">common/ScrollbarGripFO.png</texturesliderbarfocus>
+				<textureslidernib></textureslidernib>
+				<textureslidernibfocus></textureslidernibfocus>
+				<visible>!Skin.HasSetting(Scrollbars)</visible>
 			</control>
-			
-			<control type="textbox">
+
+			<!-- Settings description -->
+			<control type="fadelabel">
 				<include>script-skinshortcuts_coords8</include>
+				<font>Font27</font>
 				<label>$VAR[SkinShortcutsExplanation1]</label>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<font>Font30</font>
-				<visible>Skin.String(PlotFont,M)</visible>
-			</control>
-			
-			<control type="textbox">
-				<include>script-skinshortcuts_coords9</include>
-				<label>$VAR[SkinShortcutsExplanation1]</label>
-				<textcolor>$VAR[TextColorFO]</textcolor>
-				<font>Font33</font>
-				<visible>Skin.String(PlotFont,L)</visible>
 			</control>
 
 			<!-- Buttons -->


### PR DESCRIPTION
strings.po:
- remove line break from skinshortcuts explanation localizes (31353, 31362, 31367, 31370, 31371, 31372, 31373, 31374, 31375, 31377, 31388)

Coordinates_Custom_Skin_Shortcuts_Help.xml:
- rework coordinates for improved skinshortcuts dialog layout
- add new settings description label coordinates
- remove deprecated explanation textbox coordinates

Coordinates_DialogAddonSettings.xml:
- adjust coordinates to streamline addon settings and skinshortcuts dialog layouts
- rework and add new coordinates for added settings level button and settings description label

Coordinates_DialogVideoInfo.xml:
- fix coordinates

Coordinates_script-skinshortcuts.xml:
- adjust coordinates to streamline skinshortcuts and addon settings dialog layouts
- rework coordinates for adjusted settings description label
- remove deprecated explanation textbox coordinates

Coordinates_SettingsCategory.xml:
- adjust settings level button coordinates

Custom_Skin_Shortcuts_Help.xml:
- remove deprecated explanation textbox and add new settings description label

DialogAddonSettings.xml:
- add new added settings level button and settings description label

script-skinshortcuts.xml:
- add missing right list scrollbar
- adjust right list focus highlight
- rework settings description label

SettingsCategory.xml:
- adjust settings level button focus highlight

Variables.xml:
- adjust addonsettingsbuttonunfocusdim variable for added settings level button

addon.xml:
- update changelog

Changelog.md:
- update changelog