### PR TITLE
Add new view type selection dialog & fix current playlist duration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 _New_
 - support Omega skin engine features
+- add new view type selection dialog
 
 ---
 
@@ -567,6 +568,9 @@ Includes_MediaFlags.xml:
 
 Includes_SubMenu.xml:
 - remove deprecated favourites dialog related includes
+- adjust sub menu view button to open new view type selection dialog
+- add new ViewMenu include for additional view type dialog
+- adjust sub menu indicators to not show when new view type selection dialog is visible
 
 Includes_Widgets.xml:
 - add new browse tag to widget content tags to prevent "More..." item from showin

--- a/addon.xml
+++ b/addon.xml
@@ -17,6 +17,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- Kodi v21 Omega support</news>
+		<news>[B]New[/B][CR]- support Omega skin engine features[CR]- add new view type selection dialog</news>
 	</extension>
 </addon>

--- a/xml/Includes_SubMenu.xml
+++ b/xml/Includes_SubMenu.xml
@@ -52,6 +52,8 @@
 			</control>
 		</control>
 		
+		<include>ViewMenu</include>
+		
 	</include>
 	
 	<!-- Addon browser sub menu -->
@@ -76,7 +78,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
@@ -168,7 +170,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
@@ -279,7 +281,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
@@ -370,7 +372,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
@@ -496,7 +498,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
@@ -691,7 +693,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
@@ -1223,7 +1225,7 @@
 			<control type="button" id="99">
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
-				<onclick>Container.NextViewMode</onclick>
+				<onclick>Control.SetFocus(3002)</onclick>
 				<visible>Integer.IsGreater(Container.ViewCount,1) + ![Container.Content(videos) + Skin.HasSetting(FixedVideosView)]</visible>
 			</control>
 
@@ -1495,6 +1497,248 @@
 		</control>
 	</include>
 
+	<!-- View menu -->
+	<include name="ViewMenu">
+		<control type="group" id="9003">
+			<include>NotificationDepth</include>
+			<visible>!Skin.HasSetting(KioskMode)</visible>
+			
+			<!-- Window dim overlay -->
+			<control type="image">
+				<include>BackgroundDepth</include>
+				<include>FullscreenDimensions</include>
+				<texture colordiffuse="$VAR[DarkenColor]">common/DimOverlay.png</texture>
+				<visible>ControlGroup(9003).HasFocus</visible>
+				<include>VisibleFadeAnimation</include>
+			</control>
+			
+			<control type="group">
+				<include>SubMenu_coords1</include>
+				<animation effect="slide" start="0,0" end="460,0" time="200" condition="ControlGroup(9003).HasFocus">Conditional</animation>
+				
+				<!-- Hidden togglebutton for mouse control -->
+				<control type="togglebutton">
+					<include>SubMenu_coords2</include>
+					<texturefocus>noop</texturefocus>
+				</control>
+
+				<!-- Background -->
+				<control type="image">
+					<include>SubMenu_coords2</include>
+					<texture colordiffuse="$VAR[MenuOSDColor]">$VAR[MenuOSDBackground]</texture>
+				</control>
+				
+				<control type="grouplist" id="3002">
+					<include>SubMenu_coords3</include>
+					<onleft>50</onleft>
+					<onright>50</onright>
+					<onback>50</onback>
+					<include>SubMenuResetScroll</include>
+					<scrolltime>200</scrolltime>
+					<orientation>vertical</orientation>
+					<itemgap>0</itemgap>
+
+					<include content="SubMenuAnimation">
+						<param name="containerID">3002</param>
+					</include>
+				
+					<!-- List 50 -->
+					<control type="togglebutton" id="180">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[535]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[535]</altlabel>
+						<usealttexture>Control.IsVisible(50)</usealttexture>
+						<onclick>Container.SetViewMode(50)</onclick>
+						<visible>Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist) | Container.Content(files) | Container.Content(songs) | Container.Content(artists) | Container.Content(musicvideos) | Container.Content(genres) | Container.Content(years) | Container.Content(actors) | Container.Content(playlists) | Container.Content(plugins) | Container.Content(studios) | Container.Content(directors) | Container.Content(tags) | Container.Content(countries) | Container.Content(roles) | Container.Content(favourites) | ![Window.IsVisible(musicplaylist) | Window.IsVisible(videoplaylist) | Container.Content(files) | Container.Content(songs) | Container.Content(artists) | Container.Content(musicvideos) | Container.Content(genres) | Container.Content(years) | Container.Content(actors) | Container.Content(playlists) | Container.Content(plugins) | Container.Content(studios) | Container.Content(directors) | Container.Content(tags) | Container.Content(countries) | Container.Content(roles) | Container.Content(favourites) | Container.Content(addons) | Container.Content(albums) | Container.Content(videos) | Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | Container.Content(images)]</visible>
+					</control>
+					
+					<!-- List 51 -->
+					<control type="togglebutton" id="181">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[535]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[535]</altlabel>
+						<usealttexture>Control.IsVisible(51)</usealttexture>
+						<onclick>Container.SetViewMode(51)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(albums) | Container.Content(videos) | Container.Content(addons) | Container.Content(images) | Container.Content(games)</visible>
+					</control>
+					
+					<!-- List info 511 -->
+					<control type="togglebutton" id="182">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31117]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31117]</altlabel>
+						<usealttexture>Control.IsVisible(511)</usealttexture>
+						<onclick>Container.SetViewMode(511)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos)</visible>
+					</control>
+					
+					<!-- Wide 52 -->
+					<control type="togglebutton" id="183">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31241]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31241]</altlabel>
+						<usealttexture>Control.IsVisible(52)</usealttexture>
+						<onclick>Container.SetViewMode(52)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wide low 521 -->
+					<control type="togglebutton" id="184">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31112]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31112]</altlabel>
+						<usealttexture>Control.IsVisible(521)</usealttexture>
+						<onclick>Container.SetViewMode(521)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wide low info 522 -->
+					<control type="togglebutton" id="185">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31392]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31392]</altlabel>
+						<usealttexture>Control.IsVisible(522)</usealttexture>
+						<onclick>Container.SetViewMode(522)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wide 523 -->
+					<control type="togglebutton" id="186">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31241]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31241]</altlabel>
+						<usealttexture>Control.IsVisible(523)</usealttexture>
+						<onclick>Container.SetViewMode(523)</onclick>
+						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+					</control>
+					
+					<!-- Wide low (videos) 524 -->
+					<control type="togglebutton" id="187">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31112]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31112]</altlabel>
+						<usealttexture>Control.IsVisible(524)</usealttexture>
+						<onclick>Container.SetViewMode(524)</onclick>
+						<visible>Container.Content(videos)</visible>
+					</control>
+					
+					<!-- Wide low info (videos) 525 -->
+					<control type="togglebutton" id="188">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31392]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31392]</altlabel>
+						<usealttexture>Control.IsVisible(525)</usealttexture>
+						<onclick>Container.SetViewMode(525)</onclick>
+						<visible>Container.Content(videos)</visible>
+					</control>
+					
+					<!-- Wall 53 -->
+					<control type="togglebutton" id="189">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31078]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31078]</altlabel>
+						<usealttexture>Control.IsVisible(53)</usealttexture>
+						<onclick>Container.SetViewMode(53)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wall info 531 -->
+					<control type="togglebutton" id="190">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31133]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31133]</altlabel>
+						<usealttexture>Control.IsVisible(531)</usealttexture>
+						<onclick>Container.SetViewMode(531)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wall small 532 -->
+					<control type="togglebutton" id="191">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31114]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31114]</altlabel>
+						<usealttexture>Control.IsVisible(532)</usealttexture>
+						<onclick>Container.SetViewMode(532)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wall small info 533 -->
+					<control type="togglebutton" id="192">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31116]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31116]</altlabel>
+						<usealttexture>Control.IsVisible(533)</usealttexture>
+						<onclick>Container.SetViewMode(533)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wall low 534 -->
+					<control type="togglebutton" id="193">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31113]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31113]</altlabel>
+						<usealttexture>Control.IsVisible(534)</usealttexture>
+						<onclick>Container.SetViewMode(534)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+					</control>
+					
+					<!-- Wall 535 -->
+					<control type="togglebutton" id="194">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31078]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31078]</altlabel>
+						<usealttexture>Control.IsVisible(535)</usealttexture>
+						<onclick>Container.SetViewMode(535)</onclick>
+						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+					</control>
+					
+					<!-- Wall info (videos) 536 -->
+					<control type="togglebutton" id="195">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31133]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31133]</altlabel>
+						<usealttexture>Control.IsVisible(536)</usealttexture>
+						<onclick>Container.SetViewMode(536)</onclick>
+						<visible>Container.Content(videos)</visible>
+					</control>
+					
+					<!-- Wall small 537 -->
+					<control type="togglebutton" id="196">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31114]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31114]</altlabel>
+						<usealttexture>Control.IsVisible(537)</usealttexture>
+						<onclick>Container.SetViewMode(537)</onclick>
+						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+					</control>
+					
+					<!-- Wall small info (videos) 538 -->
+					<control type="togglebutton" id="197">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31116]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31116]</altlabel>
+						<usealttexture>Control.IsVisible(538)</usealttexture>
+						<onclick>Container.SetViewMode(538)</onclick>
+						<visible>Container.Content(videos)</visible>
+					</control>
+					
+					<!-- Wall low (videos) 539 -->
+					<control type="togglebutton" id="198">
+						<include>SubMenu_coords4</include>
+						<label>$LOCALIZE[31113]</label>
+						<altlabel>$LOCALIZE[143] $LOCALIZE[31113]</altlabel>
+						<usealttexture>Control.IsVisible(539)</usealttexture>
+						<onclick>Container.SetViewMode(539)</onclick>
+						<visible>Container.Content(videos)</visible>
+					</control>
+					
+				</control>
+				
+			</control>
+		</control>
+		
+	</include>
+	
 	<!-- Sub menu animation -->
 	<include name="SubMenuAnimation">
 		<definition>
@@ -1743,7 +1987,7 @@
 			
 			<control type="group">
 				<visible>!Skin.HasSetting(KioskMode)</visible>
-				<visible>!ControlGroup(9002).HasFocus + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(contextmenu) + [Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(511) | Control.IsVisible(53) | Control.IsVisible(531) | Control.IsVisible(532) | Control.IsVisible(533) | Control.IsVisible(534) | Control.IsVisible(535) | Control.IsVisible(536) | Control.IsVisible(537) | Control.IsVisible(538) | Control.IsVisible(539) | Window.IsVisible(addonbrowser) | Window.IsVisible(eventlog) | Window.IsVisible(MyPVRChannels.xml) | Window.IsVisible(MyPVRRecordings.xml) | Window.IsVisible(MyPVRSearch.xml) | Window.IsVisible(MyPVRTimers.xml) | Window.IsVisible(MyWeather.xml)]</visible>
+				<visible>!ControlGroup(9002).HasFocus + !ControlGroup(9003).HasFocus + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(contextmenu) + [Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(511) | Control.IsVisible(53) | Control.IsVisible(531) | Control.IsVisible(532) | Control.IsVisible(533) | Control.IsVisible(534) | Control.IsVisible(535) | Control.IsVisible(536) | Control.IsVisible(537) | Control.IsVisible(538) | Control.IsVisible(539) | Window.IsVisible(addonbrowser) | Window.IsVisible(eventlog) | Window.IsVisible(MyPVRChannels.xml) | Window.IsVisible(MyPVRRecordings.xml) | Window.IsVisible(MyPVRSearch.xml) | Window.IsVisible(MyPVRTimers.xml) | Window.IsVisible(MyWeather.xml)]</visible>
 				<include>VisibleFadeAnimation</include>
 				<animation effect="slide" time="200" start="-200,0" end="0,0">WindowOpen</animation>
 				<animation effect="slide" time="200" start="0,0" end="-200,0">WindowClose</animation>
@@ -1755,7 +1999,7 @@
 			
 			<control type="group">
 				<visible>!Skin.HasSetting(KioskMode)</visible>
-				<visible>!ControlGroup(9002).HasFocus + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(contextmenu) + [Control.IsVisible(52) | Control.IsVisible(521) | Control.IsVisible(522) | Control.IsVisible(523) | Control.IsVisible(524) | Control.IsVisible(525)]</visible>
+				<visible>!ControlGroup(9002).HasFocus + !ControlGroup(9003).HasFocus + !Window.IsVisible(shutdownmenu) + !Window.IsVisible(contextmenu) + [Control.IsVisible(52) | Control.IsVisible(521) | Control.IsVisible(522) | Control.IsVisible(523) | Control.IsVisible(524) | Control.IsVisible(525)]</visible>
 				<include>VisibleFadeAnimation</include>
 				<animation effect="slide" time="200" start="0,200" end="0,0">WindowOpen</animation>
 				<animation effect="slide" time="200" start="0,0" end="0,200">WindowClose</animation>

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -804,8 +804,8 @@
 	<!-- Audio/Video Duration -->
 	<variable name="MediaFlagsDuration">
 		<value condition="!Window.IsVisible(MyPlaylist.xml) + !String.IsEmpty(ListItem.Duration) + ![String.StartsWith(ListItem.Size,0) + String.EndsWith(ListItem.Size,0 B)]">$VAR[Duration]$INFO[ListItem.Size, &#8226; $LOCALIZE[289]: ,]</value>
-		<value condition="!Window.IsVisible(MyPlaylist.xml)">$VAR[Duration]</value>
-		<value condition="Window.IsVisible(MyPlaylist.xml)">$INFO[ListItem.Duration]$INFO[Container.Totaltime, / ,]</value>
+		<value condition="!Window.IsVisible(MyPlaylist.xml) | Window.IsVisible(MyPlaylist.xml) + !Integer.IsGreater(Container.NumItems,1)">$VAR[Duration]</value>
+		<value condition="Window.IsVisible(MyPlaylist.xml) + Integer.IsGreater(Container.NumItems,1)">$INFO[ListItem.Duration]$INFO[Container.Totaltime, / ,]</value>
 	</variable>
 	
 	<variable name="Duration">

--- a/xml/Viewtype53.xml
+++ b/xml/Viewtype53.xml
@@ -17,7 +17,7 @@
 				<preloaditems>4</preloaditems>
 				<viewtype label="$LOCALIZE[31078]">bigicon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 
 				<include>Viewtype53_coords2</include>
 

--- a/xml/Viewtype531.xml
+++ b/xml/Viewtype531.xml
@@ -10,7 +10,7 @@
 			<!-- Movie/TV show info -->
 			<control type="group">
 				<include>Viewtype531_coords1</include>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 				
 				<!-- Title -->
 				<control type="fadelabel">
@@ -132,7 +132,7 @@
 				<preloaditems>4</preloaditems>
 				<viewtype label="$LOCALIZE[31133]">bigicon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 
 				<include>Viewtype531_coords15</include>
 

--- a/xml/Viewtype533.xml
+++ b/xml/Viewtype533.xml
@@ -10,7 +10,7 @@
 			<!-- Movie/TV show info -->
 			<control type="group">
 				<include>Viewtype533_coords1</include>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 				
 				<!-- Title -->
 				<control type="fadelabel">
@@ -132,7 +132,7 @@
 				<preloaditems>4</preloaditems>
 				<viewtype label="$LOCALIZE[31116]">icon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons)</visible>
 
 				<include>Viewtype533_coords15</include>
 


### PR DESCRIPTION
Includes_SubMenu.xml:
- adjust sub menu view button to open new view type selection dialog
- add new ViewMenu include for additional view type dialog
- adjust sub menu indicators to not show when new view type selection dialog is visible

Variables.xml:
- fix MediaFlagsDuration variable to only show one track duration when current playlist contains just one title

Viewtype53.xml:
- fix visibility condition to also use view for movie sets

Viewtype531.xml:
- fix visibility condition to also use view for season

Viewtype533.xml:
- fix visibility condition to also use view for season

addon.xml:
- update changelog

Changelog.md:
- update changelog