### PR TITLE
Add new composer info to music windows and various fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,21 @@
 
 ---
 
-**_v20.0.0_**
+**_v20.1.0_**
+
+_New_
+- add composer info to fullscreen music playback window and music info dialog
+
+_Improved_
+- rework seek indicator and button behaviour
+
+_Fixed_
+- fix watched indicator background in wide and wall views
+- fix episodes image to properly react to hide thumbs for unwatched episode setting
+
+---
+
+**_v20.0.0 - June 2023_**
 
 _New_
 - Support Nexus skin engine features
@@ -20,7 +34,7 @@ _Fixed_
 
 ---
 
-**_v19.1.4_**
+**_v19.1.4 - May 2023_**
 
 _Improved_
 - improve background overlay rendering
@@ -33,7 +47,7 @@ _Fixed_
 
 ---
 
-**_v19.1.3_**
+**_v19.1.3 - September 2022_**
 
 _Improved_
 - improve window draw performance
@@ -45,7 +59,20 @@ _Fixed_
 
 ---
 
-**_v19.1.1_**
+**_v19.1.2 - March 2022_**
+
+_New_
+- reset textboxes to top scrolling position during dialog or window switches
+
+_Improved_
+- improve inital window/dialog focus fix (only apply where needed)
+
+_Fixed_
+- always show OSD playlist button when expected
+
+---
+
+**_v19.1.1 - December 2021_**
 
 _New_
 - add new video/music OSD seek slider button functionality (also adds frame advance feature)
@@ -60,7 +87,7 @@ _Fixed_
 
 ---
 
-**_v19.1.0_**
+**_v19.1.0 - August 2021_**
 
 _New_
 - add ENABLE option for new skinshortcuts version
@@ -445,189 +472,45 @@ Release
 
 ---
 
-**Changelog v20.0.0**
+**Changelog v20.1.0**
 
-_add new colors.xml file for new colour picker_
-_add new Coordinates_DialogColorPicker.xml and DialogColorPicker.xml files_
-_add new Coordinates_MyFavourites.xml and MyFavourites.xml files_
-_add new Coordinates_SettingsScreenCalibration.xml file_
-_add new Includes_GameControllers.xml file_
-_remove deprecates Coordinates_script-skin_helper_service-ColorPicker.xml and script-skin_helper_service-ColorPicker.xml files_
-_add new DialogPVRGuideControls.xml and Coordinates_DialogPVRGuideControls.xml files_
-_rename music and videos template files for skinshortcuts script_
+Coordinates_DialogSeekBar.xml:
+- remove deprecated coordinates includes
 
-strings.po:
-- update localizes for new colour picker (31026, 31037, 31050, 31060, 31295, 31297, 31298, 31299, 31300, 31405, 31407, 31435)
+Coordinates_MusicVisualisation.xml:
+- adjust position and height of now and next playing information
 
-Textures.xbt:
-- update textures file with new and updated calibrate window textures
-- update textures file with button icon for new video OSD Audio and Subtitle stream selection
+Coordinates_Viewtype52.xml:
+- fix position of watched status banner
 
-mainmenu.DATA.xml:
-- adjust default favourites main menu link to point to new favourites window
-
-movies-1.DATA.xml:
-- add new recently added movies widget entry
-
-music-1.DATA.xml:
-- add new recently added albums widget entry
-
-overrides.xml:
-- adjust favourites main menu entry template to point to new favourites window
-- add new default recently added movies, recently added albums and in-progress tv shows widget entries
-- fix default program add-ons widget entry
-
-programs-1.DATA.xml:
-- fix name label of program add-ons widget
-
-tvhsows-1.DATA.xml:
-- add new in-progress tv shows widget entry
-
-Coordinates_DialogButtonMenu.xml:
-- rework coordinates for new power menu structure
-
-Coordinates_DialogGameControllers.xml:
-- add new coordinates includes for new game controller ports dialog
-
-Coordinates_GameOSD.xml:
-- adjust height of game OSD dialog for new game controller ports entry
-
-Coordinates_SkinSettings.xml:
-- adjust coordinates of colour settings entries
-
-Coordinates_VideoOSD.xml:
-- adjust width of Controls and Options grouplists
-- add VideoOSD_coords12 include for new Audio and Subtitle stream selection grouplists
-
-Coordinates_Viewtype523.xml:
-- add new favourites image includes
-
-Coordinates_Viewtype535.xml:
-- add new favourites image includes
-
-Coordinates_Viewtype537.xml:
-- add new favourites image includes
-
-Custom_Overlay_Debug.xml:
-- add new entry for new favourites window and new colour picker dialog
-- remove entry of deprecates colour picker script dialog
-- add new entry for new PVR guide controls dialog
-
-Defaults.xml:
-- add new colorbutton control
-
-DialogAddonInfo.xml:
-- remove deprecated WindowDialogFocus include
-- remove deprecated button grouplist defaultcontrol tag
-- add new AddonInfoDialogButtonFocus include for proper inital info dialog button focus behaviour
-- revert button order to former default
-
-DialogButtonMenu.xml:
-- rework power menu to match new PVR guide controls dialog
-
-DialogGameControllers.xml:
-- rework game controllers dialog to use includes depending on which dialog is called (game controller profiles or game controller ports dialog)
-
-DialogKeyboard.xml:
-- add new show/hide password buttin
+Coordinates_Viewtype53.xml:
+- fix position of watched status banner
 
 DialogMusicInfo.xml:
-- remove deprecated WindowDialogFocus include
-- remove deprecated button grouplist defaultcontrol tag
-- add new MusicInfoDialogButtonFocus include for proper inital info dialog button focus behaviour
-
-DialogPlayerProcessInfo.xml:
-- add new video scan type info label
-
-DialogPVRInfo.xml:
-- remove deprecated WindowDialogFocus include
-- remove deprecated button grouplist defaultcontrol tag
-- add new PVRInfoDialogButtonFocus include for proper inital info dialog button focus behaviour
-- revert button order to former default
+- add new composer info
 
 DialogSeekBar.xml:
-- replace deprecated Player.DisplayAfterSeek by new Player.HasPerformedSeek(3) built-in
+- remove deprecated controls
 
 DialogVideoInfo.xml:
-- remove deprecated WindowDialogFocus include
-- remove deprecated button grouplist defaultcontrol tag
-- add new VideoInfoDialogButtonFocus include for proper inital info dialog button focus behaviour
-- revert button order to former default
-
-GameOSD.xml:
-- adjust visibility conditions with new game controller ports window condition
-- add new game controller ports entry
-
-Includes.xml:
-- add new Coordinates_DialogColorPicker.xml and Coordinates_MyFavourites.xml include files
-- remove deprevated Coordinates_script-skin_helper_service-ColorPicker.xml include file
-- adjust onloads to set default colour value to "Default" instead of "None"
-- add new Coordinates_SettingsScreenCalibration.xml include file
-- add new Includes_GameControllers.xml include file
-- add new Coordinates_DialogPVRGuideControls.xml include file
-
-Includes_SubMenu.xml:
-- add sub menu for new favourites window
-- fix include and visible conditions for view type suppression in video media window while force video addon view setting is enabled
+- add missing fallback to episode image
 
 Includes_Windows_Dialogs.xml:
-- remove deprecated WindowDialogFocus include
-- add new AddonInfoDialogButtonFocus, MusicInfoDialogButtonFocus, PVRInfoDialogButtonFocus and VideoInfoDialogButtonFocus includes
+- fix video image fallback
 
-script-skinshortcuts-static.xml:
-- adjust default favourites main menu link to point to new favourites window
-- add new default recently added movies, recently added albums and in-progress tv shows widget entries
-- fix name label and default layout of program add-ons widget
-
-SettingsCategory.xml:
-- add new default color button
-
-SettingsScreenCalibration.xml:
-- add new movingspeed tags to mover and resize controls
-- add new calibration reset control
-- add missing calibration value label
-
-SkinSettings.xml:
-- rework colour settings for new Kodi colour picker
-- remove entry for deprecated Skin Helper Service ColorPicker addon
+MusicVisualisation.xml:
+- add missing seek slider controls
+- add new composer info
 
 Variables.xml:
-- add condition to mediaImages variable utilizing new hideunwatchedepisodethumbs boolean
-- add condition to HeadingLabelPrimary for new favourites window heading
-- rework StatusOverlay and StatusOverlayWide variables to show percentage based watch status for TV shows and seasons
-- rework VideoResolution variable to incorporate new HDR info
-- add new HDRType variable
-- add new SubtitleLanguageOSD variable for new video OSD Subtitle stream selection
-- add new conditions to VideoResolution variable to support new OSMC specific video width and height infolabels
-
-Variables_Colours.xml:
-- rework colour variables with new  default colour value "Default"
-- remove deprecated SolidBackgroundColor-Name variable
-
-Variables_Settings.xml:
-- rework skin settings explanation variable after colour skin settings rework and removal of deprecated Skin Helper Service ColorPicker addon
-- add skin settings explanations for new colour skin settings
-- remove deprecated addon-skinhelpercolorpicker variable
+- rework mediaImages and VideoInfoImage variables to properly react to hide thumbs for unwatched episode setting
 
 VideoFullScreen.xml:
-- replace deprecated Player.DisplayAfterSeek by new Player.HasPerformedSeek(3) built-in
+- add missing seek slider controls
 
-VideoOSD.xml:
-- adjust visibility condition and fade animations of Options grouplist for new Audio and Subtitle stream selection
-- adjust Audio Settings and Subtitles buttons to open new Audio and Subtitle stream selection, if more than one audio or subtitle stream is present and playback isn't live TV
-- add new Audio and Subtitle stream selection
+Addon.xml:
+- bump version to 20.1.0
+- update changelog
 
-Viewtype50.xml:
-- add new favourites image include
-
-Viewtype523.xml:
-- adjust list visibility condition for new favourites content type
-
-Viewtype535.xml:
-- adjust list visibility condition for new favourites content type
-
-Viewtype537.xml:
-- adjust list visibility condition for new favourites content type
-
-addon.xml:
-- bump version to 20.0.0
+Changelog.md:
+- update changelog

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="20.0.0" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="20.1.0" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.16.0"/>
 	</requires>
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- Support Nexus skin engine features[CR]- remove Skin Helper Service ColorPicker support[CR]- add new video OSD audio and subtitle selection[CR]- add missing PVR guide controls dialog[CR]- use new OSMC specific video width and height info for media flags[CR]- add new default widgets to movies, tv shows and music home screen items[CR][CR][B]Improved[/B][CR]- improve inital info dialog button focus behaviour[CR][CR][B]Fixed[/B][CR]- fix view type button supression behaviour in video media window while video addon force view setting is enabled</news>
+		<news>[B]New[/B][CR]- add composer info to fullscreen music playback window and music info dialog[CR][CR][B]Improved[/B][CR]- rework seek indicator and button behaviour[CR][CR][B]Fixed[/B][CR]- fix watched indicator background in wide and wall views[CR]- fix episodes image to properly react to hide thumbs for unwatched episode setting</news>
 	</extension>
 </addon>

--- a/xml/Coordinates_DialogSeekBar.xml
+++ b/xml/Coordinates_DialogSeekBar.xml
@@ -8,113 +8,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSeekBar_coords1_4:3</include>
 	</include>
 	<include name="DialogSeekBar_coords1_16:9">
-		<left>150</left>
-		<top>75</top>
-		<width>1620</width>
-		<height>930</height>
+		<left>0</left>
+		<top>0</top>
+		<width>0</width>
+		<height>0</height>
 	</include>
 	<include name="DialogSeekBar_coords1_21:9">
-		<left>150</left>
-		<top>75</top>
-		<width>2260</width>
-		<height>930</height>
+		<left>0</left>
+		<top>0</top>
+		<width>0</width>
+		<height>0</height>
 	</include>
 	<include name="DialogSeekBar_coords1_21:9_masked">
-		<left>150</left>
-		<top>255</top>
-		<width>2260</width>
-		<height>930</height>
+		<left>0</left>
+		<top>0</top>
+		<width>0</width>
+		<height>0</height>
 	</include>
 	<include name="DialogSeekBar_coords1_4:3">
-		<left>150</left>
-		<top>75</top>
-		<width>1140</width>
-		<height>930</height>
-	</include>
-	
-	<include name="DialogSeekBar_coords2">
-		<include condition="$EXP[NonMaskedCoordinates]">DialogSeekBar_coords2_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSeekBar_coords2_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">DialogSeekBar_coords2_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSeekBar_coords2_4:3</include>
-	</include>
-	<include name="DialogSeekBar_coords2_16:9">
-		<top>795</top>
-		<width>1620</width>
-		<height>60</height>
-	</include>
-	<include name="DialogSeekBar_coords2_21:9">
-		<top>795</top>
-		<width>2260</width>
-		<height>60</height>
-	</include>
-	<include name="DialogSeekBar_coords2_21:9_masked">
-		<top>795</top>
-		<width>2260</width>
-		<height>60</height>
-	</include>
-	<include name="DialogSeekBar_coords2_4:3">
-		<top>795</top>
-		<width>1140</width>
-		<height>60</height>
-	</include>
-	
-	<include name="DialogSeekBar_coords3">
-		<include condition="$EXP[NonMaskedCoordinates]">DialogSeekBar_coords3_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSeekBar_coords3_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">DialogSeekBar_coords3_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSeekBar_coords3_4:3</include>
-	</include>
-	<include name="DialogSeekBar_coords3_16:9">
-		<top>75</top>
-		<width>1620</width>
-		<height>60</height>
-	</include>
-	<include name="DialogSeekBar_coords3_21:9">
-		<top>75</top>
-		<width>2260</width>
-		<height>60</height>
-	</include>
-	<include name="DialogSeekBar_coords3_21:9_masked">
-		<top>75</top>
-		<width>2260</width>
-		<height>60</height>
-	</include>
-	<include name="DialogSeekBar_coords3_4:3">
-		<top>75</top>
-		<width>1140</width>
-		<height>60</height>
-	</include>
-	
-	<include name="DialogSeekBar_coords4">
-		<include condition="$EXP[NonMaskedCoordinates]">DialogSeekBar_coords4_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSeekBar_coords4_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">DialogSeekBar_coords4_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSeekBar_coords4_4:3</include>
-	</include>
-	<include name="DialogSeekBar_coords4_16:9">
-		<left>280</left>
-		<top>12</top>
-		<width>920</width>
-		<height>20</height>
-	</include>
-	<include name="DialogSeekBar_coords4_21:9">
-		<left>280</left>
-		<top>12</top>
-		<width>1560</width>
-		<height>20</height>
-	</include>
-	<include name="DialogSeekBar_coords4_21:9_masked">
-		<left>280</left>
-		<top>12</top>
-		<width>1560</width>
-		<height>20</height>
-	</include>
-	<include name="DialogSeekBar_coords4_4:3">
-		<left>280</left>
-		<top>12</top>
-		<width>440</width>
-		<height>20</height>
+		<left>0</left>
+		<top>0</top>
+		<width>0</width>
+		<height>0</height>
 	</include>
 
 </includes>

--- a/xml/Coordinates_MusicVisualisation.xml
+++ b/xml/Coordinates_MusicVisualisation.xml
@@ -436,22 +436,22 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">MusicVisualisation_coords17_4:3</include>
 	</include>
 	<include name="MusicVisualisation_coords17_16:9">
-		<top>150</top>
+		<top>177</top>
 		<width>470</width>
 		<height>516</height>
 	</include>
 	<include name="MusicVisualisation_coords17_21:9">
-		<top>150</top>
+		<top>177</top>
 		<width>470</width>
 		<height>516</height>
 	</include>
 	<include name="MusicVisualisation_coords17_21:9_masked">
-		<top>150</top>
+		<top>177</top>
 		<width>470</width>
 		<height>516</height>
 	</include>
 	<include name="MusicVisualisation_coords17_4:3">
-		<top>150</top>
+		<top>177</top>
 		<width>470</width>
 		<height>516</height>
 	</include>
@@ -464,23 +464,23 @@
 	</include>
 	<include name="MusicVisualisation_coords18_16:9">
 		<left>520</left>
-		<top>150</top>
-		<height>276</height>
+		<top>177</top>
+		<height>324</height>
 	</include>
 	<include name="MusicVisualisation_coords18_21:9">
 		<left>520</left>
-		<top>150</top>
-		<height>276</height>
+		<top>177</top>
+		<height>324</height>
 	</include>
 	<include name="MusicVisualisation_coords18_21:9_masked">
 		<left>520</left>
-		<top>150</top>
-		<height>276</height>
+		<top>177</top>
+		<height>324</height>
 	</include>
 	<include name="MusicVisualisation_coords18_4:3">
 		<left>520</left>
-		<top>150</top>
-		<height>276</height>
+		<top>177</top>
+		<height>324</height>
 	</include>
 	
 	<include name="MusicVisualisation_coords19">
@@ -564,22 +564,22 @@
 	</include>
 	<include name="MusicVisualisation_coords22_16:9">
 		<left>520</left>
-		<top>486</top>
+		<top>513</top>
 		<height>180</height>
 	</include>
 	<include name="MusicVisualisation_coords22_21:9">
 		<left>520</left>
-		<top>486</top>
+		<top>513</top>
 		<height>180</height>
 	</include>
 	<include name="MusicVisualisation_coords22_21:9_masked">
 		<left>520</left>
-		<top>486</top>
+		<top>513</top>
 		<height>180</height>
 	</include>
 	<include name="MusicVisualisation_coords22_4:3">
 		<left>520</left>
-		<top>486</top>
+		<top>513</top>
 		<height>180</height>
 	</include>
 	
@@ -591,25 +591,25 @@
 	</include>
 	<include name="MusicVisualisation_coords23_16:9">
 		<left>520</left>
-		<top>150</top>
+		<top>177</top>
 		<height>516</height>
 		<width>1100</width>
 	</include>
 	<include name="MusicVisualisation_coords23_21:9">
 		<left>520</left>
-		<top>150</top>
+		<top>177</top>
 		<height>516</height>
 		<width>1740</width>
 	</include>
 	<include name="MusicVisualisation_coords23_21:9_masked">
 		<left>520</left>
-		<top>150</top>
+		<top>177</top>
 		<height>516</height>
 		<width>1740</width>
 	</include>
 	<include name="MusicVisualisation_coords23_4:3">
 		<left>520</left>
-		<top>150</top>
+		<top>177</top>
 		<height>516</height>
 		<width>620</width>
 	</include>

--- a/xml/Coordinates_Viewtype52.xml
+++ b/xml/Coordinates_Viewtype52.xml
@@ -373,19 +373,19 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype52_coords8_4:3</include>
 	</include>
 	<include name="Viewtype52_coords8_16:9">
-		<left>10</left>
+		<left>7</left>
 		<bottom>120</bottom>
 		<width>240</width>
 		<height>26</height>
 	</include>
 	<include name="Viewtype52_coords8_21:9">
-		<left>10</left>
+		<left>15</left>
 		<bottom>120</bottom>
 		<width>240</width>
 		<height>26</height>
 	</include>
 	<include name="Viewtype52_coords8_21:9_masked">
-		<left>10</left>
+		<left>15</left>
 		<bottom>120</bottom>
 		<width>240</width>
 		<height>26</height>

--- a/xml/Coordinates_Viewtype53.xml
+++ b/xml/Coordinates_Viewtype53.xml
@@ -361,19 +361,19 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Viewtype53_coords8_4:3</include>
 	</include>
 	<include name="Viewtype53_coords8_16:9">
-		<left>43</left>
+		<left>35</left>
 		<bottom>15</bottom>
 		<width>200</width>
 		<height>22</height>
 	</include>
 	<include name="Viewtype53_coords8_21:9">
-		<left>43</left>
+		<left>41</left>
 		<bottom>15</bottom>
 		<width>200</width>
 		<height>22</height>
 	</include>
 	<include name="Viewtype53_coords8_21:9_masked">
-		<left>43</left>
+		<left>41</left>
 		<bottom>15</bottom>
 		<width>200</width>
 		<height>22</height>

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -148,6 +148,25 @@
 							<textcolor>$VAR[TextColorFO]</textcolor>
 						</control>
 					</control>
+					
+					<!-- Composer -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Role.Composer))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>29903</label>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Role.Composer)]</label>
+							<textcolor>$VAR[TextColorFO]</textcolor>
+						</control>
+					</control>
 
 					<!-- Year -->
 					<control type="group">
@@ -385,6 +404,25 @@
 							<include>DialogMusicInfo_coords7</include>
 							<font>Font36</font>
 							<label>$INFO[ListItem.AlbumArtist]</label>
+							<textcolor>$VAR[TextColorFO]</textcolor>
+						</control>
+					</control>
+					
+					<!-- Composer -->
+					<control type="group">
+						<include>DialogMusicInfo_coords5</include>
+						<visible>!String.IsEmpty(ListItem.Property(Role.Composer))</visible>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords6</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>29903</label>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<control type="fadelabel">
+							<include>DialogMusicInfo_coords7</include>
+							<font>Font36</font>
+							<label>$INFO[ListItem.Property(Role.Composer)]</label>
 							<textcolor>$VAR[TextColorFO]</textcolor>
 						</control>
 					</control>

--- a/xml/DialogSeekBar.xml
+++ b/xml/DialogSeekBar.xml
@@ -11,47 +11,16 @@
 
 	<controls>
 		
-		<control type="group">
-			<include>DialogDepth</include>
-			<include>DialogSeekBar_coords1</include>
-				
-			<control type="group">
-				<include>DialogSeekBar_coords2</include>
-				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDFresh)) | Window.IsVisible(videobookmarks) + !Window.IsVisible(VideoOSD) + String.IsEmpty(Window(12005).Property(VideoOSDBookmarksFresh))">Conditional</animation>
-				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDFresh)) | Window.IsVisible(videobookmarks) + !Window.IsVisible(VideoOSD) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksFresh))">Conditional</animation>
-				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(VideoOSD)">Conditional</animation>
-				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(videobookmarks) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksVideoInfo))">Conditional</animation>
-				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(videobookmarks) + !String.IsEmpty(Window(12005).Property(VideoOSDBookmarksSeekBar))">Conditional</animation>
-				<animation effect="slide" start="0,0" end="0,-75" time="200" reversible="false" condition="Window.IsVisible(MusicOSD) + String.IsEmpty(Window(12006).Property(MusicOSDFresh))">Conditional</animation>
-				<animation effect="slide" start="0,0" end="0,-75" time="0" reversible="false" condition="Window.IsVisible(MusicOSD) + !String.IsEmpty(Window(12006).Property(MusicOSDFresh))">Conditional</animation>
-				<animation effect="slide" start="0,-75" end="0,0" time="200" reversible="false" condition="!Window.IsVisible(MusicOSD)">Conditional</animation>
-				<include>WindowFadeAnimation</include>
-			
-				<control type="group">
-					<include>DialogSeekBar_coords3</include>
+		<control type="slider" id="401">
+			<texturesliderbar />
+			<textureslidernib />
+			<textureslidernibfocus />
+		</control>
 		
-					<control type="slider" id="401">
-						<include>DialogSeekBar_coords4</include>
-						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
-						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>
-						<textureslidernibfocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernibfocus>
-						<visible>Player.Seeking + !Pvr.IsPlayingTv</visible>
-						<include>VisibleFadeAnimation</include>
-					</control>
-					
-					<control type="slider" id="402">
-						<include>DialogSeekBar_coords4</include>
-						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
-						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>
-						<textureslidernibfocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernibfocus>
-						<visible>Player.Seeking + Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
-						<include>VisibleFadeAnimation</include>
-					</control>
-					
-				</control>
-				
-			</control>
-			
+		<control type="slider" id="402">
+			<texturesliderbar />
+			<textureslidernib />
+			<textureslidernibfocus />
 		</control>
 
 	</controls>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -37,7 +37,7 @@
 				<control type="image">
 					<include>DialogVideoInfo_coords1</include>
 					<fadetime>100</fadetime>
-					<texture>$VAR[VideoInfoImage]</texture>
+					<texture fallback="DefaultVideo.png" background="true">$VAR[VideoInfoImage]</texture>
 					<aspectratio align="center" aligny="center">keep</aspectratio>
 				</control>
 			</control>
@@ -66,7 +66,7 @@
 				</control>
 			</control>
 			
-			<!-- Musicvideo image -->
+			<!-- Music video image -->
 			<control type="image">
 				<visible>String.IsEqual(ListItem.DBTYPE,musicvideo)</visible>
 				<include>DialogVideoInfo_coords1</include>

--- a/xml/Includes_Windows_Dialogs.xml
+++ b/xml/Includes_Windows_Dialogs.xml
@@ -704,7 +704,7 @@
 	
 	<!-- Wall and wide view images -->
 	<include name="MediaViewImageNF">
-		<param name="fallback">DefaultVideos.png</param>
+		<param name="fallback">DefaultVideo.png</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">
@@ -735,7 +735,7 @@
 	</include>
 	
 	<include name="MediaViewImageFO">
-		<param name="fallback">DefaultVideos.png</param>
+		<param name="fallback">DefaultVideo.png</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">

--- a/xml/MusicOSD.xml
+++ b/xml/MusicOSD.xml
@@ -23,7 +23,7 @@
 		</control>
 		
 		<control type="button" id="100">
-			<include>VideoOSD_coords1</include>
+			<include>MusicOSD_coords1</include>
 			<onup>5</onup>
 			<ondown>5</ondown>
 			<onleft>StepBack</onleft>

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -218,7 +218,26 @@
 					</control>
 					
 					<!-- Seek slider -->
-					<control type="slider" id="1">
+					<control type="slider">
+						<include>MusicVisualisation_coords13</include>
+						<info>Player.Seekbar</info>
+						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
+						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>
+						<textureslidernibfocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernibfocus>
+						<visible>Player.Seeking + !Pvr.IsPlayingTv</visible>
+						<include>VisibleFadeAnimation</include>
+					</control>
+					<control type="slider">
+						<include>MusicVisualisation_coords13</include>
+						<info>PVR.TimeShiftSeekbar</info>
+						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
+						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>
+						<textureslidernibfocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernibfocus>
+						<visible>Player.Seeking + Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
+						<include>VisibleFadeAnimation</include>
+					</control>
+					
+					<control type="slider">
 						<include>MusicVisualisation_coords13</include>
 						<info>Player.Progress</info>
 						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
@@ -227,7 +246,7 @@
 						<visible>!String.IsEmpty(Window(12006).Property(MusicOSDSlider)) + Player.SeekEnabled + !Player.Seeking + !Pvr.IsPlayingRadio</visible>
 						<include>VisibleFadeAnimation</include>
 					</control>
-					<control type="slider" id="1">
+					<control type="slider">
 						<include>MusicVisualisation_coords13</include>
 						<info>PVR.TimeshiftProgressPlayPos</info>
 						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
@@ -363,6 +382,24 @@
 						</control>
 					</control>
 					
+					<!-- Composer -->
+					<control type="group">
+						<include>MusicVisualisation_coords19</include>
+						<visible>!String.IsEmpty(MusicPlayer.Property(Role.Composer))</visible>
+						<control type="fadelabel">
+							<include>MusicVisualisation_coords20</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>$LOCALIZE[29903]</label>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<control type="fadelabel">
+							<include>MusicVisualisation_coords21</include>
+							<font>Font36</font>
+							<label>$INFO[MusicPlayer.Property(Role.Composer)]</label>
+						</control>
+					</control>
+					
 					<!-- Genre -->
 					<control type="group">
 						<include>MusicVisualisation_coords19</include>
@@ -378,24 +415,6 @@
 							<include>MusicVisualisation_coords21</include>
 							<font>Font36</font>
 							<label>$INFO[MusicPlayer.Genre]</label>
-						</control>
-					</control>
-					
-					<!-- Comment -->
-					<control type="group">
-						<include>MusicVisualisation_coords19</include>
-						<visible>!String.IsEmpty(MusicPlayer.Comment)</visible>
-						<control type="fadelabel">
-							<include>MusicVisualisation_coords20</include>
-							<align>right</align>
-							<font>Font36</font>
-							<label>$LOCALIZE[569]</label>
-							<textcolor>$VAR[TextColorNF]</textcolor>
-						</control>
-						<control type="fadelabel">
-							<include>MusicVisualisation_coords21</include>
-							<font>Font36</font>
-							<label>$INFO[MusicPlayer.Comment]</label>
 						</control>
 					</control>
 					

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -138,8 +138,9 @@
 		<value condition="ListItem.IsParentFolder">DefaultFolderBack.png</value>
 		<value condition="Container.Content(seasons) + !String.IsEmpty(ListItem.Art(season.poster))">$INFO[ListItem.Art(season.poster)]</value>
 		<value condition="Container.Content(tvshows) + !String.IsEmpty(ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(tvshow.poster)]</value>
-		<value condition="Container.Content(episodes) + !System.Setting(hideunwatchedepisodethumbs)">$INFO[ListItem.Icon]</value>
-		<value condition="Container.Content(episodes) + System.Setting(hideunwatchedepisodethumbs)"></value>
+		<value condition="Container.Content(episodes) + [!System.Setting(hideunwatchedepisodethumbs) | System.Setting(hideunwatchedepisodethumbs) + Integer.IsGreater(ListItem.Playcount,0)]">$INFO[ListItem.Icon]</value>
+		<value condition="Container.Content(episodes) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + !String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="Container.Content(episodes) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + String.IsEmpty(ListItem.Art(fanart))">DefaultTVShows.png</value>
 		<value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
@@ -436,7 +437,9 @@
 	</variable>
 
 	<variable name="VideoInfoImage">
-		<value condition="String.IsEqual(ListItem.DBTYPE,episode)">$INFO[ListItem.Icon]</value>
+		<value condition="String.IsEqual(ListItem.DBTYPE,episode) + [!System.Setting(hideunwatchedepisodethumbs) | System.Setting(hideunwatchedepisodethumbs) + Integer.IsGreater(ListItem.Playcount,0)]">$INFO[ListItem.Icon]</value>
+		<value condition="String.IsEqual(ListItem.DBTYPE,episode) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + !String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
+		<value condition="String.IsEqual(ListItem.DBTYPE,episode) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + String.IsEmpty(ListItem.Art(fanart))">DefaultTVShows.png</value>
 		<value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>

--- a/xml/VideoFullScreen.xml
+++ b/xml/VideoFullScreen.xml
@@ -314,6 +314,25 @@
 					<!-- Seek slider -->
 					<control type="slider" id="1">
 						<include>VideoFullScreen_coords23</include>
+						<info>Player.Seekbar</info>
+						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
+						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>
+						<textureslidernibfocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernibfocus>
+						<visible>Player.Seeking + !Pvr.IsPlayingTv</visible>
+						<include>VisibleFadeAnimation</include>
+					</control>
+					<control type="slider" id="1">
+						<include>VideoFullScreen_coords23</include>
+						<info>PVR.TimeShiftSeekbar</info>
+						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
+						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>
+						<textureslidernibfocus colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernibfocus>
+						<visible>Player.Seeking + Pvr.IsPlayingTv + VideoPlayer.HasEpg</visible>
+						<include>VisibleFadeAnimation</include>
+					</control>
+					
+					<control type="slider" id="1">
+						<include>VideoFullScreen_coords23</include>
 						<info>Player.Progress</info>
 						<texturesliderbar colordiffuse="00FFFFFF">osd/OSDSliderBack.png</texturesliderbar>
 						<textureslidernib colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibBig.png</textureslidernib>

--- a/xml/Viewtype511.xml
+++ b/xml/Viewtype511.xml
@@ -153,7 +153,7 @@
 	</include>
 
 	<include name="image-511">
-		<param name="fallback">DefaultVideos.png</param>
+		<param name="fallback">DefaultVideo.png</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">
@@ -168,7 +168,7 @@
 	</include>
 	
 	<include name="image-511-episodes">
-		<param name="fallback">DefaultVideos.png</param>
+		<param name="fallback">DefaultVideo.png</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">

--- a/xml/Viewtype53.xml
+++ b/xml/Viewtype53.xml
@@ -54,7 +54,7 @@
 	</include>
 
 	<include name="image-53">
-		<param name="fallback">DefaultVideos.png</param>
+		<param name="fallback">DefaultVideo.png</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">
@@ -69,7 +69,7 @@
 	</include>
 	
 	<include name="image-53-focused">
-		<param name="fallback">DefaultVideos.png</param>
+		<param name="fallback">DefaultVideo.png</param>
 		<param name="visible">False</param>
 		<definition>
 			<control type="image">


### PR DESCRIPTION
Coordinates_DialogSeekBar.xml:
- remove deprecated coordinates includes

Coordinates_MusicVisualisation.xml:
- adjust position and height of now and next playing information

Coordinates_Viewtype52.xml:
- fix position of watched status banner

Coordinates_Viewtype53.xml:
- fix position of watched status banner

DialogMusicInfo.xml:
- add new composer info

DialogSeekBar.xml:
- remove deprecated controls

DialogVideoInfo.xml:
- add missing fallback to episode image

Includes_Windows_Dialogs.xml:
- fix video image fallback

MusicOSD.xml:
- fix wrong seek button coordinates include

MusicVisualisation.xml:
- add missing seek slider controls
- add new composer info

Variables.xml:
- rework mediaImages and VideoInfoImage variables to properly react to hide thumbs for unwatched episode setting

VideoFullScreen.xml:
- add missing seek slider controls

Viewtype511.xml:
- fix video image fallback

Viewtype53.xml:
- fix video image fallback

Addon.xml:
- bump version to 20.1.0
- update changelog

Changelog.md:
- update changelog