### PR TITLE
Fix wide view focus animation and media flags scrolling transition

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@
 _New_
 - add new setting to adjust select action of album, TV show and movie set main menu widgets
 
+_Fixed_
+- fix focus cover animation in wide views
+- fix media flags transition glitch
+
 ---
 
 **_v20.1.0 - August 2023_**
@@ -487,8 +491,30 @@ strings.po:
 template.xml:
 - add new widget onclick controls
 
+Coordinates_Viewtype52.xml:
+- fix focus cover animation
+
+Coordinates_Viewtype521.xml:
+- fix focus cover animation
+
+Coordinates_Viewtype522.xml:
+- fix focus cover animation
+
+Coordinates_Viewtype523.xml:
+- fix focus cover animation
+
+Coordinates_Viewtype524.xml:
+- fix focus cover animation
+
+Coordinates_Viewtype525.xml:
+- fix focus cover animation
+
 Includes.xml:
 - add new onload conditions for new adjust select action of album, TV show and movie set main menu widgets settings
+
+Includes_MediaFlags.xml:
+- add fade animation during on next and on previous transitions to hide media flags glitch
+- fix hide animation for edge cases
 
 script-skinshortcuts-static.xml:
 - add new widget onclick controls

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new setting to adjust select action of album, TV show and movie set main menu widgets</news>
+		<news>[B]New[/B][CR]- add new setting to adjust select action of album, TV show and movie set main menu widgets[CR][CR][B]Fixed[/B][CR]- fix focus cover animation in wide views[CR]- fix media flags transition glitch</news>
 	</extension>
 </addon>

--- a/xml/Coordinates_Viewtype52.xml
+++ b/xml/Coordinates_Viewtype52.xml
@@ -144,7 +144,7 @@
 	<include name="Viewtype52_coords3_16:9">
 		<focusedlayout width="405" height="600">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(52).OnNext + !Container(52).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(52).OnNext | Container(52).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -169,7 +169,7 @@
 	<include name="Viewtype52_coords3_21:9">
 		<focusedlayout width="405" height="600">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(52).OnNext + !Container(52).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(52).OnNext | Container(52).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -194,7 +194,7 @@
 	<include name="Viewtype52_coords3_21:9_masked">
 		<focusedlayout width="405" height="600">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(52).OnNext + !Container(52).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(52).OnNext | Container(52).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -219,7 +219,7 @@
 	<include name="Viewtype52_coords3_4:3">
 		<focusedlayout width="405" height="600">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(52).OnNext + !Container(52).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(52).OnNext | Container(52).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>

--- a/xml/Coordinates_Viewtype521.xml
+++ b/xml/Coordinates_Viewtype521.xml
@@ -144,7 +144,7 @@
 	<include name="Viewtype521_coords3_16:9">
 		<focusedlayout width="180" height="270">
 			<control type="group">
-				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="!Container(521).OnNext + !Container(521).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="Container(521).OnNext | Container(521).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -169,7 +169,7 @@
 	<include name="Viewtype521_coords3_21:9">
 		<focusedlayout width="180" height="270">
 			<control type="group">
-				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="!Container(521).OnNext + !Container(521).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="Container(521).OnNext | Container(521).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -194,7 +194,7 @@
 	<include name="Viewtype521_coords3_21:9_masked">
 		<focusedlayout width="180" height="270">
 			<control type="group">
-				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="!Container(521).OnNext + !Container(521).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="Container(521).OnNext | Container(521).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -219,7 +219,7 @@
 	<include name="Viewtype521_coords3_4:3">
 		<focusedlayout width="180" height="270">
 			<control type="group">
-				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="!Container(521).OnNext + !Container(521).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="77" end="100" center="90,166" time="300" tween="back" easing="out" reversible="false" condition="Container(521).OnNext | Container(521).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>

--- a/xml/Coordinates_Viewtype522.xml
+++ b/xml/Coordinates_Viewtype522.xml
@@ -144,7 +144,7 @@
 	<include name="Viewtype522_coords3_16:9">
 		<focusedlayout width="320" height="480">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="!Container(522).OnNext + !Container(522).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="Container(522).OnNext | Container(522).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -169,7 +169,7 @@
 	<include name="Viewtype522_coords3_21:9">
 		<focusedlayout width="320" height="480">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="!Container(522).OnNext + !Container(522).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="Container(522).OnNext | Container(522).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -194,7 +194,7 @@
 	<include name="Viewtype522_coords3_21:9_masked">
 		<focusedlayout width="320" height="480">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="!Container(522).OnNext + !Container(522).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="Container(522).OnNext | Container(522).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>
@@ -219,7 +219,7 @@
 	<include name="Viewtype522_coords3_4:3">
 		<focusedlayout width="320" height="480">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="!Container(522).OnNext + !Container(522).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="160,384" time="300" tween="back" easing="out" reversible="false" condition="Container(522).OnNext | Container(522).OnPrevious">Focus</animation>
 				<!-- Image - Movies -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultMovie.png</param>

--- a/xml/Coordinates_Viewtype523.xml
+++ b/xml/Coordinates_Viewtype523.xml
@@ -288,7 +288,7 @@
 	<include name="Viewtype523_coords3_16:9">
 		<focusedlayout width="405" height="400">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(523).OnNext + !Container(523).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(523).OnNext | Container(523).OnPrevious">Focus</animation>
 				<!-- Image - Albums -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAlbumCover.png</param>
@@ -349,7 +349,7 @@
 	<include name="Viewtype523_coords3_21:9">
 		<focusedlayout width="405" height="400">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(523).OnNext + !Container(523).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(523).OnNext | Container(523).OnPrevious">Focus</animation>
 				<!-- Image - Albums -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAlbumCover.png</param>
@@ -410,7 +410,7 @@
 	<include name="Viewtype523_coords3_21:9_masked">
 		<focusedlayout width="405" height="400">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(523).OnNext + !Container(523).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(523).OnNext | Container(523).OnPrevious">Focus</animation>
 				<!-- Image - Albums -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAlbumCover.png</param>
@@ -471,7 +471,7 @@
 	<include name="Viewtype523_coords3_4:3">
 		<focusedlayout width="405" height="400">
 			<control type="group">
-				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="!Container(523).OnNext + !Container(523).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="60" end="100" center="auto" time="300" tween="back" easing="out" reversible="false" condition="Container(523).OnNext | Container(523).OnPrevious">Focus</animation>
 				<!-- Image - Albums -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAlbumCover.png</param>

--- a/xml/Coordinates_Viewtype524.xml
+++ b/xml/Coordinates_Viewtype524.xml
@@ -108,7 +108,7 @@
 	<include name="Viewtype524_coords3_16:9">
 		<focusedlayout width="248" height="244">
 			<control type="group">
-				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="!Container(524).OnNext + !Container(524).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="Container(524).OnNext | Container(524).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -124,7 +124,7 @@
 	<include name="Viewtype524_coords3_21:9">
 		<focusedlayout width="244" height="244">
 			<control type="group">
-				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="!Container(524).OnNext + !Container(524).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="Container(524).OnNext | Container(524).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -140,7 +140,7 @@
 	<include name="Viewtype524_coords3_21:9_masked">
 		<focusedlayout width="244" height="244">
 			<control type="group">
-				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="!Container(524).OnNext + !Container(524).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="Container(524).OnNext | Container(524).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -156,7 +156,7 @@
 	<include name="Viewtype524_coords3_4:3">
 		<focusedlayout width="246" height="244">
 			<control type="group">
-				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="!Container(524).OnNext + !Container(524).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="76" end="100" center="124,152" time="300" tween="back" easing="out" reversible="false" condition="Container(524).OnNext | Container(524).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>

--- a/xml/Coordinates_Viewtype525.xml
+++ b/xml/Coordinates_Viewtype525.xml
@@ -108,7 +108,7 @@
 	<include name="Viewtype525_coords3_16:9">
 		<focusedlayout width="400" height="400">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="!Container(525).OnNext + !Container(525).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="Container(525).OnNext | Container(525).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -124,7 +124,7 @@
 	<include name="Viewtype525_coords3_21:9">
 		<focusedlayout width="400" height="400">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="!Container(525).OnNext + !Container(525).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="Container(525).OnNext | Container(525).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -140,7 +140,7 @@
 	<include name="Viewtype525_coords3_21:9_masked">
 		<focusedlayout width="400" height="400">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="!Container(525).OnNext + !Container(525).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="Container(525).OnNext | Container(525).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -156,7 +156,7 @@
 	<include name="Viewtype525_coords3_4:3">
 		<focusedlayout width="402" height="400">
 			<control type="group">
-				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="!Container(525).OnNext + !Container(525).OnPrevious">Conditional</animation>
+				<animation effect="zoom" start="40" end="100" center="200,320" time="300" tween="back" easing="out" reversible="false" condition="Container(525).OnNext | Container(525).OnPrevious">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>

--- a/xml/DialogMusicInfo.xml
+++ b/xml/DialogMusicInfo.xml
@@ -357,7 +357,7 @@
 						</control>
 					</control>
 
-					<!-- Audio -->
+					<!-- File information -->
 					<control type="group">
 						<include>DialogMusicInfo_coords5</include>
 						<visible>!String.IsEmpty(ListItem.MusicChannels)</visible>

--- a/xml/Includes_MediaFlags.xml
+++ b/xml/Includes_MediaFlags.xml
@@ -6,6 +6,9 @@
 		<control type="group">
 			<include>MediaFlags_coords1</include>
 			<visible>Integer.IsGreater(Container.NumItems,0) + !String.IsEqual(Skin.String(mediaflags),None) + [Container.Content(files) | Container.Content(songs) | Container.Content(movies) | Container.Content(episodes) | Container.Content(musicvideos) | Container.Content(videos) | Window.IsVisible(MyPlaylist.xml)]</visible>
+			<animation type="Conditional" reversible="false" condition="Container.OnNext | Container.OnPrevious">
+				<effect type="fade" end="0" time="0" />
+			</animation>
 			
 			<!-- File first/only -->
 			<control type="grouplist">
@@ -18,7 +21,7 @@
 				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),Language first) + [Control.IsVisible(9995) | Control.IsVisible(9997)] + !System.IdleTime(1)">
 					<effect type="fade" end="0" time="0" />
 				</animation>
-				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),Language first) + ![Control.IsVisible(9995) | Control.IsVisible(9997)] + !System.IdleTime(1)">
+				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),Language first) + !Control.IsVisible(9995) + !Control.IsVisible(9997) + !System.IdleTime(1)">
 					<effect type="fade" end="100" time="0" />
 				</animation>
 				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),Language first) + [Control.IsVisible(9995) | Control.IsVisible(9997)] + System.IdleTime(1)" loop="true">
@@ -111,7 +114,7 @@
 				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),File first) + [Control.IsVisible(9989) | Control.IsVisible(9991) | Control.IsVisible(9993)] + !System.IdleTime(1)">
 					<effect type="fade" end="0" time="0" />
 				</animation>
-				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),File first) + ![Control.IsVisible(9989) | Control.IsVisible(9991) | Control.IsVisible(9993)] + !System.IdleTime(1)">
+				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),File first) + !Control.IsVisible(9989) + !Control.IsVisible(9991) + !Control.IsVisible(9993) + !System.IdleTime(1)">
 					<effect type="fade" end="100" time="0" />
 				</animation>
 				<animation type="Conditional" reversible="false" condition="String.IsEqual(Skin.String(mediaflags),File first) + [Control.IsVisible(9989) | Control.IsVisible(9991) | Control.IsVisible(9993)] + System.IdleTime(1)" loop="true">
@@ -178,7 +181,7 @@
 			<!-- Duration only -->
 			<control type="group">
 				<include>MediaFlags_coords2</include>
-				<visible>String.IsEqual(Skin.String(mediaflags),Duration only) | String.IsEqual(Skin.String(mediaflags),File only) + ![Control.IsVisible(9989) | Control.IsVisible(9991) | Control.IsVisible(9993)] | String.IsEqual(Skin.String(mediaflags),Language only) + ![Control.IsVisible(9995) | Control.IsVisible(9997)] | [String.IsEqual(Skin.String(mediaflags),File first) | String.IsEqual(Skin.String(mediaflags),Language first)] + ![Control.IsVisible(9989) | Control.IsVisible(9991) | Control.IsVisible(9993) | Control.IsVisible(9995) | Control.IsVisible(9997)] | Window.IsVisible(MyPlaylist.xml)</visible>
+				<visible>String.IsEqual(Skin.String(mediaflags),Duration only) | String.IsEqual(Skin.String(mediaflags),File only) + !Control.IsVisible(9989) + !Control.IsVisible(9991) + !Control.IsVisible(9993) | String.IsEqual(Skin.String(mediaflags),Language only) + !Control.IsVisible(9995) + !Control.IsVisible(9997) | [String.IsEqual(Skin.String(mediaflags),File first) | String.IsEqual(Skin.String(mediaflags),Language first)] + !Control.IsVisible(9989) + !Control.IsVisible(9991) + !Control.IsVisible(9993) + !Control.IsVisible(9995) + !Control.IsVisible(9997) | Window.IsVisible(MyPlaylist.xml)</visible>
 				<visible>!String.IsEmpty(ListItem.Duration)</visible>
 				<control type="image">
 					<include>MediaFlags_coords7</include>

--- a/xml/MusicVisualisation.xml
+++ b/xml/MusicVisualisation.xml
@@ -418,6 +418,24 @@
 						</control>
 					</control>
 					
+					<!-- Comment -->
+					<control type="group">
+						<include>MusicVisualisation_coords19</include>
+						<visible>!String.IsEmpty(MusicPlayer.Comment) + [String.IsEmpty(MusicPlayer.Artist) | String.IsEmpty(MusicPlayer.Album) | String.IsEmpty(Player.Title) | String.IsEmpty(MusicPlayer.Genre) | String.IsEmpty(MusicPlayer.Property(Role.Composer))]</visible>
+						<control type="fadelabel">
+							<include>MusicVisualisation_coords20</include>
+							<align>right</align>
+							<font>Font36</font>
+							<label>$LOCALIZE[569]</label>
+							<textcolor>$VAR[TextColorNF]</textcolor>
+						</control>
+						<control type="fadelabel">
+							<include>MusicVisualisation_coords21</include>
+							<font>Font36</font>
+							<label>$INFO[MusicPlayer.Comment]</label>
+						</control>
+					</control>
+					
 					<!-- File information (non-DSD) -->
 					<control type="group">
 						<include>MusicVisualisation_coords19</include>


### PR DESCRIPTION
Coordinates_Viewtype52.xml:
- fix focus cover animation

Coordinates_Viewtype521.xml:
- fix focus cover animation

Coordinates_Viewtype522.xml:
- fix focus cover animation

Coordinates_Viewtype523.xml:
- fix focus cover animation

Coordinates_Viewtype524.xml:
- fix focus cover animation

Coordinates_Viewtype525.xml:
- fix focus cover animation

Includes_MediaFlags.xml:
- add fade animation during on next and on previous transitions to hide media flags glitch
- fix hide animation for edge cases

MusicVisualisation.xml:
- add back comment info (only shown, if one of the other info fields is empty)
