### PR TITLE
Fix player OSD labels

### DIFF
--- a/xml/Includes_Time_NowPlaying.xml
+++ b/xml/Includes_Time_NowPlaying.xml
@@ -263,7 +263,7 @@
 							<include>nowplaying_coords5</include>
 							<aligny>top</aligny>
 							<align>right</align>
-							<label>$INFO[Player.Time]$INFO[Player.Duration, / ,] ($INFO[System.Time,[LIGHT]$LOCALIZE[142] ,[/LIGHT]]$INFO[Player.FinishTime,[LIGHT] / $LOCALIZE[19081]: [/LIGHT]])</label>
+							<label>$INFO[Player.Time]$INFO[Player.Duration, / ,] ($INFO[System.Time,[LIGHT]$LOCALIZE[555]: ,[/LIGHT]]$INFO[Player.FinishTime,[LIGHT] / $LOCALIZE[19081]: [/LIGHT]])</label>
 							<visible>!Player.HasGame + [!Pvr.IsPlayingTv + !Pvr.IsPlayingRadio | [Pvr.IsPlayingTv | Pvr.IsPlayingRadio] + !VideoPlayer.HasEpg] + Integer.IsGreater(Player.Duration,0)</visible>
 						</control>
 						
@@ -271,7 +271,7 @@
 							<include>nowplaying_coords5</include>
 							<aligny>top</aligny>
 							<align>right</align>
-							<label>$INFO[Player.Time] ($INFO[System.Time,[LIGHT]$LOCALIZE[142] ,[/LIGHT]])</label>
+							<label>$INFO[Player.Time] ($INFO[System.Time,[LIGHT]$LOCALIZE[555]: ,[/LIGHT]])</label>
 							<visible>!Player.HasGame + [!Pvr.IsPlayingTv + !Pvr.IsPlayingRadio | [Pvr.IsPlayingTv | Pvr.IsPlayingRadio] + !VideoPlayer.HasEpg] + !Integer.IsGreater(Player.Duration,0)</visible>
 						</control>
 						
@@ -280,7 +280,7 @@
 							<include>nowplaying_coords5</include>
 							<aligny>top</aligny>
 							<align>right</align>
-							<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration, / ,] ($INFO[System.Time,[LIGHT]$LOCALIZE[142] ,[/LIGHT]]$INFO[PVR.EpgEventFinishTime,[LIGHT] / $LOCALIZE[19081]: [/LIGHT]])</label>
+							<label>$INFO[PVR.EpgEventElapsedTime]$INFO[PVR.EpgEventDuration, / ,] ($INFO[System.Time,[LIGHT]$LOCALIZE[555]: ,[/LIGHT]]$INFO[PVR.EpgEventFinishTime,[LIGHT] / $LOCALIZE[19081]: [/LIGHT]])</label>
 							<visible>[Pvr.IsPlayingTv | Pvr.IsPlayingRadio] + VideoPlayer.HasEpg</visible>
 						</control>
 					

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -93,7 +93,7 @@
 						<include>MusicVisualisation_coords3</include>
 						<font>Font27-bold</font>
 						<align>center</align>
-						<label>$INFO[Player.Chapter,(,/]$INFO[Player.ChapterCount,,)]$INFO[MusicPlayer.PlaylistPosition,(,/]$INFO[MusicPlayer.PlaylistLength,,)]</label>
+						<label>$INFO[Player.Chapter,, / ]$INFO[Player.ChapterCount]$INFO[MusicPlayer.PlaylistPosition,, / ]$INFO[MusicPlayer.PlaylistLength]</label>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 						<visible>!Window.IsVisible(visualisation) + String.IsEmpty(Player.SeekStepSize)</visible>
 						<include>VisibleFadeAnimation</include>
@@ -104,7 +104,7 @@
 						<include>MusicVisualisation_coords3</include>
 						<font>Font27-bold</font>
 						<align>center</align>
-						<label>$INFO[MusicPlayer.PlaylistPosition,(,/]$INFO[MusicPlayer.PlaylistLength,,)]</label>
+						<label>$INFO[MusicPlayer.PlaylistPosition,, / ]$INFO[MusicPlayer.PlaylistLength]</label>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 						<visible>Window.IsVisible(visualisation) + String.IsEmpty(Player.SeekStepSize)</visible>
 						<include>VisibleFadeAnimation</include>
@@ -243,7 +243,7 @@
 						<align>right</align>
 						<font>Font27</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
-						<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
+						<label>$INFO[System.Time,$LOCALIZE[555]: ,]$INFO[Player.FinishTime, / $LOCALIZE[19081]: ,]</label>
 						<visible>!Pvr.IsPlayingRadio + Integer.IsGreater(Player.Duration,0)</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>
@@ -252,7 +252,7 @@
 						<align>center</align>
 						<font>Font27</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
-						<label>$INFO[System.Time,$LOCALIZE[142] ,]</label>
+						<label>$INFO[System.Time,$LOCALIZE[555]: ,]</label>
 						<visible>!Pvr.IsPlayingRadio + !Integer.IsGreater(Player.Duration,0) | !VideoPlayer.HasEpg + Pvr.IsPlayingRadio</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>
@@ -263,7 +263,7 @@
 						<align>right</align>
 						<font>Font27</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
-						<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081] ,]</label>
+						<label>$INFO[System.Time,$LOCALIZE[555]: ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081]: ,]</label>
 						<visible>Pvr.IsPlayingRadio + VideoPlayer.HasEpg</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>

--- a/xml/VideoFullScreen.xml
+++ b/xml/VideoFullScreen.xml
@@ -138,7 +138,7 @@
 						<include>VideoFullScreen_coords7</include>
 						<font>Font27-bold</font>
 						<align>center</align>
-						<label>$INFO[Player.Chapter,(,/]$INFO[Player.ChapterCount,,)]</label>
+						<label>$INFO[Player.Chapter,, / ]$INFO[Player.ChapterCount]</label>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 						<visible>Integer.IsGreater(Player.ChapterCount,0) + String.IsEmpty(Player.SeekStepSize) + [String.IsEmpty(Player.SeekNumeric) | !String.IsEmpty(Player.SeekNumeric) + Window.IsVisible(fullscreeninfo)]</visible>
 						<include>VisibleFadeAnimation</include>
@@ -337,7 +337,7 @@
 						<align>right</align>
 						<font>Font27</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
-						<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[Player.FinishTime, / $LOCALIZE[19081] ,]</label>
+						<label>$INFO[System.Time,$LOCALIZE[555]: ,]$INFO[Player.FinishTime, / $LOCALIZE[19081]: ,]</label>
 						<visible>!Pvr.IsPlayingTv + Integer.IsGreater(Player.Duration,0)</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>
@@ -346,7 +346,7 @@
 						<align>center</align>
 						<font>Font27</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
-						<label>$INFO[System.Time,$LOCALIZE[142] ,]</label>
+						<label>$INFO[System.Time,$LOCALIZE[555]: ,]</label>
 						<visible>!Pvr.IsPlayingTv + !Integer.IsGreater(Player.Duration,0) | !VideoPlayer.HasEpg + Pvr.IsPlayingTv</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>
@@ -357,7 +357,7 @@
 						<align>right</align>
 						<font>Font27</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
-						<label>$INFO[System.Time,$LOCALIZE[142] ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081] ,]</label>
+						<label>$INFO[System.Time,$LOCALIZE[555]: ,]$INFO[PVR.EpgEventFinishTime, / $LOCALIZE[19081]: ,]</label>
 						<visible>Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>


### PR DESCRIPTION
Includes_Time_NowPlaying.xml:
- relace time localize and add colon to now playing labels

MusicVisualisation.xml:
- add space before and after slash to status label
- remove brackets from status label
- replace time localize and add colons to current time/end time labels

VideoFullScreen.xml:
- add space before and after slash to status label
- remove brackets from status label
- replace time localize and add colons to current time/end time labels