### PR TITLE
Add new settings to adjust select action of certain main menu widgets

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,14 @@
 
 ---
 
-**_v20.1.0_**
+**_v20.1.1_**
+
+_New_
+- add new setting to adjust select action of album, TV show and movie set main menu widgets
+
+---
+
+**_v20.1.0 - August 2023_**
 
 _New_
 - add composer info to fullscreen music playback window and music info dialog
@@ -472,44 +479,31 @@ Release
 
 ---
 
-**Changelog v20.1.0**
+**Changelog v20.1.1**
 
-Coordinates_DialogSeekBar.xml:
-- remove deprecated coordinates includes
+strings.po:
+- add localizes for new adjust select action of album, TV show and movie set main menu widgets settings (31438, 31439, 31440, 31441, 31442, 31443)
 
-Coordinates_MusicVisualisation.xml:
-- adjust position and height of now and next playing information
+template.xml:
+- add new widget onclick controls
 
-Coordinates_Viewtype52.xml:
-- fix position of watched status banner
+Includes.xml:
+- add new onload conditions for new adjust select action of album, TV show and movie set main menu widgets settings
 
-Coordinates_Viewtype53.xml:
-- fix position of watched status banner
+script-skinshortcuts-static.xml:
+- add new widget onclick controls
 
-DialogMusicInfo.xml:
-- add new composer info
+SkinSettings.xml:
+- add new adjust select action of album, TV show and movie set main menu widgets settings
 
-DialogSeekBar.xml:
-- remove deprecated controls
+Variables_Settings.xml:
+- add new variable values to SkinSettingsExplanation for new adjust select action of album, TV show and movie set main menu widgets settings
 
-DialogVideoInfo.xml:
-- add missing fallback to episode image
-
-Includes_Windows_Dialogs.xml:
-- fix video image fallback
-
-MusicVisualisation.xml:
-- add missing seek slider controls
-- add new composer info
-
-Variables.xml:
-- rework mediaImages and VideoInfoImage variables to properly react to hide thumbs for unwatched episode setting
-
-VideoFullScreen.xml:
-- add missing seek slider controls
+Variables_Skinshortcuts.xml:
+- add new WidgetOnClickAlbum, WidgetOnClickTVShow and WidgetOnClickMovieSet variables for new widget onclick controls
 
 Addon.xml:
-- bump version to 20.1.0
+- bump version to 20.1.1
 - update changelog
 
 Changelog.md:

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="20.1.0" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="20.1.1" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.16.0"/>
 	</requires>
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add composer info to fullscreen music playback window and music info dialog[CR][CR][B]Improved[/B][CR]- rework seek indicator and button behaviour[CR][CR][B]Fixed[/B][CR]- fix watched indicator background in wide and wall views[CR]- fix episodes image to properly react to hide thumbs for unwatched episode setting</news>
+		<news>[B]New[/B][CR]- add new setting to adjust select action of album, TV show and movie set main menu widgets</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -356,12 +356,12 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31076"
-msgid "Widget fanart on home screen"
+msgid "Widget fanart in the main menu"
 msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31077"
-msgid "Widget icons on home screen"
+msgid "Widget icons in the main menu"
 msgstr ""
 
 #: /Viewtype53.xml /Viewtype535.xml
@@ -1576,7 +1576,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31320"
-msgid "Settings to change the look of the weather window and the weather home screen widget"
+msgid "Settings to change the look of the weather window and the weather main menu widget"
 msgstr ""
 
 #: /SkinSettings.xml
@@ -2162,4 +2162,34 @@ msgstr ""
 #: /SkinSettings.xml
 msgctxt "#31437"
 msgid "Replace the default two-shaded background colour overlay by a plain colour style for the background overlay of windows and dialogs."
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31438"
+msgid "Default select action for album widgets"
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31439"
+msgid "Default select action for TV show widgets"
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31440"
+msgid "Default select action for movie set widgets"
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31441"
+msgid "Action used when selecting an album widget item in the main menu (Default: Browse into)"
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31442"
+msgid "Action used when selecting a TV show widget item in the main menu (Default: Browse into)"
+msgstr ""
+
+#: /SkinSettings.xml
+msgctxt "#31443"
+msgid "Action used when selecting a movie set widget item in the main menu (Default: Browse into)"
 msgstr ""

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -392,6 +392,11 @@
 					<param name="container1">1000$SKINSHORTCUTS[auto-rootID]</param>
 					<param name="container2">$SKINSHORTCUTS[auto-rootID]-$SKINSHORTCUTS[id]</param>
 				</include>
+				
+				<!-- Widget onclick -->
+				<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow)">$VAR[WidgetOnClickTVShow]</onclick>
+				<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 
 				<itemlayout width="$SKINSHORTCUTS[layoutWidth]" height="$SKINSHORTCUTS[layoutHeight]">
 					<include content="$PYTHON[$SKINSHORTCUTS[primary-art]]">

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -192,6 +192,9 @@
 		<onload condition="String.IsEqual(Skin.String(mediaflags),Language)">Skin.SetString(mediaflags,Language first)</onload>
 		<onload condition="String.IsEmpty(Skin.String(MaskingBars))">Skin.SetString(MaskingBars,2.40:1)</onload>
 		<onload condition="![Skin.HasSetting(DefaultVideosViewList) | Skin.HasSetting(DefaultVideosViewListinfo) | Skin.HasSetting(DefaultVideosViewWide) | Skin.HasSetting(DefaultVideosViewWidelow) | Skin.HasSetting(DefaultVideosViewWidelowinfo) | Skin.HasSetting(DefaultVideosViewWall) | Skin.HasSetting(DefaultVideosViewWallinfo) | Skin.HasSetting(DefaultVideosViewWallsmall) | Skin.HasSetting(DefaultVideosViewWallsmallinfo) | Skin.HasSetting(DefaultVideosViewWalllow)]">Skin.SetBool(DefaultVideosViewList)</onload>
+		<onload condition="String.IsEmpty(Skin.String(WidgetOnClickAlbum))">Skin.SetString(WidgetOnClickAlbum,AlbumWidgetBrowse)</onload>
+		<onload condition="String.IsEmpty(Skin.String(WidgetOnClickTVShow))">Skin.SetString(WidgetOnClickTVShow,TVShowWidgetBrowse)</onload>
+		<onload condition="String.IsEmpty(Skin.String(WidgetOnClickMovieSet))">Skin.SetString(WidgetOnClickMovieSet,MovieSetWidgetBrowse)</onload>
 	</include>
 	
 	<!-- Default forced views -->

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -149,7 +149,7 @@
 						<usecontrolcoords>true</usecontrolcoords>
 						<scrolltime tween="sine" easing="out">240</scrolltime>
 						<visible>Container(9000).HasFocus(1)</visible>
-						<!-- Edit menu -->
+						<!-- Edit main menu -->
 						<control type="button" id="101">
 							<include>SkinSettings_coords16</include>
 							<label>31049</label>
@@ -169,8 +169,49 @@
 							<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 							<textcolor>$VAR[TextColorNF]</textcolor>
 						</control>
+						<!-- Default select action for album widgets -->
+						<control type="button" id="103">
+							<include>SkinSettings_coords16</include>
+							<font>Font33</font>
+							<label> - $LOCALIZE[31438]</label>
+							<label2>$VAR[WidgetOnClickAlbumLabel]</label2>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetBrowse)">Skin.SetString(WidgetOnClickAlbum,AlbumWidgetPlay)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetPlay)">Skin.SetString(WidgetOnClickAlbum,AlbumWidgetPlayNext)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetPlayNext)">Skin.SetString(WidgetOnClickAlbum,AlbumWidgetQueue)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetQueue)">Skin.SetString(WidgetOnClickAlbum,AlbumWidgetBrowse)</onclick>
+							<focusedcolor>$VAR[TextColorFO]</focusedcolor>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<!-- Default select action for TV show widgets -->
+						<control type="button" id="104">
+							<include>SkinSettings_coords16</include>
+							<font>Font33</font>
+							<label> - $LOCALIZE[31439]</label>
+							<label2>$VAR[WidgetOnClickTVShowLabel]</label2>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetBrowse)">Skin.SetString(WidgetOnClickTVShow,TVShowWidgetContinueWatching)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetContinueWatching)">Skin.SetString(WidgetOnClickTVShow,TVShowWidgetPlayFromBeginning)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetPlayFromBeginning)">Skin.SetString(WidgetOnClickTVShow,TVShowWidgetPlayNext)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetPlayNext)">Skin.SetString(WidgetOnClickTVShow,TVShowWidgetQueue)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetQueue)">Skin.SetString(WidgetOnClickTVShow,TVShowWidgetBrowse)</onclick>
+							<focusedcolor>$VAR[TextColorFO]</focusedcolor>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<!-- Default select action for movie set widgets -->
+						<control type="button" id="105">
+							<include>SkinSettings_coords16</include>
+							<font>Font33</font>
+							<label> - $LOCALIZE[31440]</label>
+							<label2>$VAR[WidgetOnClickMovieSetLabel]</label2>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetBrowse)">Skin.SetString(WidgetOnClickMovieSet,MovieSetWidgetContinueWatching)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetContinueWatching)">Skin.SetString(WidgetOnClickMovieSet,MovieSetWidgetPlayFromBeginning)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetPlayFromBeginning)">Skin.SetString(WidgetOnClickMovieSet,MovieSetWidgetPlayNext)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetPlayNext)">Skin.SetString(WidgetOnClickMovieSet,MovieSetWidgetQueue)</onclick>
+							<onclick condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetQueue)">Skin.SetString(WidgetOnClickMovieSet,MovieSetWidgetBrowse)</onclick>
+							<focusedcolor>$VAR[TextColorFO]</focusedcolor>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
 						<!-- Always show settings link -->
-						<control type="radiobutton" id="103">
+						<control type="radiobutton" id="106">
 							<include>SkinSettings_coords16</include>
 							<font>Font33</font>
 							<label>$LOCALIZE[31096]</label>
@@ -179,7 +220,7 @@
 							<visible>System.HasAddon(script.skinshortcuts)</visible>
 						</control>
 						<!-- Show date above system time -->
-						<control type="radiobutton" id="104">
+						<control type="radiobutton" id="107">
 							<include>SkinSettings_coords16</include>
 							<font>Font33</font>
 							<label>31101</label>
@@ -187,7 +228,7 @@
 							<selected>Skin.HasSetting(Dateaboveclock)</selected>
 						</control>
 						<!-- Toggle masking -->
-						<control type="button" id="105">
+						<control type="button" id="108">
 							<include>SkinSettings_coords16</include>
 							<font>Font33</font>
 							<label>$LOCALIZE[31065]</label>
@@ -202,7 +243,7 @@
 							<visible>$EXP[Masking]</visible>
 						</control>
 						<!-- Automatic masking -->
-						<control type="radiobutton" id="106">
+						<control type="radiobutton" id="109">
 							<include>SkinSettings_coords16</include>
 							<font>Font33</font>
 							<label>31401</label>

--- a/xml/Variables_Settings.xml
+++ b/xml/Variables_Settings.xml
@@ -23,11 +23,14 @@
 		<value condition="Container(9000).HasFocus(1) + !ControlGroup(10000).HasFocus">$LOCALIZE[31098]</value>
 		<value condition="Control.HasFocus(101)">$LOCALIZE[31140]</value>
 		<value condition="Control.HasFocus(102)">$LOCALIZE[31267]</value>
-		<value condition="Control.HasFocus(103) + Skin.HasSetting(AlwaysShowSettingsLink)">[B]$LOCALIZE[31051][/B]</value>
-		<value condition="Control.HasFocus(103) + !Skin.HasSetting(AlwaysShowSettingsLink)">$LOCALIZE[31268]</value>
-		<value condition="Control.HasFocus(104)">$LOCALIZE[31269]</value>
-		<value condition="Control.HasFocus(105)">$LOCALIZE[31270]</value>
-		<value condition="Control.HasFocus(106)">$LOCALIZE[31402]</value>
+		<value condition="Control.HasFocus(103)">$LOCALIZE[31441]</value>
+		<value condition="Control.HasFocus(104)">$LOCALIZE[31442]</value>
+		<value condition="Control.HasFocus(105)">$LOCALIZE[31443]</value>
+		<value condition="Control.HasFocus(106) + Skin.HasSetting(AlwaysShowSettingsLink)">[B]$LOCALIZE[31051][/B]</value>
+		<value condition="Control.HasFocus(106) + !Skin.HasSetting(AlwaysShowSettingsLink)">$LOCALIZE[31268]</value>
+		<value condition="Control.HasFocus(107)">$LOCALIZE[31269]</value>
+		<value condition="Control.HasFocus(108)">$LOCALIZE[31270]</value>
+		<value condition="Control.HasFocus(109)">$LOCALIZE[31402]</value>
 		<value condition="Container(9000).HasFocus(2) + !ControlGroup(10000).HasFocus">$LOCALIZE[31271]</value>
 		<value condition="Control.HasFocus(201)">$LOCALIZE[31272]</value>
 		<value condition="Control.HasFocus(202)">$LOCALIZE[31273]</value>
@@ -165,6 +168,29 @@
 	</variable>
 	
 	<!-- Skin Settings label2 -->
+	<variable name="WidgetOnClickAlbumLabel">
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetBrowse)">$LOCALIZE[37015]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetPlay)">$LOCALIZE[208]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetPlayNext)">$LOCALIZE[10008]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetQueue)">$LOCALIZE[13347]</value>
+	</variable>
+	
+	<variable name="WidgetOnClickTVShowLabel">
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetBrowse)">$LOCALIZE[37015]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetContinueWatching)">$LOCALIZE[13362]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetPlayFromBeginning)">$LOCALIZE[12021]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetPlayNext)">$LOCALIZE[10008]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetQueue)">$LOCALIZE[13347]</value>
+	</variable>
+	
+	<variable name="WidgetOnClickMovieSetLabel">
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetBrowse)">$LOCALIZE[37015]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetContinueWatching)">$LOCALIZE[13362]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetPlayFromBeginning)">$LOCALIZE[12021]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetPlayNext)">$LOCALIZE[10008]</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetQueue)">$LOCALIZE[13347]</value>
+	</variable>
+	
 	<variable name="MaskingBars">
 		<value condition="String.IsEqual(Skin.String(MaskingBars),2.40:1)">$LOCALIZE[31428]</value>
 		<value condition="String.IsEqual(Skin.String(MaskingBars),2.35:1)">$LOCALIZE[31429]</value>

--- a/xml/Variables_Skinshortcuts.xml
+++ b/xml/Variables_Skinshortcuts.xml
@@ -107,5 +107,28 @@
 		<value condition="!String.IsEmpty(Container(211).ListItem.Property(widgetLimit))">$INFO[Container(211).ListItem.Property(widgetLimit)]</value>
 		<value>$LOCALIZE[16018]</value>
 	</variable>
+	
+	<variable name="WidgetOnClickAlbum">
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetBrowse)">ActivateWindow(music,musicdb://albums/$INFO[ListItem.DBID]/,return)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetPlay)">PlayMedia(musicdb://albums/$INFO[ListItem.DBID]/)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetPlayNext)">QueueMedia(musicdb://albums/$INFO[ListItem.DBID]/,playnext)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickAlbum),AlbumWidgetQueue)">QueueMedia(musicdb://albums/$INFO[ListItem.DBID]/)</value>
+	</variable>
+	
+	<variable name="WidgetOnClickTVShow">
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetBrowse)">ActivateWindow(videos,videodb://tvshows/titles/$INFO[ListItem.DBID]/,return)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetContinueWatching)">PlayMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/,resume)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetPlayFromBeginning)">PlayMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/,noresume)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetPlayNext)">QueueMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/,playnext)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickTVShow),TVShowWidgetQueue)">QueueMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/)</value>
+	</variable>
+	
+	<variable name="WidgetOnClickMovieSet">
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetBrowse)">ActivateWindow(videos,videodb://movies/sets/$INFO[ListItem.DBID]/,return)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetContinueWatching)">PlayMedia(videodb://movies/sets/$INFO[ListItem.DBID]/,resume)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetPlayFromBeginning)">PlayMedia(videodb://movies/sets/$INFO[ListItem.DBID]/,noresume)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetPlayNext)">QueueMedia(videodb://movies/sets/$INFO[ListItem.DBID]/,playnext)</value>
+		<value condition="String.IsEqual(Skin.String(WidgetOnClickMovieSet),MovieSetWidgetQueue)">QueueMedia(videodb://movies/sets/$INFO[ListItem.DBID]/)</value>
+	</variable>
 
 </includes>

--- a/xml/script-skinshortcuts-static.xml
+++ b/xml/script-skinshortcuts-static.xml
@@ -1545,6 +1545,9 @@
 				<param name="container1">10001</param>
 				<param name="container2">1-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="360" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -1806,6 +1809,9 @@
 				<param name="container1">10001</param>
 				<param name="container2">1-2</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="360" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -2067,6 +2073,9 @@
 				<param name="container1">10002</param>
 				<param name="container2">2-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="360" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -2326,6 +2335,9 @@
 				<param name="container1">10002</param>
 				<param name="container2">2-2</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="360" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -2585,6 +2597,9 @@
 				<param name="container1">10004</param>
 				<param name="container2">4-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="240" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -2844,6 +2859,9 @@
 				<param name="container1">10004</param>
 				<param name="container2">4-2</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="240" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -3103,6 +3121,9 @@
 				<param name="container1">10006</param>
 				<param name="container2">6-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="240" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -3362,6 +3383,9 @@
 				<param name="container1">10008</param>
 				<param name="container2">8-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="240" width="240">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -3822,6 +3846,9 @@
 				<param name="container1">100010</param>
 				<param name="container2">10-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="320" width="320">
 				<include content="widget-image">
 					<description>Primary art</description>
@@ -4081,6 +4108,9 @@
 				<param name="container1">100011</param>
 				<param name="container2">11-1</param>
 			</include>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,album)">$VAR[WidgetOnClickAlbum]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)">$VAR[WidgetOnClickTVShow]</onclick>
+			<onclick condition="String.IsEqual(ListItem.DBTYPE,set)">$VAR[WidgetOnClickMovieSet]</onclick>
 			<itemlayout height="320" width="320">
 				<include content="widget-image">
 					<description>Primary art</description>


### PR DESCRIPTION
strings.po:
- adjust localizes to always use 'main menu' instead of 'home screen' (31076, 31077, 31320)
- add localizes for new adjust select action of album, TV show and movie set main menu widgets settings (31438, 31439, 31440, 31441, 31442, 31443)

template.xml:
- add new widget onclick controls

Includes.xml:
- add new onload conditions for new adjust select action of album, TV show and movie set main menu widgets settings

script-skinshortcuts-static.xml:
- add new widget onclick controls

SkinSettings.xml:
- add new adjust select action of album, TV show and movie set main menu widgets settings

Variables_Settings.xml:
- add new variable values to SkinSettingsExplanation for new adjust select action of album, TV show and movie set main menu widgets settings

Variables_Skinshortcuts.xml:
- add new WidgetOnClickAlbum, WidgetOnClickTVShow and WidgetOnClickMovieSet variables for new widget onclick controls

Addon.xml:
- bump version to 20.1.1
- update changelog

Changelog.md:
- update changelog