### PR TITLE
Various fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,18 @@
 
 ---
 
+**_v20.2.1 - March 2024_**
+
+_Improved_
+- improve video info dialog button navigation when moving away from the cast list
+
+_Fixed_
+- fix select dialog icons
+- fix dialog background fallback layers
+- minor fixes before transition to v21
+
+---
+
 **_v20.2.0 - December 2023_**
 
 _New_
@@ -494,234 +506,54 @@ Release
 
 ---
 
-**Changelog v20.1.1**
-
-_rename default live TV home menu items to use new heading localize ID_
-
-strings.po:
-- add localizes for new adjust select action of album, TV show and movie set main menu widgets settings (31438, 31439, 31440, 31441, 31442, 31443)
-- remove deprecated live TV localize and replace it with new favourite content label (31015)
-- remove deprecated search result and timer localizes (31293, 31433, 31434)
-- add new localizes for TV/radio guide genre colour setting (31293, 31433)
-
-textures.xbt:
-- update textures file with new TV/radio guide genre colour assets
-
-mainmenu.DATA.xml:
-- replace live TV home menu item localize to use the new localize ID
-
-overrides.xml:
-- rework TV and radio nodes for home menu item and widgets sections using the new localize ID for the TV section
+**Changelog v20.2.1**
 
 template.xml:
-- add new widget onclick controls
-- add new recording, timer and reminder icons to the widget template
+- fix animation condition of recording, timer and reminder icon slide animations
 
-Coordinates_Custom_DialogMasking.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
+Coordinates_DialogSelect.xml:
+- remove deprecated image controls for cases where the icon info label was populated with a 'Default' string
 
-Coordinates_DialogAddonSettings.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
+Coordinates_FileBrowser.xml:
+- remove deprecated image controls for cases where the icon info label was populated with a 'Default' string
 
-Coordinates_DialogExtendedProgressBar.xml:
-- add coordinates includes for new progress bar busy spinner icon
+DialogSelect.xml:
+- remove deprecated image control for cases where the icon info label was populated with a 'Default' string
 
-Coordinates_DialogKeyboard.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_DialogPVRChannelGuide.xml:
-- add new reminder icons and rework recording and timer icons for consistency
-
-Coordinates_DialogPVRChannelManager.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_DialogPVRChannelsOSD.xml:
-- add missing recording and timer and new reminder icons
-
-Coordinates_DialogPVRGroupManager.xml:
-- add missing channel icons to lists
-
-Coordinates_DialogPVRGuideSearch.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_DialogSettings.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_Includes_SubMenu.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_Includes_Time_NowPlaying.xml:
-- add coordinates includes for new dialog confirm busy spinner icon
-
-Coordinates_MyPVRChannels.xml:
-- rework coordinates includes for more consistent window look
-- add missing recording and timer and new reminder icons
-
-Coordinates_MyPVRGuide.xml:
-- fix colours of timer and reminder icons
-- adjust position of recording, timer and reminder images to prevent overlap with added highlighting textures
-- adjust TV/radio guide background textures for new TV/radio guide genre colours
-
-Coordinates_MyPVRRecordings.xml:
-- rework coordinates includes for more consistent window look
-- add missing recording and timer and new reminder icons
-
-Coordinates_MyPVRSearch.xml:
-- rework coordinates includes for more consistent window look
-- add missing recording and timer and new reminder icons
-
-Coordinates_MyPVRTimers.xml:
-- rework coordinates includes for more consistent window look
-- add missing recording and timer and new reminder icons
-
-Coordinates_script-skinshortcuts.xml:
-- add new coordinates includes to add textwidth tags for radio button control
-
-Coordinates_SettingsCategory.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_SettingsProfiles.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_SkinSettings.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_SmartPlaylistEditor.xml:
-- rework coordinates includes to add and adjust textwidth tags for radio button controls
-
-Coordinates_Viewtype52.xml:
-- fix focus cover animation
-
-Coordinates_Viewtype521.xml:
-- fix focus cover animation
-
-Coordinates_Viewtype522.xml:
-- fix focus cover animation
-
-Coordinates_Viewtype523.xml:
-- fix focus cover animation
-
-Coordinates_Viewtype524.xml:
-- fix focus cover animation
-
-Coordinates_Viewtype525.xml:
-- fix focus cover animation
-
-Defaults.xml:
-- adjust textwidth tag of default radio button control
-
-DialogAddonInfo.xml:
-- adjust textwidth tag of radio button control
-
-DialogConfirm.xml:
-- adjust time include for new progress busy spinner icon
-
-DialogExtendedProgressBar.xml:
-- add new busy spinner icon
-
-DialogFavourites.xml:
-- rework item count visibility condition and animation
-
-DialogKeybard.xml:
-- replace coordinates includes to add and adjust textwidth tags for radio button controls
-
-DialogPVRChannelManager.xml:
-- fix defaultcontrol
-- replace coordinates includes of edit, button, spincontrolex and radio button controls
-
-DialogPVRGroupManager.xml:
-- fix defaultcontrol
-- add textwidth tag to radio button control
-
-DialogPVRGuideSearch.xml:
-- replace coordinates includes to add and adjust textwidth tags for radio button controls
+DialogVideoInfo.xml:
+- fix onright and onleft of cast list to always navigate to last used button
 
 FileBrowser.xml:
-- add textwidth tag to radio button control
-
-FileManager.xml:
-- rework item count visibility condition and animation
-
-Includes.xml:
-- add new onload conditions for new adjust select action of album, TV show and movie set main menu widgets settings
-
-Includes_DialogSettings.xml:
-- replace coordinates include to add and adjust textwidth tags for radio button control
-
-Includes_MediaFlags.xml:
-- add fade animation during on next and on previous transitions to hide media flags glitch
-- adjust media flags animations for more consitent behaviour
-- rework duration only label to incorporate MyPlaylist window more seamlessly
-- rework item count visibility condition and animation
-
-Includes_SubMenu.xml:
-- adjust addon browser submenu onleft, onright and onback tags for now utilized view types 50 and 51
-- replace PVR & live TV settings sub menu item localize to use the new localize ID
-
-Includes_Time_NowPlaying.xml:
-- adjust now playing labels conditional visibility for better pre-playback information (before streams or network resources are available)
-- adjust time include for new dialog confirm busy spinner icon
+- remove deprecated image control for cases where the icon info label was populated with a 'Default' string
 
 Includes_Windows_Dialogs.xml:
-- add new background transition fallback when media window view type controls are not yet visible
+- adjust color as well as single and multiple background image controls' visibility condition to always render these layers as fallback
 
-MyPrograms.xml:
-- adjust scrollbar visibility condition to remove never used control
-
-MyPVRChannels.xml:
-- rework window for more consistent look
-
-MyPVRGuide.xml:
-- rework item count visibility condition and animation
-- add new colour diffuse variable to guide grid progress timeline
-
-MyPVRRecordings.xml:
-- rework window for more consistent look
-
-MyPVRSearch.xml:
-- rework scrollbar position for more consistent look
-
-MyPVRTimers.xml:
-- rework scrollbar position for more consistent look
+MyVideoNav.xml:
+- remove deprecated movie sets hidden list
 
 script-skinshortcuts-static.xml:
-- add new widget onclick controls
-- add new recording, timer and reminder icons to the widget template
-
-script-skinshortcuts.xml:
-- replace coordinates includes to add and adjust textwidth tags for radio button control
-
-Settings.xml:
-- replace PVR & live TV settings section localize to use the new localize ID
-
-SettingsCategory.xml:
-- replace coordinates includes to add and adjust textwidth tags for radio button controls
-
-SettingsProfiles.xml:
-- replace coordinates includes to add and adjust textwidth tags for radio button control
-
-SkinSettings.xml:
-- add new adjust select action of album, TV show and movie set main menu widgets settings
-- replace coordinates includes to add and adjust textwidth tags for radio button controls
-- add setting for new TV/radio guide colours
+- fix animation condition of recording, timer and reminder icon slide animations
 
 Variables.xml:
-- add new value condition to HeadingLabelSecondary variable for new PVR & live TV settings section localize ID
-- rework PlayerIcon variable for better pre-playback player icon
-- add new epggridunfocusdim variable for unfocus dimming of TV/radio guide grid progress timeline
+- add missing variable condition to SelectImage variable
+- add variable conditions for movie sets to Label2 variable
+- remove deprecated SetListContent, SetLabel and VideoInfoListPlot variables
 
-Variables_Settings.xml:
-- add new variable values to SkinSettingsExplanation for new adjust select action of album, TV show and movie set main menu widgets settings
-- add new variable value for TV/radio guide colour setting explanation text
+Viewtype511.xml:
+- remove deprecated VideoInfoListPlot variable from plot textbox
 
-Variables_Skinshortcuts.xml:
-- add new WidgetOnClickAlbum, WidgetOnClickTVShow and WidgetOnClickMovieSet variables for new widget onclick controls
+Viewtype522.xml:
+- remove deprecated VideoInfoListPlot variable from plot textbox
 
-Viewtype50.xml:
-- rework view type for better content type related icons and instances where the content type is returned empty
+Viewtype531.xml:
+- remove deprecated movie set info label
+
+Viewtype533.xml:
+- remove deprecated movie set info label
 
 Addon.xml:
-- bump version to 20.2.0
+- bump version to 20.2.1
 - update changelog
 
 Changelog.md:

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="20.2.0" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="20.2.1" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.16.0"/>
 	</requires>
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new setting to adjust select action of album, TV show and movie set main menu widgets[CR]- add consistent reminder icons for v20 PVR reminder feature[CR]- add genre colours to TV/radio guide[CR][CR][B]Improved[/B][CR]- improve live TV and radio related localizes[CR]- improve pre-playback behaviour of now playing information section in the top right corner of each window/dialog[CR]- improve consistency between PVR windows and dialogs (feature parity as well as cosmetic appearance)[CR]- improve media flags behaviour during window transitions and when encountering edge cases[CR]- improve progress feedback of confirm dialog as well as the extended progress notification[CR][CR][B]Fixed[/B][CR]- fix focus cover animation in wide views[CR]- fix media flags transition glitch[CR]- fix radio button control text width[CR]- fix behaviour when the correct view type or content type is not yet ready (especially related to addons loading new pages)</news>
+		<news>[B]Improved[/B][CR]- - improve video info dialog button navigation when moving away from the cast list[CR][CR][B]Fixed[/B][CR]- fix select dialog icons[CR]- fix dialog background fallback layers[CR]- minor fixes before transition to v21</news>
 	</extension>
 </addon>

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -452,7 +452,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -460,7 +460,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -468,7 +468,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -535,21 +535,21 @@
 									<centerleft>$PYTHON[int(imageWidthNoFocus) / 2]</centerleft>
 									<texture background="true">pvr/Recording.png</texture>
 									<visible>ListItem.IsRecording</visible>
-									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 								</control>
 								<control type="image">
 									<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
 									<centerleft>$PYTHON[int(imageWidthNoFocus) / 2]</centerleft>
 									<texture background="true">pvr/Timer.png</texture>
 									<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 								</control>
 								<control type="image">
 									<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
 									<centerleft>$PYTHON[int(imageWidthNoFocus) / 2]</centerleft>
 									<texture background="true">pvr/Reminder.png</texture>
 									<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 								</control>
 								<control type="image">
 									<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -614,7 +614,7 @@
 									<texture background="true">pvr/Recording.png</texture>
 									<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 									<visible>ListItem.IsRecording</visible>
-									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 								</control>
 								<control type="image">
 									<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -622,7 +622,7 @@
 									<texture background="true">pvr/Timer.png</texture>
 									<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 									<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 								</control>
 								<control type="image">
 									<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -630,7 +630,7 @@
 									<texture background="true">pvr/Reminder.png</texture>
 									<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 									<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+									<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 								</control>
 								<control type="image">
 									<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -697,7 +697,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
@@ -705,14 +705,14 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>
 								<centerleft>$PYTHON[int(imageWidthNoFocus) / 2]</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
-								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible><animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible><animation effect="slide" end="-$PYTHON[int(imageWidthNoFocus) * 0.11 / 2],0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>$PYTHON[int(imageWidthNoFocus) * 0.11]</width>

--- a/xml/Coordinates_DialogFullScreenInfo.xml
+++ b/xml/Coordinates_DialogFullScreenInfo.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 
-	<include name="DialogFavourites_coords">
-		<include condition="$EXP[NonMaskedCoordinates]">DialogFavourites_coords_16:9</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogFavourites_coords_21:9</include>
-		<include condition="$EXP[MaskedCoordinates]">DialogFavourites_coords_21:9_masked</include>
-		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogFavourites_coords_4:3</include>
+	<include name="DialogFullScreenInfo_coords">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogFullScreenInfo_coords_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogFullScreenInfo_coords_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogFullScreenInfo_coords_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogFullScreenInfo_coords_4:3</include>
 	</include>
-	<include name="DialogFavourites_coords_16:9">
+	<include name="DialogFullScreenInfo_coords_16:9">
 		<left>0</left>
 		<top>292</top>
 		<width>1620</width>
 		<height>40</height>
 	</include>
-	<include name="DialogFavourites_coords_21:9">
+	<include name="DialogFullScreenInfo_coords_21:9">
 		<left>0</left>
 		<top>472</top>
 		<width>1620</width>
 		<height>40</height>
 	</include>
-	<include name="DialogFavourites_coords_21:9_masked">
+	<include name="DialogFullScreenInfo_coords_21:9_masked">
 		<left>0</left>
 		<top>292</top>
 		<width>1620</width>
 		<height>40</height>
 	</include>
-	<include name="DialogFavourites_coords_4:3">
+	<include name="DialogFullScreenInfo_coords_4:3">
 		<left>150</left>
 		<top>225</top>
 		<width>405</width>

--- a/xml/Coordinates_DialogSelect.xml
+++ b/xml/Coordinates_DialogSelect.xml
@@ -259,16 +259,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$VAR[SelectImage]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -311,16 +301,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$VAR[SelectImage]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -363,16 +343,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$VAR[SelectImage]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -415,16 +385,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$VAR[SelectImage]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -477,16 +437,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$VAR[SelectImage]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="group">
 					<visible>String.IsEmpty(ListItem.Label2)</visible>
@@ -537,7 +487,6 @@
 						<textcolor>$VAR[TextColorFO]</textcolor>
 						<label>$INFO[ListItem.Label2]</label>
 						<scroll>True</scroll>
-						<visible>!String.IsEmpty(ListItem.Label2)</visible>
 					</control>
 				</control>
 			</control>
@@ -555,16 +504,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$VAR[SelectImage]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="group">
 					<visible>String.IsEmpty(ListItem.Label2)</visible>
@@ -615,7 +554,6 @@
 						<textcolor>$VAR[TextColorFO]</textcolor>
 						<label>$INFO[ListItem.Label2]</label>
 						<scroll>True</scroll>
-						<visible>!String.IsEmpty(ListItem.Label2)</visible>
 					</control>
 				</control>
 			</control>
@@ -633,16 +571,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$VAR[SelectImage]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="group">
 					<visible>String.IsEmpty(ListItem.Label2)</visible>
@@ -710,16 +638,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$VAR[SelectImage]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="group">
 					<visible>String.IsEmpty(ListItem.Label2)</visible>

--- a/xml/Coordinates_FileBrowser.xml
+++ b/xml/Coordinates_FileBrowser.xml
@@ -446,16 +446,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$INFO[ListItem.Icon]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -476,16 +466,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$INFO[ListItem.Icon]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -506,16 +486,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$INFO[ListItem.Icon]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -536,16 +506,6 @@
 				<aspectratio>keep</aspectratio>
 				<texture>$INFO[ListItem.Icon]</texture>
 				<include>NonFocusImageFadeAnimation</include>
-				<visible>!String.Contains(ListItem.Icon,Default)</visible>
-			</control>
-			<control type="image">
-				<width>96</width>
-				<height>96</height>
-				<bordersize>6</bordersize>
-				<aspectratio>keep</aspectratio>
-				<include>NonFocusImageFadeAnimation</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
 			</control>
 			<control type="label">
 				<left>140</left>
@@ -576,16 +536,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="label">
 					<left>140</left>
@@ -619,16 +569,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="label">
 					<left>140</left>
@@ -662,16 +602,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="label">
 					<left>140</left>
@@ -705,16 +635,6 @@
 					<bordersize>6</bordersize>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>!String.Contains(ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<width>96</width>
-					<height>96</height>
-					<bordersize>6</bordersize>
-					<aspectratio>keep</aspectratio>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<texture>$INFO[ListItem.Icon]</texture>
-					<visible>String.Contains(ListItem.Icon,Default)</visible>
 				</control>
 				<control type="label">
 					<left>140</left>

--- a/xml/Coordinates_Viewtype539.xml
+++ b/xml/Coordinates_Viewtype539.xml
@@ -406,9 +406,7 @@
 	</include>
 	<include name="Viewtype539_coords12_16:9">
 		<left>15</left>
-		<bottom>0</bottom>
-		<width>133</width>
-		<height>15</height>
+		<centerleft>67</centerleft>
 	</include>
 	<include name="Viewtype539_coords12_21:9">
 		<width>15</width>

--- a/xml/DialogFullScreenInfo.xml
+++ b/xml/DialogFullScreenInfo.xml
@@ -12,7 +12,7 @@
 	<controls>
 	
 		<control type="button" id="100">
-			<include>DialogFavourites_coords</include>
+			<include>DialogFullScreenInfo_coords</include>
 			<onright condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + String.IsEmpty(Window(12005).Property(shownext))">SetProperty(shownext,True,12005)</onright>
 			<onleft condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + String.IsEmpty(Window(12005).Property(shownext))">SetProperty(shownext,True,12005)</onleft>
 			<onright condition="Pvr.IsPlayingTv + VideoPlayer.HasEpg + !String.IsEmpty(Window(12005).Property(shownext))">ClearProperty(shownext,12005)</onright>

--- a/xml/DialogPlayerProcessInfo.xml
+++ b/xml/DialogPlayerProcessInfo.xml
@@ -75,7 +75,7 @@
 					<control type="label">
 						<include>DialogPlayerProcessInfo_coords5</include>
 						<aligny>bottom</aligny>
-						<label>$INFO[Player.Process(VideoDecoder),[LIGHT]$LOCALIZE[38031]:[/LIGHT] [CAPITALIZE],[/CAPITALIZE]][LIGHT] ($INFO[Player.Process(videowidth),,x]$INFO[Player.Process(videoheight)]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA ,:1]$INFO[Player.Process(videofps),$COMMA , fps])[/LIGHT]</label>
+						<label>$INFO[Player.Process(VideoDecoder),[LIGHT]$LOCALIZE[38031]:[/LIGHT] [CAPITALIZE],[/CAPITALIZE]][LIGHT] ($INFO[Player.Process(videowidth)]$INFO[Player.Process(videoheight),x,]$INFO[Player.Process(videoscantype)]$INFO[Player.Process(videodar),$COMMA ,:1]$INFO[Player.Process(videofps),$COMMA , fps])[/LIGHT]</label>
 						<font>Font25</font>
 						<visible>Player.HasVideo</visible>					
 					</control>

--- a/xml/DialogSelect.xml
+++ b/xml/DialogSelect.xml
@@ -17,6 +17,7 @@
 			
 			<control type="group">
 				<include>DialogDepth</include>
+				
 				<!-- Animation -->
 				<include>DialogZoomAnimation</include>
 			
@@ -35,14 +36,7 @@
 					<include>DialogSelect_coords1</include>
 					<texture>$VAR[SelectImage]</texture>
 					<aspectratio aligny="center">keep</aspectratio>
-					<visible>Control.IsVisible(6) + !String.Contains(Container(6).ListItem.Icon,Default)</visible>
-				</control>
-				<control type="image">
-					<include>DialogSelect_coords1</include>
-					<texture>$INFO[Container(6).ListItem.Icon]</texture>
-					<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-					<aspectratio aligny="center">keep</aspectratio>
-					<visible>Control.IsVisible(6) + String.Contains(Container(6).ListItem.Icon,Default)</visible>
+					<visible>Control.IsVisible(6)</visible>
 				</control>
 
 				<!-- List -->
@@ -135,6 +129,7 @@
 		<control type="group">
 			<include>DialogDepth</include>
 			<visible>[Window.IsVisible(gamevideofilter) | Window.IsVisible(gamestretchmode) | Window.IsVisible(gamevideorotation)] + !Window.IsVisible(shutdownmenu)</visible>
+			
 			<!-- Animation -->
 			<animation effect="slide" start="0,500" time="200">WindowOpen</animation>
 			<animation effect="slide" end="0,500" time="200">WindowClose</animation>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -610,7 +610,8 @@
 				<onup>50</onup>
 				<ondown>50</ondown>
 				<onleft>60</onleft>
-				<onright>9000</onright>
+				<onright condition="Control.IsVisible(17) + !Control.IsVisible(18)">17</onright>
+				<onright condition="!Control.IsVisible(17) + Control.IsVisible(18)">18</onright>
 				<orientation>vertical</orientation>
 				<viewtype label="$LOCALIZE[535]">list</viewtype>
 				<pagecontrol>60</pagecontrol>
@@ -627,7 +628,8 @@
 			<!-- Scrollbar -->
 			<control type="scrollbar" id="60">
 				<include>DialogVideoInfo_coords12</include>
-				<onleft>9000</onleft>
+				<onleft condition="Control.IsVisible(17) + !Control.IsVisible(18)">17</onleft>
+				<onleft condition="!Control.IsVisible(17) + Control.IsVisible(18)">18</onleft>
 				<onright>50</onright>
 				<showonepage>false</showonepage>
 				<orientation>vertical</orientation>

--- a/xml/FileBrowser.xml
+++ b/xml/FileBrowser.xml
@@ -32,20 +32,13 @@
 				<include>FileBrowser_coords1</include>
 				<texture>$INFO[ListItem.Icon]</texture>
 				<aspectratio aligny="center">keep</aspectratio>
-				<visible>!String.Contains(ListItem.Icon,Default) + !String.Contains(Control.GetLabel(416),*)</visible>
+				<visible>!String.Contains(Control.GetLabel(416),*)</visible>
 			</control>
 			<control type="image">
 				<include>FileBrowser_coords1</include>
 				<texture flipx="true">$INFO[ListItem.Icon]</texture>
 				<aspectratio aligny="center">keep</aspectratio>
-				<visible>!String.Contains(ListItem.Icon,Default) + String.Contains(Control.GetLabel(416),*)</visible>
-			</control>
-			<control type="image">
-				<include>FileBrowser_coords1</include>
-				<texture>$INFO[ListItem.Icon]</texture>
-				<colordiffuse>$VAR[OverlayColorFO]</colordiffuse>
-				<aspectratio aligny="center">keep</aspectratio>
-				<visible>String.Contains(ListItem.Icon,Default)</visible>
+				<visible>String.Contains(Control.GetLabel(416),*)</visible>
 			</control>
 			<control type="image">
 				<include>FileBrowser_coords1</include>

--- a/xml/Includes_Windows_Dialogs.xml
+++ b/xml/Includes_Windows_Dialogs.xml
@@ -288,7 +288,7 @@
 			<include>FullscreenDimensions</include>
 			<texture background="true">common/white.png</texture>
 			<colordiffuse>$VAR[SolidBackgroundColor]</colordiffuse>
-			<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),no) | String.IsEqual(Skin.String(BackgroundSingleImage),solid)] + ![!String.IsEmpty(ListItem.Art(fanart)) + !Skin.HasSetting(HideFanart)]</visible>
+			<visible>String.IsEqual(Skin.String(BackgroundDefaultImage),no) | String.IsEqual(Skin.String(BackgroundSingleImage),solid)</visible>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
 			<include>DialogBackgroundDepth</include>
@@ -298,7 +298,7 @@
 		<control type="image">
 			<include>FullscreenDimensions</include>
 			<texture background="true">$VAR[OSMCBackgroundImage]</texture>
-			<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(9000).ListItem.Property(background)) + ![!String.IsEmpty(ListItem.Art(fanart)) + !Skin.HasSetting(HideFanart)]</visible>
+			<visible>[String.IsEqual(Skin.String(BackgroundDefaultImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),yes) | String.IsEqual(Skin.String(BackgroundSingleImage),no) + String.IsEmpty(Skin.String(CustomBackgroundFolder))] + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
 			<aspectratio>scale</aspectratio>
 			<include>DialogZoomAnimation</include>
 			<include>DialogBackgroundDepth</include>
@@ -308,7 +308,7 @@
 		<control type="multiimage">
 			<include>FullscreenDimensions</include>
 			<imagepath background="true">$VAR[OSMCBackgroundImage]</imagepath>
-			<visible>String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder)) + String.IsEmpty(Container(9000).ListItem.Property(background)) + ![!String.IsEmpty(ListItem.Art(fanart)) + !Skin.HasSetting(HideFanart)]</visible>
+			<visible>String.IsEqual(Skin.String(BackgroundSingleImage),no) + !String.IsEmpty(Skin.String(CustomBackgroundFolder)) + String.IsEmpty(Container(9000).ListItem.Property(background))</visible>
 			<aspectratio>scale</aspectratio>
 			<include>CustomBackgroundFolderDuration</include>
 			<fadetime>2000</fadetime>

--- a/xml/MyVideoNav.xml
+++ b/xml/MyVideoNav.xml
@@ -136,17 +136,6 @@
 				<include>SubMenu</include>
 
 			</control>
-			
-			<!-- Movie sets hidden list -->
-			<control type="list" id="4500">
-				<left>-100</left>
-				<top>-100</top>
-				<width>100</width>
-				<height>100</height>
-				<itemlayout height="100" width="100" />
-				<focusedlayout height="100" width="100" />
-				<content sortby="year" sortorder="ascending">$VAR[SetListContent]</content>
-			</control>
 
 			<include>MaskingBars</include>
 			

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -448,6 +448,7 @@
 	
 	<variable name="SelectImage">
 		<value condition="!String.IsEmpty(Container(6).ListItem.Art(poster))">$INFO[Container(6).ListItem.Art(poster)]</value>
+		<value condition="!String.IsEmpty(Container(6).ListItem.Art(thumb))">$INFO[Container(6).ListItem.Art(thumb)]</value>
 		<value>$INFO[Container(6).ListItem.Icon]</value>
 	</variable>
 
@@ -483,7 +484,11 @@
 	<variable name="Label2">
 		<value condition="Container.Content(movies) + !ListItem.IsCollection + !String.IsEmpty(ListItem.Year)">$INFO[ListItem.Year]$INFO[ListItem.Genre, &#8226; ,]$VAR[LabelUserRating]</value>
 		<value condition="Container.Content(movies) + !ListItem.IsCollection + String.IsEmpty(ListItem.Year)">$INFO[ListItem.Genre]$VAR[LabelUserRating]</value>
-		<value condition="[Container.Content(sets) | ListItem.IsCollection] + !ListItem.IsParentFolder">$LOCALIZE[20457]</value>
+		<value condition="[Container.Content(sets) | ListItem.IsCollection] + !ListItem.IsParentFolder + Integer.IsGreater(ListItem.Property(Total),1) + Integer.IsGreater(ListItem.Property(Watched),0)">$INFO[ListItem.Property(Watched),$LOCALIZE[20457] &#8226; $LOCALIZE[16102]: , $LOCALIZE[1443] ]$INFO[ListItem.Property(Total),, $LOCALIZE[36900]]</value>
+		<value condition="[Container.Content(sets) | ListItem.IsCollection] + !ListItem.IsParentFolder + Integer.IsGreater(ListItem.Property(Total),1) + Integer.IsEqual(ListItem.Property(Watched),0)">$INFO[ListItem.Property(Total),$LOCALIZE[20457] &#8226; , $LOCALIZE[36901]]</value>
+		<value condition="[Container.Content(sets) | ListItem.IsCollection] + !ListItem.IsParentFolder + Integer.IsEqual(ListItem.Property(Total),1) + Integer.IsGreater(ListItem.Property(Watched),0)">$INFO[ListItem.Property(Watched),$LOCALIZE[20457] &#8226; $LOCALIZE[16102]: , $LOCALIZE[1443] ]$INFO[ListItem.Property(Total),, $LOCALIZE[36900]]</value>
+		<value condition="[Container.Content(sets) | ListItem.IsCollection] + !ListItem.IsParentFolder + Integer.IsEqual(ListItem.Property(Total),1) + Integer.IsEqual(ListItem.Property(Watched),0)">$INFO[ListItem.Property(Total),$LOCALIZE[20457] &#8226; , $LOCALIZE[36900]]</value>
+		<value condition="[Container.Content(sets) | ListItem.IsCollection] + !ListItem.IsParentFolder + Integer.IsEqual(ListItem.Property(Total),0)">$INFO[ListItem.Property(Total),$LOCALIZE[20457] &#8226; , $LOCALIZE[36901]]</value>
 		<value condition="Container.Content(tvshows) + Integer.IsGreater(ListItem.Property(TotalSeasons),1) + Integer.IsGreater(ListItem.Property(TotalEpisodes),1) + Integer.IsGreater(ListItem.Property(WatchedEpisodes),0)">$INFO[ListItem.Year,, &#8226; ]$INFO[ListItem.Property(TotalSeasons),, $LOCALIZE[36905] &#8226; ]$INFO[ListItem.Property(WatchedEpisodes),$LOCALIZE[16102]: , $LOCALIZE[1443] ]$INFO[ListItem.Property(TotalEpisodes),, $LOCALIZE[36907]]$VAR[LabelUserRating]</value>
 		<value condition="Container.Content(tvshows) + Integer.IsGreater(ListItem.Property(TotalSeasons),1) + Integer.IsGreater(ListItem.Property(TotalEpisodes),1) + Integer.IsEqual(ListItem.Property(WatchedEpisodes),0)">$INFO[ListItem.Year,, &#8226; ]$INFO[ListItem.Property(TotalSeasons),, $LOCALIZE[36905] &#8226; ]$INFO[ListItem.Property(TotalEpisodes),, $LOCALIZE[36907]]$VAR[LabelUserRating]</value>
 		<value condition="Container.Content(tvshows) + Integer.IsEqual(ListItem.Property(TotalSeasons),1) + Integer.IsGreater(ListItem.Property(TotalEpisodes),1) + Integer.IsGreater(ListItem.Property(WatchedEpisodes),0)">$INFO[ListItem.Year,, &#8226; ]$INFO[ListItem.Property(TotalSeasons),, $LOCALIZE[36904] &#8226; ]$INFO[ListItem.Property(WatchedEpisodes),$LOCALIZE[16102]: , $LOCALIZE[1443] ]$INFO[ListItem.Property(TotalEpisodes),, $LOCALIZE[36907]]$VAR[LabelUserRating]</value>
@@ -516,21 +521,6 @@
 	<variable name="LabelUserRating">
 		<value condition="Skin.HasSetting(UserRating) + ![Control.IsVisible(531) | Control.IsVisible(533)]">$INFO[ListItem.UserRating, &#8226; $LOCALIZE[38018]: ,]</value>
 		<value condition="!Skin.HasSetting(UserRating)"></value>
-	</variable>
-	
-	<variable name="SetListContent">
-		<value condition="String.IsEqual(Container.ListItem.dbtype,set)">videodb://movies/sets/$INFO[ListItem.DBID]/?setid=$INFO[ListItem.DBID]</value>
-		<value>-</value>
-	</variable>
-	
-	<variable name="SetLabel">
-		<value condition="Integer.IsEqual(Container(4500).NumItems,1)">$INFO[Container(4500).ListItem(0).Year,, &#8226; ]$INFO[Container(4500).NumItems,, $LOCALIZE[20338]]</value>
-		<value condition="Integer.IsGreater(Container(4500).NumItems,1)">$INFO[Container(4500).ListItem(0).Year]$INFO[Container(4500).ListItem(-1).Year, - , &#8226; ]$INFO[Container(4500).NumItems,, $LOCALIZE[342]]</value>
-	</variable>
-	
-	<variable name="VideoInfoListPlot">
-		<value condition="Container.Content(sets) | ListItem.IsCollection">$VAR[SetLabel][CR][CR]$INFO[ListItem.Plot]</value>
-		<value>$INFO[ListItem.Plot]</value>
 	</variable>
 
 	<!-- Audio labels -->

--- a/xml/Viewtype511.xml
+++ b/xml/Viewtype511.xml
@@ -38,7 +38,7 @@
 					<include>Viewtype511_coords4</include>
 					<align>left</align>
 					<font>Font27</font>
-					<label>$VAR[VideoInfoListPlot]$INFO[Window(Home).Property(ResetScroll.511)]</label>
+					<label>$INFO[ListItem.Plot]$INFO[Window(Home).Property(ResetScroll.511)]</label>
 					<textcolor>$VAR[TextColorFO]</textcolor>
 					<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>
 					<visible>Skin.String(PlotFont,S)</visible>
@@ -47,7 +47,7 @@
 					<include>Viewtype511_coords5</include>
 					<align>left</align>
 					<font>Font30</font>
-					<label>$VAR[VideoInfoListPlot]$INFO[Window(Home).Property(ResetScroll.511)]</label>
+					<label>$INFO[ListItem.Plot]$INFO[Window(Home).Property(ResetScroll.511)]</label>
 					<textcolor>$VAR[TextColorFO]</textcolor>
 					<autoscroll delay="5000" time="1300" repeat="10000">true</autoscroll>
 					<visible>Skin.String(PlotFont,M)</visible>
@@ -56,7 +56,7 @@
 					<include>Viewtype511_coords6</include>
 					<align>left</align>
 					<font>Font33</font>
-					<label>$VAR[VideoInfoListPlot]$INFO[Window(Home).Property(ResetScroll.511)]</label>
+					<label>$INFO[ListItem.Plot]$INFO[Window(Home).Property(ResetScroll.511)]</label>
 					<textcolor>$VAR[TextColorFO]</textcolor>
 					<autoscroll delay="5000" time="1200" repeat="10000">true</autoscroll>
 					<visible>Skin.String(PlotFont,L)</visible>

--- a/xml/Viewtype522.xml
+++ b/xml/Viewtype522.xml
@@ -60,7 +60,7 @@
 						<include>Viewtype522_coords8</include>
 						<align>left</align>
 						<font>Font27</font>
-						<label>$VAR[VideoInfoListPlot]$INFO[Window(Home).Property(ResetScroll.522)]</label>
+						<label>$INFO[ListItem.Plot]$INFO[Window(Home).Property(ResetScroll.522)]</label>
 						<textcolor>$VAR[TextColorFO]</textcolor>
 						<autoscroll delay="5000" time="1400" repeat="10000">true</autoscroll>
 						<visible>Skin.String(PlotFont,S)</visible>
@@ -69,7 +69,7 @@
 						<include>Viewtype522_coords9</include>
 						<align>left</align>
 						<font>Font30</font>
-						<label>$VAR[VideoInfoListPlot]$INFO[Window(Home).Property(ResetScroll.522)]</label>
+						<label>$INFO[ListItem.Plot]$INFO[Window(Home).Property(ResetScroll.522)]</label>
 						<textcolor>$VAR[TextColorFO]</textcolor>
 						<autoscroll delay="5000" time="1300" repeat="10000">true</autoscroll>
 						<visible>Skin.String(PlotFont,M)</visible>
@@ -78,7 +78,7 @@
 						<include>Viewtype522_coords10</include>
 						<align>left</align>
 						<font>Font33</font>
-						<label>$VAR[VideoInfoListPlot]$INFO[Window(Home).Property(ResetScroll.522)]</label>
+						<label>$INFO[ListItem.Plot]$INFO[Window(Home).Property(ResetScroll.522)]</label>
 						<textcolor>$VAR[TextColorFO]</textcolor>
 						<autoscroll delay="5000" time="1200" repeat="10000">true</autoscroll>
 						<visible>Skin.String(PlotFont,L)</visible>

--- a/xml/Viewtype531.xml
+++ b/xml/Viewtype531.xml
@@ -44,17 +44,6 @@
 					<visible>[!String.IsEmpty(ListItem.Plot) | !String.IsEmpty(ListItem.PlotOutline)] + Skin.HasSetting(UserRating) + !String.IsEmpty(ListItem.UserRating) + ![Container.Content(sets) | ListItem.IsCollection]</visible>
 				</control>
 				
-				<!-- Movie Set Info -->
-				<control type="fadelabel">
-					<include>Viewtype531_coords4</include>
-					<font>Font27</font>
-					<align>center</align>
-					<aligny>top</aligny>
-					<label>$VAR[SetLabel]</label>
-					<textcolor>$VAR[TextColorFO]</textcolor>
-					<visible>Container.Content(sets) | ListItem.IsCollection</visible>
-				</control>
-				
 				<!-- Title -->
 				<control type="fadelabel">
 					<include>Viewtype531_coords5</include>

--- a/xml/Viewtype533.xml
+++ b/xml/Viewtype533.xml
@@ -44,17 +44,6 @@
 					<visible>[!String.IsEmpty(ListItem.Plot) | !String.IsEmpty(ListItem.PlotOutline)] + Skin.HasSetting(UserRating) + !String.IsEmpty(ListItem.UserRating) + ![Container.Content(sets) | ListItem.IsCollection]</visible>
 				</control>
 				
-				<!-- Movie Set Info -->
-				<control type="fadelabel">
-					<include>Viewtype533_coords4</include>
-					<font>Font27</font>
-					<align>center</align>
-					<aligny>top</aligny>
-					<label>$VAR[SetLabel]</label>
-					<textcolor>$VAR[TextColorFO]</textcolor>
-					<visible>Container.Content(sets) | ListItem.IsCollection</visible>
-				</control>
-				
 				<!-- Title -->
 				<control type="fadelabel">
 					<include>Viewtype533_coords5</include>

--- a/xml/script-skinshortcuts-static.xml
+++ b/xml/script-skinshortcuts-static.xml
@@ -1601,7 +1601,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -1609,7 +1609,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -1617,7 +1617,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -1682,21 +1682,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -1760,7 +1760,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -1768,7 +1768,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -1776,7 +1776,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -1843,7 +1843,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -1851,7 +1851,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -1859,7 +1859,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -1958,7 +1958,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -1966,7 +1966,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -1974,7 +1974,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2039,21 +2039,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2117,7 +2117,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2125,7 +2125,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2133,7 +2133,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2200,7 +2200,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2208,7 +2208,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2216,7 +2216,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2315,7 +2315,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2323,7 +2323,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2331,7 +2331,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2396,21 +2396,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2474,7 +2474,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2482,7 +2482,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2490,7 +2490,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2556,7 +2556,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2564,7 +2564,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2572,7 +2572,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2670,7 +2670,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2678,7 +2678,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2686,7 +2686,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -2751,21 +2751,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2829,7 +2829,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2837,7 +2837,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2845,7 +2845,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -2911,7 +2911,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2919,7 +2919,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -2927,7 +2927,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3025,7 +3025,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3033,7 +3033,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3041,7 +3041,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3106,21 +3106,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3184,7 +3184,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3192,7 +3192,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3200,7 +3200,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3266,7 +3266,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3274,7 +3274,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3282,7 +3282,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3380,7 +3380,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3388,7 +3388,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3396,7 +3396,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3461,21 +3461,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3539,7 +3539,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3547,7 +3547,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3555,7 +3555,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3621,7 +3621,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3629,7 +3629,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3637,7 +3637,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3735,7 +3735,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3743,7 +3743,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3751,7 +3751,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -3816,21 +3816,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3894,7 +3894,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3902,7 +3902,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3910,7 +3910,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -3976,7 +3976,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3984,7 +3984,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -3992,7 +3992,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -4090,7 +4090,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -4098,7 +4098,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -4106,7 +4106,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>24</width>
@@ -4171,21 +4171,21 @@
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
 								<centerleft>108</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -4249,7 +4249,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -4257,7 +4257,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -4265,7 +4265,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>24</width>
@@ -4331,7 +4331,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -4339,7 +4339,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -4347,7 +4347,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-12,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>24</width>
@@ -4646,7 +4646,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>32</width>
@@ -4654,7 +4654,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>32</width>
@@ -4662,7 +4662,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>32</width>
@@ -4727,21 +4727,21 @@
 								<centerleft>144</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
 								<centerleft>144</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
 								<centerleft>144</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -4805,7 +4805,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -4813,7 +4813,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -4821,7 +4821,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -4887,7 +4887,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>32</width>
@@ -4895,7 +4895,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>32</width>
@@ -4903,7 +4903,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>32</width>
@@ -5001,7 +5001,7 @@
 						<texture background="true">pvr/Recording.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>ListItem.IsRecording</visible>
-						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>32</width>
@@ -5009,7 +5009,7 @@
 						<texture background="true">pvr/Timer.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>32</width>
@@ -5017,7 +5017,7 @@
 						<texture background="true">pvr/Reminder.png</texture>
 						<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 						<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+						<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 					</control>
 					<control type="image">
 						<width>32</width>
@@ -5082,21 +5082,21 @@
 								<centerleft>144</centerleft>
 								<texture background="true">pvr/Recording.png</texture>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
 								<centerleft>144</centerleft>
 								<texture background="true">pvr/Timer.png</texture>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
 								<centerleft>144</centerleft>
 								<texture background="true">pvr/Reminder.png</texture>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -5160,7 +5160,7 @@
 								<texture background="true">pvr/Recording.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -5168,7 +5168,7 @@
 								<texture background="true">pvr/Timer.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -5176,7 +5176,7 @@
 								<texture background="true">pvr/Reminder.png</texture>
 								<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 								<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+								<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 							</control>
 							<control type="image">
 								<width>32</width>
@@ -5242,7 +5242,7 @@
 							<texture background="true">pvr/Recording.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>ListItem.IsRecording</visible>
-							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>32</width>
@@ -5250,7 +5250,7 @@
 							<texture background="true">pvr/Timer.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasTimer | ListItem.HasTimerSchedule] + !ListItem.IsRecording + !ListItem.HasReminder + !ListItem.HasReminderRule</visible>
-							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>32</width>
@@ -5258,7 +5258,7 @@
 							<texture background="true">pvr/Reminder.png</texture>
 							<colordiffuse>$VAR[DiffusePosterNF]</colordiffuse>
 							<visible>[ListItem.HasReminder | ListItem.HasReminderRule] + !ListItem.IsRecording</visible>
-							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)">Conditional</animation>
+							<animation effect="slide" end="-16,0" time="0" reversible="false" condition="[String.IsEqual(ListItem.Overlay,OverlayWatched.png) | ListItem.IsResumable | !String.IsEmpty(ListItem.PlayCount)] + [[String.IsEqual(ListItem.DBTYPE,music) | String.IsEqual(ListItem.DBTYPE,song) | String.IsEqual(ListItem.DBTYPE,album) | String.IsEqual(ListItem.DBTYPE,artist)] + !Skin.HasSetting(MusicListenedToStatus) | [String.IsEqual(ListItem.DBTYPE,video) | String.IsEqual(ListItem.DBTYPE,movie) | String.IsEqual(ListItem.DBTYPE,set) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season) | String.IsEqual(ListItem.DBTYPE,episode) | String.IsEqual(ListItem.DBTYPE,musicvideo)] + !Skin.HasSetting(VideoWatchedStatus)]">Conditional</animation>
 						</control>
 						<control type="image">
 							<width>32</width>


### PR DESCRIPTION
template.xml:
- fix animation condition of recording, timer and reminder icon slide animations

Coordinates_DialogFullScreenInfo.xml:
- fix include names

Coordinates_DialogSelect.xml:
- remove deprecated image controls for cases where the icon info label was populated with a 'Default' string

Coordinates_FileBrowser.xml:
- remove deprecated image controls for cases where the icon info label was populated with a 'Default' string

Coordinates_Viewtype539.xml:
- fix coordinates

DialogFullScreenInfo.xml:
- fix include name

DialogPlayerProcessInfo.xml:
- fix video decoder information label formatting

DialogSelect.xml:
- remove deprecated image control for cases where the icon info label was populated with a 'Default' string

DialogVideoInfo.xml:
- fix onright and onleft of cast list to always navigate to last used button

FileBrowser.xml:
- remove deprecated image control for cases where the icon info label was populated with a 'Default' string

Includes_Windows_Dialogs.xml:
- adjust color as well as single and multiple background image controls' visibility condition to always render these layers as fallback

MyVideoNav.xml:
- remove deprecated movie sets hidden list

script-skinshortcuts-static.xml:
- fix animation condition of recording, timer and reminder icon slide animations

Variables.xml:
- add missing variable condition to SelectImage variable
- add variable conditions for movie sets to Label2 variable
- remove deprecated SetListContent, SetLabel and VideoInfoListPlot variables

Viewtype511.xml:
- remove deprecated VideoInfoListPlot variable from plot textbox

Viewtype522.xml:
- remove deprecated VideoInfoListPlot variable from plot textbox

Viewtype531.xml:
- remove deprecated movie set info label

Viewtype533.xml:
- remove deprecated movie set info label

Addon.xml:
- bump version to 20.2.1
- update changelog

Changelog.md:
- update changelog
