### PR TITLE
Added Addon Settings button (and Get More Addons) to the side menu

### DIFF
--- a/xml/MyGames.xml
+++ b/xml/MyGames.xml
@@ -186,9 +186,7 @@
 						<texture>transparent.png</texture>
 					</control>
 
-
-
-					<!-- Settings -->
+					<!-- Addon Settings -->
 					<control type="button" id="624">
 						<height>52</height>
 						<label>$LOCALIZE[10140]</label>
@@ -203,9 +201,9 @@
 						<onclick>ActivateWindow(addonbrowser,addons://more/game/,return)</onclick>
 						<visible>Container.Content(addons)</visible>
 					</control>
-					
+
 					<include>SideMenuControls</include>
-					
+
 				</control>
 			</control>
 		</control>

--- a/xml/MyMusicNav.xml
+++ b/xml/MyMusicNav.xml
@@ -235,9 +235,25 @@
 						<onclick condition="System.HasAddon(plugin.library.node.editor) + System.AddonIsEnabled(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=video,return)</onclick>
 						<visible>Container.Content() + String.IsEmpty(Container.PluginName)</visible>
 					</control>
+
+					<!-- Addon Settings -->
+					<control type="button" id="624">
+						<height>52</height>
+						<label>$LOCALIZE[10140]</label>
+						<visible>Control.IsEnabled(624)</visible>
+						<onclick>Addon.OpenSettings($INFO[Container.PluginName])</onclick>
+						<visible>!String.IsEmpty(Container.PluginName)</visible>
+					</control>
+					<!-- Get more -->
+					<control type="button" id="621">
+						<height>52</height>
+						<label>$LOCALIZE[21452]</label>
+						<onclick>ActivateWindow(addonbrowser,addons://more/audio/,return)</onclick>
+						<visible>Container.Content(addons)</visible>
+					</control>
 					
 					<include>SideMenuControls</include>
-					
+
 				</control>
 			</control>
 		</control>

--- a/xml/MyPics.xml
+++ b/xml/MyPics.xml
@@ -171,9 +171,25 @@
 						<label>13319</label>
 						<visible>Control.IsEnabled(9)</visible>
 					</control>
+
+					<!-- Addon Settings -->
+					<control type="button" id="624">
+						<height>52</height>
+						<label>$LOCALIZE[10140]</label>
+						<visible>Control.IsEnabled(624)</visible>
+						<onclick>Addon.OpenSettings($INFO[Container.PluginName])</onclick>
+						<visible>!String.IsEmpty(Container.PluginName)</visible>
+					</control>
+					<!-- Get more -->
+					<control type="button" id="621">
+						<height>52</height>
+						<label>$LOCALIZE[21452]</label>
+						<onclick>ActivateWindow(addonbrowser,addons://more/image/,return)</onclick>
+						<visible>Container.Content(addons)</visible>
+					</control>
 					
 					<include>SideMenuControls</include>
-					
+
 				</control>
 			</control>
 		</control>

--- a/xml/MyPrograms.xml
+++ b/xml/MyPrograms.xml
@@ -232,15 +232,24 @@
 						<texture>transparent.png</texture>
 					</control>
 
-					<!-- Addons -->
-					<control type="button" id="92">
+					<!-- Addon Settings -->
+					<control type="button" id="624">
+						<height>52</height>
+						<label>$LOCALIZE[10140]</label>
+						<visible>Control.IsEnabled(624)</visible>
+						<onclick>Addon.OpenSettings($INFO[Container.PluginName])</onclick>
+						<visible>!String.IsEmpty(Container.PluginName)</visible>
+					</control>
+					<!-- Get more -->
+					<control type="button" id="621">
 						<height>52</height>
 						<label>$LOCALIZE[21452]</label>
-						<onclick>ActivateWindow(addonbrowser)</onclick>
+						<onclick>ActivateWindow(addonbrowser,addons://more/executable/,return)</onclick>
+						<visible>Container.Content(addons)</visible>
 					</control>
-					
+
 					<include>SideMenuControls</include>
-					
+
 				</control>
 			</control>
 		</control>

--- a/xml/MyVideoNav.xml
+++ b/xml/MyVideoNav.xml
@@ -299,9 +299,25 @@
 						<onclick condition="System.HasAddon(plugin.library.node.editor) + System.AddonIsEnabled(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=video,return)</onclick>
 						<visible>Container.Content() + String.IsEmpty(Container.PluginName)</visible>
 					</control>
-					
+
+					<!-- Addon Settings -->
+					<control type="button" id="624">
+						<height>52</height>
+						<label>$LOCALIZE[10140]</label>
+						<visible>Control.IsEnabled(624)</visible>
+						<onclick>Addon.OpenSettings($INFO[Container.PluginName])</onclick>
+						<visible>!String.IsEmpty(Container.PluginName)</visible>
+					</control>
+					<!-- Get more -->
+					<control type="button" id="621">
+						<height>52</height>
+						<label>$LOCALIZE[21452]</label>
+						<onclick>ActivateWindow(addonbrowser,addons://more/video/,return)</onclick>
+						<visible>Container.Content(addons)</visible>
+					</control>
+
 					<include>SideMenuControls</include>
-					
+
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
New year, new experience.
First attemp at Kodi skin modification and PR.


The default skin in the side menu has a button to access the Addon Settings.
It's very useful because you can access the settings of the addon you are currently using without going out of it.


![screenshot00002](https://user-images.githubusercontent.com/426049/147858317-e0088873-0b78-4c06-9212-ca5a28d47269.png)
![screenshot00001](https://user-images.githubusercontent.com/426049/147858314-4374951e-fb90-46e3-a2f0-fc127f5834aa.png)

The button label `Addon Settings` needs to be localized. I do not know if you need to do it manually in the English PO and then that gets picked up by weblate automatically, so I left it hardcoded

