### PR TITLE
Add legacy font titles to Font.xml for backwards compatibility

### DIFF
--- a/xml/Font.xml
+++ b/xml/Font.xml
@@ -241,6 +241,44 @@
 			<linespacing>1.3</linespacing>
 			<style>italics</style>
 		</font>
+
+		<!-- Legacy Titles -->
+		<font>
+			<name>XLarge</name>
+			<filename>SourceSansPro-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>48</size>
+		</font>
+		<font>
+			<name>Large</name>
+			<filename>SourceSansPro-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>43</size>
+		</font>
+		<font>
+			<name>Med</name>
+			<filename>SourceSansPro-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>38</size>
+		</font>
+		<font>
+			<name>Small</name>
+			<filename>SourceSansPro-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>33</size>
+		</font>
+		<font>
+			<name>XSmall</name>
+			<filename>SourceSansPro-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>28</size>
+		</font>
+		<font>
+			<name>Clock</name>
+			<filename>SourceSansPro-Regular.ttf</filename>
+			<linespacing>0.94</linespacing>
+			<size>120</size>
+		</font>			
 		
 		<!-- Original Title -->
 		<font>
@@ -548,6 +586,50 @@
 			<style>italics</style>
 			<aspect>0.92</aspect>
 		</font>
+
+		<!-- Legacy Titles -->
+		<font>
+			<name>XLarge</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>48</size>
+		</font>
+		<font>
+			<name>Large</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>43</size>
+		</font>
+		<font>
+			<name>Med</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>38</size>
+		</font>
+		<font>
+			<name>Small</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>33</size>
+		</font>
+		<font>
+			<name>XSmall</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>28</size>
+		</font>
+		<font>
+			<name>Clock</name>
+			<filename>Arial.ttf</filename>
+			<aspect>0.95</aspect>
+			<linespacing>0.94</linespacing>
+			<size>120</size>
+		</font>			
 		
 		<!-- Original Title -->
 		<font>


### PR DESCRIPTION
Some addons such as Digital Clock Screensaver by vdb86 use fonts named with legacy font naming scheme ("Large", "Small" etc.) Also there are no large enough fonts to use for fullscreen clock. See https://github.com/vdb86/screensaver.digitalclock/issues/60
I propose adding legacy font titles to font.xml for backwards compatibility.