### PR TITLE
Fix seek bar mouse control

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@ _New_
 - Support Nexus skin engine features
 - remove Skin Helper Service ColorPicker support
 
+_Fixed_
+- fix seek slider mouse control
+
 ---
 
 **_v19.1.3_**
@@ -449,6 +452,9 @@ Coordinates_Includes_MediaFlags.xml:
 Coordinates_SkinSettings.xml:
 - adjust coordinates of colour settings entries
 
+Coordinates_VideoOSD.xml:
+- adjust top coordinates to match video fullscreen progress bar position
+
 Coordinates_Viewtype523.xml:
 - add new favourites image includes
 
@@ -512,6 +518,9 @@ Variables_Settings.xml:
 - rework skin settings explanation variable after colour skin settings rework and removal of deprecated Skin Helper Service ColorPicker addon
 - add skin settings explanations for new colour skin settings
 - remove deprecated addon-skinhelpercolorpicker variable
+
+VideoOSD.xml:
+- adjust order of seek slider and seek slider button for mouse to be able catch control of the slider control
 
 VideoFullScreen.xml:
 - replace deprecated Player.DisplayAfterSeek by new Player.HasPerformedSeek(3) built-in

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- Support Nexus skin engine features[CR]- remove Skin Helper Service ColorPicker support</news>
+		<news>[B]New[/B][CR]- Support Nexus skin engine features[CR]- remove Skin Helper Service ColorPicker support[CR][CR][B]Fixed[/B][CR]- fix seek slider mouse control</news>
 	</extension>
 </addon>

--- a/xml/Coordinates_VideoOSD.xml
+++ b/xml/Coordinates_VideoOSD.xml
@@ -9,7 +9,7 @@
 	</include>
 	<include name="VideoOSD_coords1_16:9">
 		<left>430</left>
-		<top>890</top>
+		<top>882</top>
 		<width>920</width>
 		<height>20</height>
 	</include>

--- a/xml/VideoOSD.xml
+++ b/xml/VideoOSD.xml
@@ -11,14 +11,6 @@
 	<controls>
 
 		<!-- Seek slider -->
-		<control type="slider">
-			<include>VideoOSD_coords1</include>
-			<texturesliderbar />
-			<textureslidernib />
-			<textureslidernibfocus />
-			<action>seek</action>
-		</control>
-		
 		<control type="button" id="100">
 			<include>VideoOSD_coords1</include>
 			<onup>5</onup>
@@ -32,6 +24,14 @@
 			<oninfo condition="Window.IsVisible(fullscreeninfo)">Dialog.Close(fullscreeninfo)</oninfo>
 			<texturefocus />
 			<texturenofocus />
+		</control>
+		
+		<control type="slider">
+			<include>VideoOSD_coords1</include>
+			<texturesliderbar />
+			<textureslidernib />
+			<textureslidernibfocus />
+			<action>seek</action>
 		</control>
 
 		<control type="group">


### PR DESCRIPTION
Coordinates_VideoOSD.xml:
- adjust top coordinates to match video fullscreen progress bar position

VideoOSD.xml:
- adjust order of seek slider and seek slider button for mouse to be able catch control of the slider control

addon.xml:
- update changelog

Changelog.md:
- update changelog