### PR TITLE
Widget and other minor improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@
 
 _Improved_
 - improve window draw performance
+- rework home screen widget animation and heading/details behaviour
+
+_Fixed_
+- use proper localize for Player settings entry
+- fix default (non-skinshortcuts) home menu widget headings
 
 ---
 
@@ -413,11 +418,33 @@ Release
 
 _add fade animations to all windows to hide content while fullscreen dialogs are visible_
 
+template.xml:
+- only zoom in on weather widget icons, not text
+- adjust temperature font size of weather widget
+
+Includes_SubMenu.xml:
+- replace Player settings entry localize to use the proper one
+
+Includes_Widgets.xml:
+- remove slide effect from home screen widget animations
+- rework widget heading and details for less item movement on screen
+
 Includes_Windows_Dialogs.xml:
 - add new WindowFullscreenDialogFadeAnimation animation include
 - remove unnecessary Black background image from WindowBackgroundImage and DialogBackgroundImage includes
 - add visible conditions to hide background images while fanart image control is enabled
 - add visible conditions to only enable fanart image control, if it's actually populated
+
+script-skonshortcuts-static.xml:
+- add missing container2 parameter to widgetHeading includes
+- only zoom in on weather widget icons, not text
+- adjust temperature font size of weather widget
+
+Settings.xml:
+- replace Player settings entry localize to use the proper one
+
+Variables.xml:
+- replace Player settings entry localize in HeadingLabelSecondary variable to use the proper one
 
 addon.xml:
 - bump version to 19.1.3

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]Improved[/B][CR]- improve window draw performance</news>
+		<news>[B]Improved[/B][CR]- improve window draw performance[CR]- rework home screen widget animation and heading/details behaviour[CR][CR][B]Fixed[/B][CR]- use proper localize for Player settings entry[CR]- fix default (non-skinshortcuts) home menu widget headings</news>
 	</extension>
 </addon>

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -156,7 +156,6 @@
 
 				<itemlayout width="203" height="306">
 					<control type="group">
-						<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 						<control type="label">
 							<top>2</top>
 							<width>203</width>
@@ -174,6 +173,7 @@
 							<texture background="true" colordiffuse="$VAR[DiffusePosterNF]">$INFO[ListItem.Icon]</texture>
 							<aspectratio align="center">keep</aspectratio>
 							<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
+							<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 						</control>
 						<control type="multiimage">
 							<left>0</left>
@@ -185,12 +185,13 @@
 							<timeperimage>200</timeperimage>
 							<aspectratio align="center">keep</aspectratio>
 							<visible>Skin.HasSetting(weatherIcons.multi)</visible>
+							<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 						</control>
 						<control type="label">
 							<top>281</top>
 							<width>203</width>
-							<height>25</height>
-							<font>Font25</font>
+							<height>33</height>
+							<font>Font33</font>
 							<align>center</align>
 							<textcolor>$VAR[TextColorNF]</textcolor>
 							<label>$INFO[ListItem.Label2]</label>
@@ -200,7 +201,6 @@
 
 				<focusedlayout width="203" height="306">
 					<control type="group">
-						<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 						<animation effect="fade" start="100" end="0" time="0" reversible="false" condition="Control.HasFocus(9000)">Conditional</animation>
 						<animation effect="fade" start="100" end="0" time="0" reversible="false">Unfocus</animation>
 						<control type="label">
@@ -220,6 +220,7 @@
 							<texture background="true">$INFO[ListItem.Icon]</texture>
 							<aspectratio align="center">keep</aspectratio>
 							<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
+							<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 						</control>
 						<control type="multiimage">
 							<left>0</left>
@@ -230,12 +231,13 @@
 							<timeperimage>200</timeperimage>
 							<aspectratio align="center">keep</aspectratio>
 							<visible>Skin.HasSetting(weatherIcons.multi)</visible>
+							<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 						</control>
 						<control type="label">
 							<top>281</top>
 							<width>203</width>
-							<height>25</height>
-							<font>Font25</font>
+							<height>33</height>
+							<font>Font33</font>
 							<align>center</align>
 							<textcolor>$VAR[TextColorFO]</textcolor>
 							<label>$INFO[ListItem.Label2]</label>
@@ -243,7 +245,6 @@
 					</control>
 					<control type="group">
 						<animation effect="fade" start="100" end="0" time="0" reversible="false">Focus</animation>
-						<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 						<control type="label">
 							<top>2</top>
 							<width>203</width>
@@ -261,6 +262,7 @@
 							<texture background="true" colordiffuse="$VAR[DiffusePosterNF]">$INFO[ListItem.Icon]</texture>
 							<aspectratio align="center">keep</aspectratio>
 							<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
+							<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 						</control>
 						<control type="multiimage">
 							<left>0</left>
@@ -272,12 +274,13 @@
 							<timeperimage>200</timeperimage>
 							<aspectratio align="center">keep</aspectratio>
 							<visible>Skin.HasSetting(weatherIcons.multi)</visible>
+							<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 						</control>
 						<control type="label">
 							<top>281</top>
 							<width>203</width>
-							<height>25</height>
-							<font>Font25</font>
+							<height>33</height>
+							<font>Font33</font>
 							<align>center</align>
 							<textcolor>$VAR[TextColorNF]</textcolor>
 							<label>$INFO[ListItem.Label2]</label>

--- a/xml/Includes_SubMenu.xml
+++ b/xml/Includes_SubMenu.xml
@@ -1359,7 +1359,7 @@
 			<!-- Player -->
 			<control type="button" id="91">
 				<include>SubMenu_coords5</include>
-				<label>16003</label>
+				<label>14200</label>
 				<onclick>ReplaceWindow(PlayerSettings)</onclick>
 				<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus52.png</texturefocus>
 				<visible>!Window.IsVisible(PlayerSettings)</visible>

--- a/xml/Includes_Widgets.xml
+++ b/xml/Includes_Widgets.xml
@@ -512,22 +512,18 @@
 		<definition>
 			<!-- Visible/Hidden (group) animation -->
 			<animation type="Conditional" condition="Control.IsVisible($PARAM[container1])">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
+				<effect type="fade" start="0" end="100" time="400" delay="400" />
 			</animation>
 			<animation type="Conditional" condition="!Control.IsVisible($PARAM[container1])">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
+				<effect type="fade" start="100" end="0" time="400" />
 			</animation>
 
 			<!-- Selected/deselected widget animation -->
 			<animation type="Conditional" condition="String.IsEqual(Container($PARAM[container1]).ListItem.Property(widgetID),$PARAM[container2])">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
+				<effect type="fade" start="0" end="100" time="400" delay="400" />
 			</animation>
 			<animation type="Conditional" condition="!String.IsEqual(Container($PARAM[container1]).ListItem.Property(widgetID),$PARAM[container2])">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
+				<effect type="fade" start="100" end="0" time="400" />
 			</animation>
 		</definition>
 	</include>
@@ -555,34 +551,79 @@
 	<include name="widgetHeading-content">
 		<definition>
 			<animation type="Visible">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
+				<effect type="fade" start="0" end="100" time="400" delay="400" />
 			</animation>
 			<animation type="Hidden">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
+				<effect type="fade" start="100" end="0" time="400" />
 			</animation>
 			<animation type="Conditional" condition="!String.IsEmpty(Container($PARAM[container2]).ListItem.Property(outlook)) + !String.IsEqual(Container($PARAM[container2]).ListItem.Property(outlook),$LOCALIZE[10006]) + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),weather)">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
+				<effect type="fade" start="0" end="100" time="400" delay="400"  />
 			</animation>
 			<animation type="Conditional" condition="[String.IsEmpty(Container($PARAM[container2]).ListItem.Property(outlook)) | String.IsEqual(Container($PARAM[container2]).ListItem.Property(outlook),$LOCALIZE[10006])] + String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),weather)">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
+				<effect type="fade" start="100" end="0" time="400" />
 			</animation>
 
 			<!-- Widget has focus -->
 			<control type="grouplist">
 				<orientation>vertical</orientation>
 				<usecontrolcoords>true</usecontrolcoords>
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
+				
+				<!-- Widget heading -->
+				<control type="label">
+					<include>widgetdetails_coords</include>
+					<height>46</height>
+					<font>Font33</font>
+					<align>right</align>
+					<aligny>top</aligny>
+					<visible>Integer.IsEqual(Container($PARAM[container]).NumItems,1)</visible>
+					<label>$INFO[Container($PARAM[container]).ListItem.Label]</label>
+					<textcolor>$VAR[TextColorNF]</textcolor>
+					<scroll>True</scroll>
+				</control>
+				
+				<!-- Indicators + Widget heading -->
+				<control type="grouplist">
+					<height>46</height>
+					<include>widgetdetails_coords</include>
+					<itemgap>10</itemgap>
+					<align>right</align>
+					<orientation>horizontal</orientation>
+					<usecontrolcoords>true</usecontrolcoords>
+					<visible>Integer.IsGreater(Container($PARAM[container]).NumItems,1)</visible>
+					<control type="label">
+						<width>auto</width>
+						<height>46</height>
+						<font>Font33</font>
+						<align>right</align>
+						<aligny>top</aligny>
+						<label>$INFO[Container($PARAM[container]).ListItem.Label]</label>
+						<textcolor>$VAR[TextColorNF]</textcolor>
+					</control>
+					<control type="button">
+						<top>15</top>
+						<width>30</width>
+						<height>16</height>
+						<onleft>9000</onleft>
+						<onright>9000</onright>
+						<onup>9000</onup>
+						<ondown>9000</ondown>
+						<texturenofocus colordiffuse="$VAR[OverlayColorNF]">up.png</texturenofocus>
+						<texturefocus colordiffuse="$VAR[OverlayColorFO]">up.png</texturefocus>
+						<onclick>Control.Move($PARAM[container],-1)</onclick>
+					</control>
+					<control type="button">
+						<top>15</top>
+						<width>30</width>
+						<height>16</height>
+						<onleft>9000</onleft>
+						<onright>9000</onright>
+						<onup>9000</onup>
+						<ondown>9000</ondown>
+						<texturenofocus colordiffuse="$VAR[OverlayColorNF]">down.png</texturenofocus>
+						<texturefocus colordiffuse="$VAR[OverlayColorFO]">down.png</texturefocus>
+						<onclick>Control.Move($PARAM[container],1)</onclick>
+					</control>
+				</control>
 
 				<!-- Widget details -->
 				<control type="textbox">
@@ -591,161 +632,22 @@
 					<font>Font33</font>
 					<align>right</align>
 					<aligny>top</aligny>
-					<label>$VAR[widgetDetails]</label>
+					<label>$INFO[Control.GetLabel(9988)]</label>
 					<textcolor>$VAR[TextColorFO]</textcolor>
+					<visible>!String.IsEmpty(Control.GetLabel(9988))</visible>
+					<animation effect="fade" start="0" end="100" time="200">Visible</animation>
+					<animation effect="fade" start="100" end="0" time="200">Hidden</animation>
 				</control>
 				
-				<!-- Indicators + Widget heading -->
-				<control type="grouplist">
-					<height>46</height>
-					<include>widgetdetails_coords</include>
-					<itemgap>10</itemgap>
-					<align>right</align>
-					<orientation>horizontal</orientation>
-					<usecontrolcoords>true</usecontrolcoords>
-					<visible>Integer.IsGreater(Container($PARAM[container]).NumItems,1)</visible>
-					<control type="label">
-						<width>auto</width>
-						<height>46</height>
-						<font>Font33</font>
-						<align>right</align>
-						<aligny>top</aligny>
-						<label>$INFO[Container($PARAM[container]).ListItem.Label]</label>
-						<textcolor>$VAR[TextColorNF]</textcolor>
-					</control>
-					<control type="button">
-						<top>15</top>
-						<width>30</width>
-						<height>16</height>
-						<onleft>9000</onleft>
-						<onright>9000</onright>
-						<onup>9000</onup>
-						<ondown>9000</ondown>
-						<texturenofocus colordiffuse="$VAR[OverlayColorNF]">up.png</texturenofocus>
-						<texturefocus colordiffuse="$VAR[OverlayColorFO]">up.png</texturefocus>
-						<onclick>Control.Move($PARAM[container],-1)</onclick>
-					</control>
-					<control type="button">
-						<top>15</top>
-						<width>30</width>
-						<height>16</height>
-						<onleft>9000</onleft>
-						<onright>9000</onright>
-						<onup>9000</onup>
-						<ondown>9000</ondown>
-						<texturenofocus colordiffuse="$VAR[OverlayColorNF]">down.png</texturenofocus>
-						<texturefocus colordiffuse="$VAR[OverlayColorFO]">down.png</texturefocus>
-						<onclick>Control.Move($PARAM[container],1)</onclick>
-					</control>
+				<control type="label" id="9988">
+					<font></font>
+					<label>$VAR[widgetDetails]</label>
 				</control>
 				
-				<!-- Widget heading -->
-				<control type="label">
-					<include>widgetdetails_coords</include>
-					<height>46</height>
-					<font>Font33</font>
-					<align>right</align>
-					<aligny>top</aligny>
-					<visible>Integer.IsEqual(Container($PARAM[container]).NumItems,1)</visible>
-					<label>$INFO[Container($PARAM[container]).ListItem.Label]</label>
-					<textcolor>$VAR[TextColorNF]</textcolor>
-					<scroll>True</scroll>
-				</control>
-				
-			</control>
-			<!-- Reloading indicator -->
-			<control type="group">
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
-				<include>widgetreloadingindicator_coords</include>
-				<include>skinshortcuts-template-reloading</include>
 			</control>
 			
-			<!-- Widget does not have focus -->
-			<control type="group">
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
-				
-				<!-- Indicators + Widget heading -->
-				<control type="grouplist">
-					<height>46</height>
-					<include>widgetdetails_coords</include>
-					<itemgap>10</itemgap>
-					<align>right</align>
-					<orientation>horizontal</orientation>
-					<usecontrolcoords>true</usecontrolcoords>
-					<visible>Integer.IsGreater(Container($PARAM[container]).NumItems,1)</visible>
-					<control type="label">
-						<width>auto</width>
-						<height>46</height>
-						<font>Font33</font>
-						<align>right</align>
-						<aligny>top</aligny>
-						<label>$INFO[Container($PARAM[container]).ListItem.Label]</label>
-						<textcolor>$VAR[TextColorNF]</textcolor>
-					</control>
-					<control type="button">
-						<top>15</top>
-						<width>30</width>
-						<height>16</height>
-						<onleft>9000</onleft>
-						<onright>9000</onright>
-						<onup>9000</onup>
-						<ondown>9000</ondown>
-						<texturenofocus colordiffuse="$VAR[OverlayColorNF]">up.png</texturenofocus>
-						<texturefocus colordiffuse="$VAR[OverlayColorFO]">up.png</texturefocus>
-						<onclick>Control.Move($PARAM[container],-1)</onclick>
-					</control>
-					<control type="button">
-						<top>15</top>
-						<width>30</width>
-						<height>16</height>
-						<onleft>9000</onleft>
-						<onright>9000</onright>
-						<onup>9000</onup>
-						<ondown>9000</ondown>
-						<texturenofocus colordiffuse="$VAR[OverlayColorNF]">down.png</texturenofocus>
-						<texturefocus colordiffuse="$VAR[OverlayColorFO]">down.png</texturefocus>
-						<onclick>Control.Move($PARAM[container],1)</onclick>
-					</control>
-				</control>
-				
-				<!-- Widget heading -->
-				<control type="label">
-					<include>widgetdetails_coords</include>
-					<height>46</height>
-					<font>Font33</font>
-					<align>right</align>
-					<aligny>top</aligny>
-					<visible>Integer.IsEqual(Container($PARAM[container]).NumItems,1)</visible>
-					<label>$INFO[Container($PARAM[container]).ListItem.Label]</label>
-					<textcolor>$VAR[TextColorNF]</textcolor>
-					<scroll>True</scroll>
-				</control>
-				
-			</control>
 			<!-- Reloading indicator -->
 			<control type="group">
-				<animation type="Conditional" condition="!ControlGroup(9002).HasFocus">
-					<effect type="fade" start="0" end="100" time="200" />
-					<effect type="slide" start="1800,0" end="0,0" time="400" />
-				</animation>
-				<animation type="Conditional" condition="ControlGroup(9002).HasFocus">
-					<effect type="fade" start="100" end="0" time="200" />
-					<effect type="slide" start="0,0" end="1800,0" time="400" />
-				</animation>
 				<include>widgetreloadingindicator_coords</include>
 				<include>skinshortcuts-template-reloading</include>
 			</control>

--- a/xml/Settings.xml
+++ b/xml/Settings.xml
@@ -47,7 +47,7 @@
 
 						<!-- Player -->
 						<item>
-							<label>$LOCALIZE[16003]</label>
+							<label>$LOCALIZE[14200]</label>
 							<onclick>ActivateWindow(PlayerSettings)</onclick>
 						</item>
 

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -192,7 +192,7 @@
 		<value condition="Window.IsVisible(videoplaylist) | Window.IsVisible(musicplaylist)">$INFO[Container.FolderName]</value>
 		<value condition="Window.IsVisible(settings)"></value>
 		<value condition="Window.IsVisible(InterfaceSettings)">$LOCALIZE[14206]</value>
-		<value condition="Window.IsVisible(PlayerSettings)">$LOCALIZE[16003]</value>
+		<value condition="Window.IsVisible(PlayerSettings)">$LOCALIZE[14200]</value>
 		<value condition="Window.IsVisible(MediaSettings)">$LOCALIZE[14211]</value>
 		<value condition="Window.IsVisible(PVRSettings)">$LOCALIZE[31015]</value>
 		<value condition="Window.IsVisible(ServiceSettings)">$LOCALIZE[14036]</value>

--- a/xml/script-skinshortcuts-static.xml
+++ b/xml/script-skinshortcuts-static.xml
@@ -924,6 +924,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),movies)</visible>
 			<include content="widgetHeading">
 				<param name="container">10001</param>
+				<param name="container2">10101</param>
 			</include>
 		</control>
 		<control id="10002" type="list">
@@ -993,6 +994,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),tvshows)</visible>
 			<include content="widgetHeading">
 				<param name="container">10002</param>
+				<param name="container2">10201</param>
 			</include>
 		</control>
 		<control id="10004" type="list">
@@ -1062,6 +1064,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),music)</visible>
 			<include content="widgetHeading">
 				<param name="container">10004</param>
+				<param name="container2">10401</param>
 			</include>
 		</control>
 		<control id="10006" type="list">
@@ -1131,6 +1134,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-15016)</visible>
 			<include content="widgetHeading">
 				<param name="container">10006</param>
+				<param name="container2">10601</param>
 			</include>
 		</control>
 		<control id="10008" type="list">
@@ -1200,6 +1204,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),programs)</visible>
 			<include content="widgetHeading">
 				<param name="container">10008</param>
+				<param name="container2">10801</param>
 			</include>
 		</control>
 		<control id="10009" type="list">
@@ -1269,6 +1274,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),weather)</visible>
 			<include content="widgetHeading">
 				<param name="container">10009</param>
+				<param name="container2">10901</param>
 			</include>
 		</control>
 		<control id="100010" type="list">
@@ -1338,6 +1344,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-14204)</visible>
 			<include content="widgetHeading">
 				<param name="container">100010</param>
+				<param name="container2">101001</param>
 			</include>
 		</control>
 		<control id="100011" type="list">
@@ -1407,6 +1414,7 @@
 			<visible>String.IsEqual(Container(9000).ListItem.Property(submenuVisibility),num-19021)</visible>
 			<include content="widgetHeading">
 				<param name="container">100011</param>
+				<param name="container2">101101</param>
 			</include>
 		</control>
 	</include>
@@ -1491,8 +1499,8 @@
 						<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 					</control>
 					<control type="image">
-							<width>24</width>
-							<centerleft>108</centerleft>
+						<width>24</width>
+						<centerleft>108</centerleft>
 						<texture background="true">$VAR[StatusOverlayWide]</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 					</control>
@@ -1547,8 +1555,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 						</control>
 					</control>
@@ -1604,8 +1612,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						</control>
@@ -1692,8 +1700,8 @@
 						<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 					</control>
 					<control type="image">
-							<width>24</width>
-							<centerleft>108</centerleft>
+						<width>24</width>
+						<centerleft>108</centerleft>
 						<texture background="true">$VAR[StatusOverlayWide]</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 					</control>
@@ -1748,8 +1756,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 						</control>
 					</control>
@@ -1804,8 +1812,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						</control>
@@ -1891,8 +1899,8 @@
 						<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 					</control>
 					<control type="image">
-							<width>24</width>
-							<centerleft>108</centerleft>
+						<width>24</width>
+						<centerleft>108</centerleft>
 						<texture background="true">$VAR[StatusOverlayWide]</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 					</control>
@@ -1947,8 +1955,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 						</control>
 					</control>
@@ -2003,8 +2011,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						</control>
@@ -2090,8 +2098,8 @@
 						<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 					</control>
 					<control type="image">
-							<width>24</width>
-							<centerleft>108</centerleft>
+						<width>24</width>
+						<centerleft>108</centerleft>
 						<texture background="true">$VAR[StatusOverlayWide]</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 					</control>
@@ -2146,8 +2154,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 						</control>
 					</control>
@@ -2202,8 +2210,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						</control>
@@ -2289,8 +2297,8 @@
 						<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 					</control>
 					<control type="image">
-							<width>24</width>
-							<centerleft>108</centerleft>
+						<width>24</width>
+						<centerleft>108</centerleft>
 						<texture background="true">$VAR[StatusOverlayWide]</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 					</control>
@@ -2345,8 +2353,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 						</control>
 					</control>
@@ -2401,8 +2409,8 @@
 							<visible>[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)</visible>
 						</control>
 						<control type="image">
-								<width>24</width>
-								<centerleft>108</centerleft>
+							<width>24</width>
+							<centerleft>108</centerleft>
 							<texture background="true">$VAR[StatusOverlayWide]</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						</control>
@@ -2427,25 +2435,8 @@
 				<param name="container1">10009</param>
 				<param name="container2">9-1</param>
 			</include>
-			<animation type="Conditional" condition="!String.IsEmpty(Container(10901).ListItem.Property(outlook)) + !String.IsEqual(Container(10901).ListItem.Property(outlook),$LOCALIZE[10006])">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
-			</animation>
-			<animation type="Conditional" condition="String.IsEmpty(Container(10901).ListItem.Property(outlook)) | String.IsEqual(Container(10901).ListItem.Property(outlook),$LOCALIZE[10006])">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
-			</animation>
-			<animation type="Conditional" condition="String.IsEqual(Container(10009).ListItem.Property(widgetID),9-1)">
-				<effect type="fade" start="0" end="100" time="200" />
-				<effect type="slide" start="1800,0" end="0,0" time="400" />
-			</animation>
-			<animation type="Conditional" condition="!String.IsEqual(Container(10009).ListItem.Property(widgetID),9-1)">
-				<effect type="fade" start="100" end="0" time="200" />
-				<effect type="slide" start="0,0" end="1800,0" time="400" />
-			</animation>
 			<itemlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 					<control type="label">
 						<top>2</top>
 						<width>203</width>
@@ -2463,6 +2454,7 @@
 						<texture background="true" colordiffuse="$VAR[DiffusePosterNF]">$INFO[ListItem.Icon]</texture>
 						<aspectratio align="center">keep</aspectratio>
 						<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
+						<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 					</control>
 					<control type="multiimage">
 						<left>0</left>
@@ -2474,12 +2466,13 @@
 						<timeperimage>200</timeperimage>
 						<aspectratio align="center">keep</aspectratio>
 						<visible>Skin.HasSetting(weatherIcons.multi)</visible>
+						<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 					</control>
 					<control type="label">
 						<top>281</top>
 						<width>203</width>
-						<height>25</height>
-						<font>Font25</font>
+						<height>33</height>
+						<font>Font33</font>
 						<align>center</align>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 						<label>$INFO[ListItem.Label2]</label>
@@ -2488,7 +2481,6 @@
 			</itemlayout>
 			<focusedlayout height="326" width="203">
 				<control type="group">
-					<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 					<animation effect="fade" start="100" end="0" time="0" reversible="false" condition="Control.HasFocus(9000)">Conditional</animation>
 					<animation effect="fade" start="100" end="0" time="0" reversible="false">Unfocus</animation>
 					<control type="label">
@@ -2508,6 +2500,7 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 						<aspectratio align="center">keep</aspectratio>
 						<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
+						<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 					</control>
 					<control type="multiimage">
 						<left>0</left>
@@ -2518,12 +2511,13 @@
 						<timeperimage>200</timeperimage>
 						<aspectratio align="center">keep</aspectratio>
 						<visible>Skin.HasSetting(weatherIcons.multi)</visible>
+						<animation effect="zoom" start="80" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 					</control>
 					<control type="label">
 						<top>281</top>
 						<width>203</width>
-						<height>25</height>
-						<font>Font25</font>
+						<height>33</height>
+						<font>Font33</font>
 						<align>center</align>
 						<textcolor>$VAR[TextColorFO]</textcolor>
 						<label>$INFO[ListItem.Label2]</label>
@@ -2531,7 +2525,6 @@
 				</control>
 				<control type="group">
 					<animation effect="fade" start="100" end="0" time="0" reversible="false">Focus</animation>
-					<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 					<control type="label">
 						<top>2</top>
 						<width>203</width>
@@ -2549,6 +2542,7 @@
 						<texture background="true" colordiffuse="$VAR[DiffusePosterNF]">$INFO[ListItem.Icon]</texture>
 						<aspectratio align="center">keep</aspectratio>
 						<visible>!Skin.HasSetting(weatherIcons.multi)</visible>
+						<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 					</control>
 					<control type="multiimage">
 						<left>0</left>
@@ -2560,12 +2554,13 @@
 						<timeperimage>200</timeperimage>
 						<aspectratio align="center">keep</aspectratio>
 						<visible>Skin.HasSetting(weatherIcons.multi)</visible>
+						<animation effect="zoom" end="80" center="auto" time="0" condition="True">Conditional</animation>
 					</control>
 					<control type="label">
 						<top>281</top>
 						<width>203</width>
-						<height>25</height>
-						<font>Font25</font>
+						<height>33</height>
+						<font>Font33</font>
 						<align>center</align>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 						<label>$INFO[ListItem.Label2]</label>


### PR DESCRIPTION
template.xml:
- only zoom in on weather widget icons, not text
- adjust temperature font size of weather widget

Includes_SubMenu.xml:
- replace Player settings entry localize to use the proper one

Includes_Widgets.xml:
- remove slide effect from home screen widget animations
- rework widget heading and details for less item movement on screen

script-skonshortcuts-static.xml:
- add missing container2 parameter to widgetHeading includes
- only zoom in on weather widget icons, not text
- adjust temperature font size of weather widget

Settings.xml:
- replace Player settings entry localize to use the proper one

Variables.xml:
- replace Player settings entry localize in HeadingLabelSecondary variable to use the proper one

addon.xml:
- update changelog

Changelog.md:
- update changelog