### PR TITLE
Adjust video addon views to work with multiple content types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,15 @@
 
 ---
 
-**_v21.1.0_**
+**_v21.2.0_**
+
+_Improved_
+- adjust video addon views to work with multiple content types (videos, episodes, movies)
+- add fixed video addon views setting to side menu
+
+---
+
+**_v21.1.0 - October 2024_**
 
 _New_
 - add new notification icon
@@ -527,20 +535,77 @@ Release
 
 ---
 
-**Changelog v21.1.0**
+**Changelog v21.2.0**
 
-template.xml:
-- adjust widget onclick options to avoid errors when widgets are pointing to addon directories
+Coordinates_Viewtype523.xml:
+- add new content type image includes
 
-Coordinates_DialogNotification.xml:
-- add coordinates includes for new notification icon
+Coordinates_Viewtype524.xml:
+- add new content type image includes
 
-DialogNotification.xml:
-- add new notification icon
+Coordinates_Viewtype525.xml:
+- add new content type image includes
+
+Coordinates_Viewtype535.xml:
+- add new content type image includes
+
+Coordinates_Viewtype536.xml:
+- add new content type image includes
+
+Coordinates_Viewtype537.xml:
+- add new content type image includes
+
+Coordinates_Viewtype538.xml:
+- add new content type image includes
+
+Coordinates_Viewtype539.xml:
+- add new content type image includes
+- fix videos fallback icon
+
+Includes.xml:
+- adjust DefaultView include to work with multiple content types and specifically with video addons
+
+Includes_SubMenu.xml:
+- add fixed video addon views setting to side menu
+- adjust views menu to work together with fixed video addon views setting
+
+Variables.xml:
+- add new DefaultViewSettings variable for reworked views menu buttons
+- adjust HeadingLabelSecondary variable to show proper information on episodes level (TV show title and season, if useful)
+- adjust ContentType variable to show videos content type when a list of video addon items are shown
+
+Viewtype51.xml:
+- adjust visibility conditions of images and list container to work with multiple with multiple video addons content type
+
+Viewtype511.xml:
+- adjust visibility conditions of images and list container to work with multiple with multiple video addons content type
+
+Viewtype523.xml:
+- adjust visibility conditions of list container to work with multiple with multiple video addons content type
+
+Viewtype524xml:
+- adjust visibility conditions of list container to work with multiple with multiple video addons content type
+
+Viewtype525.xml:
+- adjust visibility conditions of list container and info controls to work with multiple with multiple video addons content type
+
+Viewtype535.xml:
+- adjust visibility conditions of panel container to work with multiple with multiple video addons content type
+
+Viewtype536.xml:
+- adjust visibility conditions of panel container and info controls to work with multiple with multiple video addons content type
+
+Viewtype537.xml:
+- adjust visibility conditions of panel container to work with multiple with multiple video addons content type
+
+Viewtype538.xml:
+- adjust visibility conditions of panel container and info controls to work with multiple with multiple video addons content type
+
+Viewtype539.xml:
+- adjust visibility conditions of panel container to work with multiple with multiple video addons content type
 
 addon.xml:
-- bump version to 21.1.0
-- add skinshortcuts script as an optional dependency to avoid removal of the addon when marked as unused
+- bump version to 21.2.0
 - update changelog
 
 Changelog.md:

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="21.1.1" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="21.2.0" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.17.0"/>
 		<import addon="script.skinshortcuts" version="2.0.3" optional="true"/>
@@ -18,6 +18,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]New[/B][CR]- add new notification icon[CR][CR][B]Improved[/B][CR]- add skinshortcuts script as an optional dependency to avoid removal of the addon when marked as unused[CR][CR][B]Fixed[/B][CR]- fix widget onclick options to avoid errors when widgets are pointing to addon directories</news>
+		<news>[B]Improved[/B][CR]- adjust video addon views to work with multiple content types (videos, episodes, movies)[CR]- add fixed video addon views setting to side menu</news>
 	</extension>
 </addon>

--- a/xml/Coordinates_Viewtype523.xml
+++ b/xml/Coordinates_Viewtype523.xml
@@ -84,6 +84,24 @@
 				<param name="coords2">Viewtype523_coords8</param>
 				<param name="coords3">Viewtype523_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -137,6 +155,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">523</param>
 				<param name="coords">Viewtype523_coords7</param>
 				<param name="coords2">Viewtype523_coords8</param>
@@ -200,6 +236,24 @@
 				<param name="coords2">Viewtype523_coords8</param>
 				<param name="coords3">Viewtype523_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -253,6 +307,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">523</param>
+				<param name="coords">Viewtype523_coords7</param>
+				<param name="coords2">Viewtype523_coords8</param>
+				<param name="coords3">Viewtype523_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">523</param>
 				<param name="coords">Viewtype523_coords7</param>
 				<param name="coords2">Viewtype523_coords8</param>
@@ -325,6 +397,24 @@
 					<param name="coords2">Viewtype523_coords11</param>
 					<param name="coords3">Viewtype523_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -381,6 +471,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">523</param>
 					<param name="coords">Viewtype523_coords10</param>
 					<param name="coords2">Viewtype523_coords11</param>
@@ -447,6 +555,24 @@
 					<param name="coords2">Viewtype523_coords11</param>
 					<param name="coords3">Viewtype523_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -503,6 +629,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">523</param>
+					<param name="coords">Viewtype523_coords10</param>
+					<param name="coords2">Viewtype523_coords11</param>
+					<param name="coords3">Viewtype523_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">523</param>
 					<param name="coords">Viewtype523_coords10</param>
 					<param name="coords2">Viewtype523_coords11</param>

--- a/xml/Coordinates_Viewtype524.xml
+++ b/xml/Coordinates_Viewtype524.xml
@@ -57,6 +57,24 @@
 				<param name="coords2">Viewtype524_coords8</param>
 				<param name="coords3">Viewtype524_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
 		</itemlayout>
 	</include>
 	<include name="Viewtype524_coords2_21:9">
@@ -65,6 +83,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">524</param>
 				<param name="coords">Viewtype524_coords7</param>
 				<param name="coords2">Viewtype524_coords8</param>
@@ -83,6 +119,24 @@
 				<param name="coords2">Viewtype524_coords8</param>
 				<param name="coords3">Viewtype524_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
 		</itemlayout>
 	</include>
 	<include name="Viewtype524_coords2_4:3">
@@ -91,6 +145,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">524</param>
+				<param name="coords">Viewtype524_coords7</param>
+				<param name="coords2">Viewtype524_coords8</param>
+				<param name="coords3">Viewtype524_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">524</param>
 				<param name="coords">Viewtype524_coords7</param>
 				<param name="coords2">Viewtype524_coords8</param>
@@ -118,6 +190,24 @@
 					<param name="coords2">Viewtype524_coords11</param>
 					<param name="coords3">Viewtype524_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
 			</control>
 		</focusedlayout>
 	</include>
@@ -129,6 +219,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">524</param>
 					<param name="coords">Viewtype524_coords10</param>
 					<param name="coords2">Viewtype524_coords11</param>
@@ -150,6 +258,24 @@
 					<param name="coords2">Viewtype524_coords11</param>
 					<param name="coords3">Viewtype524_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
 			</control>
 		</focusedlayout>
 	</include>
@@ -161,6 +287,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">524</param>
+					<param name="coords">Viewtype524_coords10</param>
+					<param name="coords2">Viewtype524_coords11</param>
+					<param name="coords3">Viewtype524_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">524</param>
 					<param name="coords">Viewtype524_coords10</param>
 					<param name="coords2">Viewtype524_coords11</param>

--- a/xml/Coordinates_Viewtype525.xml
+++ b/xml/Coordinates_Viewtype525.xml
@@ -57,6 +57,24 @@
 				<param name="coords2">Viewtype525_coords12</param>
 				<param name="coords3">Viewtype525_coords13</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
 		</itemlayout>
 	</include>
 	<include name="Viewtype525_coords2_21:9">
@@ -65,6 +83,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">525</param>
 				<param name="coords">Viewtype525_coords11</param>
 				<param name="coords2">Viewtype525_coords12</param>
@@ -83,6 +119,24 @@
 				<param name="coords2">Viewtype525_coords12</param>
 				<param name="coords3">Viewtype525_coords13</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
 		</itemlayout>
 	</include>
 	<include name="Viewtype525_coords2_4:3">
@@ -91,6 +145,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">525</param>
+				<param name="coords">Viewtype525_coords11</param>
+				<param name="coords2">Viewtype525_coords12</param>
+				<param name="coords3">Viewtype525_coords13</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">525</param>
 				<param name="coords">Viewtype525_coords11</param>
 				<param name="coords2">Viewtype525_coords12</param>
@@ -118,6 +190,24 @@
 					<param name="coords2">Viewtype525_coords15</param>
 					<param name="coords3">Viewtype525_coords16</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
 			</control>
 		</focusedlayout>
 	</include>
@@ -129,6 +219,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">525</param>
 					<param name="coords">Viewtype525_coords14</param>
 					<param name="coords2">Viewtype525_coords15</param>
@@ -150,6 +258,24 @@
 					<param name="coords2">Viewtype525_coords15</param>
 					<param name="coords3">Viewtype525_coords16</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
 			</control>
 		</focusedlayout>
 	</include>
@@ -161,6 +287,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">525</param>
+					<param name="coords">Viewtype525_coords14</param>
+					<param name="coords2">Viewtype525_coords15</param>
+					<param name="coords3">Viewtype525_coords16</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">525</param>
 					<param name="coords">Viewtype525_coords14</param>
 					<param name="coords2">Viewtype525_coords15</param>

--- a/xml/Coordinates_Viewtype535.xml
+++ b/xml/Coordinates_Viewtype535.xml
@@ -80,6 +80,24 @@
 				<param name="coords2">Viewtype535_coords8</param>
 				<param name="coords3">Viewtype535_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -133,6 +151,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">535</param>
 				<param name="coords">Viewtype535_coords7</param>
 				<param name="coords2">Viewtype535_coords8</param>
@@ -196,6 +232,24 @@
 				<param name="coords2">Viewtype535_coords8</param>
 				<param name="coords3">Viewtype535_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -249,6 +303,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">535</param>
+				<param name="coords">Viewtype535_coords7</param>
+				<param name="coords2">Viewtype535_coords8</param>
+				<param name="coords3">Viewtype535_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">535</param>
 				<param name="coords">Viewtype535_coords7</param>
 				<param name="coords2">Viewtype535_coords8</param>
@@ -321,6 +393,24 @@
 					<param name="coords2">Viewtype535_coords11</param>
 					<param name="coords3">Viewtype535_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -377,6 +467,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">535</param>
 					<param name="coords">Viewtype535_coords10</param>
 					<param name="coords2">Viewtype535_coords11</param>
@@ -443,6 +551,24 @@
 					<param name="coords2">Viewtype535_coords11</param>
 					<param name="coords3">Viewtype535_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -499,6 +625,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">535</param>
+					<param name="coords">Viewtype535_coords10</param>
+					<param name="coords2">Viewtype535_coords11</param>
+					<param name="coords3">Viewtype535_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">535</param>
 					<param name="coords">Viewtype535_coords10</param>
 					<param name="coords2">Viewtype535_coords11</param>

--- a/xml/Coordinates_Viewtype536.xml
+++ b/xml/Coordinates_Viewtype536.xml
@@ -399,6 +399,24 @@
 				<param name="coords2">Viewtype536_coords18</param>
 				<param name="coords3">Viewtype536_coords19</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -443,6 +461,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">536</param>
 				<param name="coords">Viewtype536_coords17</param>
 				<param name="coords2">Viewtype536_coords18</param>
@@ -497,6 +533,24 @@
 				<param name="coords2">Viewtype536_coords18</param>
 				<param name="coords3">Viewtype536_coords19</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -541,6 +595,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">536</param>
+				<param name="coords">Viewtype536_coords17</param>
+				<param name="coords2">Viewtype536_coords18</param>
+				<param name="coords3">Viewtype536_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">536</param>
 				<param name="coords">Viewtype536_coords17</param>
 				<param name="coords2">Viewtype536_coords18</param>
@@ -604,6 +676,24 @@
 					<param name="coords2">Viewtype536_coords21</param>
 					<param name="coords3">Viewtype536_coords22</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -651,6 +741,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">536</param>
 					<param name="coords">Viewtype536_coords20</param>
 					<param name="coords2">Viewtype536_coords21</param>
@@ -708,6 +816,24 @@
 					<param name="coords2">Viewtype536_coords21</param>
 					<param name="coords3">Viewtype536_coords22</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -755,6 +881,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">536</param>
+					<param name="coords">Viewtype536_coords20</param>
+					<param name="coords2">Viewtype536_coords21</param>
+					<param name="coords3">Viewtype536_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">536</param>
 					<param name="coords">Viewtype536_coords20</param>
 					<param name="coords2">Viewtype536_coords21</param>

--- a/xml/Coordinates_Viewtype537.xml
+++ b/xml/Coordinates_Viewtype537.xml
@@ -80,6 +80,24 @@
 				<param name="coords2">Viewtype537_coords8</param>
 				<param name="coords3">Viewtype537_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -133,6 +151,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">537</param>
 				<param name="coords">Viewtype537_coords7</param>
 				<param name="coords2">Viewtype537_coords8</param>
@@ -196,6 +232,24 @@
 				<param name="coords2">Viewtype537_coords8</param>
 				<param name="coords3">Viewtype537_coords9</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -249,6 +303,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">537</param>
+				<param name="coords">Viewtype537_coords7</param>
+				<param name="coords2">Viewtype537_coords8</param>
+				<param name="coords3">Viewtype537_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">537</param>
 				<param name="coords">Viewtype537_coords7</param>
 				<param name="coords2">Viewtype537_coords8</param>
@@ -321,6 +393,24 @@
 					<param name="coords2">Viewtype537_coords11</param>
 					<param name="coords3">Viewtype537_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -377,6 +467,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">537</param>
 					<param name="coords">Viewtype537_coords10</param>
 					<param name="coords2">Viewtype537_coords11</param>
@@ -443,6 +551,24 @@
 					<param name="coords2">Viewtype537_coords11</param>
 					<param name="coords3">Viewtype537_coords12</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -499,6 +625,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">537</param>
+					<param name="coords">Viewtype537_coords10</param>
+					<param name="coords2">Viewtype537_coords11</param>
+					<param name="coords3">Viewtype537_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">537</param>
 					<param name="coords">Viewtype537_coords10</param>
 					<param name="coords2">Viewtype537_coords11</param>

--- a/xml/Coordinates_Viewtype538.xml
+++ b/xml/Coordinates_Viewtype538.xml
@@ -399,6 +399,24 @@
 				<param name="coords2">Viewtype538_coords18</param>
 				<param name="coords3">Viewtype538_coords19</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -443,6 +461,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">538</param>
 				<param name="coords">Viewtype538_coords17</param>
 				<param name="coords2">Viewtype538_coords18</param>
@@ -497,6 +533,24 @@
 				<param name="coords2">Viewtype538_coords18</param>
 				<param name="coords3">Viewtype538_coords19</param>
 			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultVideo.png</param>
@@ -541,6 +595,24 @@
 			<include content="MediaViewImageNF">
 				<param name="fallback">DefaultAddonGame.png</param>
 				<param name="visible">Container.Content(games)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">538</param>
+				<param name="coords">Viewtype538_coords17</param>
+				<param name="coords2">Viewtype538_coords18</param>
+				<param name="coords3">Viewtype538_coords19</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">538</param>
 				<param name="coords">Viewtype538_coords17</param>
 				<param name="coords2">Viewtype538_coords18</param>
@@ -604,6 +676,24 @@
 					<param name="coords2">Viewtype538_coords21</param>
 					<param name="coords3">Viewtype538_coords22</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -651,6 +741,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">538</param>
 					<param name="coords">Viewtype538_coords20</param>
 					<param name="coords2">Viewtype538_coords21</param>
@@ -708,6 +816,24 @@
 					<param name="coords2">Viewtype538_coords21</param>
 					<param name="coords3">Viewtype538_coords22</param>
 				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultVideo.png</param>
@@ -755,6 +881,24 @@
 				<include content="MediaViewImageFO">
 					<param name="fallback">DefaultAddonGame.png</param>
 					<param name="visible">Container.Content(games)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">538</param>
+					<param name="coords">Viewtype538_coords20</param>
+					<param name="coords2">Viewtype538_coords21</param>
+					<param name="coords3">Viewtype538_coords22</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">538</param>
 					<param name="coords">Viewtype538_coords20</param>
 					<param name="coords2">Viewtype538_coords21</param>

--- a/xml/Coordinates_Viewtype539.xml
+++ b/xml/Coordinates_Viewtype539.xml
@@ -42,8 +42,26 @@
 		<itemlayout width="133" height="133">
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
-				<param name="fallback">DefaultVideoDefaultVideo.png</param>
+				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">539</param>
 				<param name="coords">Viewtype539_coords7</param>
 				<param name="coords2">Viewtype539_coords8</param>
@@ -55,8 +73,26 @@
 		<itemlayout width="133" height="133">
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
-				<param name="fallback">DefaultVideoDefaultVideo.png</param>
+				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">539</param>
 				<param name="coords">Viewtype539_coords7</param>
 				<param name="coords2">Viewtype539_coords8</param>
@@ -68,8 +104,26 @@
 		<itemlayout width="133" height="133">
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
-				<param name="fallback">DefaultVideoDefaultVideo.png</param>
+				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">539</param>
 				<param name="coords">Viewtype539_coords7</param>
 				<param name="coords2">Viewtype539_coords8</param>
@@ -81,8 +135,26 @@
 		<itemlayout width="133" height="133">
 			<!-- Image - Videos -->
 			<include content="MediaViewImageNF">
-				<param name="fallback">DefaultVideoDefaultVideo.png</param>
+				<param name="fallback">DefaultVideo.png</param>
 				<param name="visible">Container.Content(videos)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Episodes -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultTVShows.png</param>
+				<param name="visible">Container.Content(episodes)</param>
+				<param name="id">539</param>
+				<param name="coords">Viewtype539_coords7</param>
+				<param name="coords2">Viewtype539_coords8</param>
+				<param name="coords3">Viewtype539_coords9</param>
+			</include>
+			<!-- Image - Movies -->
+			<include content="MediaViewImageNF">
+				<param name="fallback">DefaultMovies.png</param>
+				<param name="visible">Container.Content(movies)</param>
 				<param name="id">539</param>
 				<param name="coords">Viewtype539_coords7</param>
 				<param name="coords2">Viewtype539_coords8</param>
@@ -103,8 +175,26 @@
 				<animation effect="zoom" start="90" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
-					<param name="fallback">DefaultVideoDefaultVideo.png</param>
+					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">539</param>
 					<param name="coords">Viewtype539_coords10</param>
 					<param name="coords2">Viewtype539_coords11</param>
@@ -119,8 +209,26 @@
 				<animation effect="zoom" start="90" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
-					<param name="fallback">DefaultVideoDefaultVideo.png</param>
+					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">539</param>
 					<param name="coords">Viewtype539_coords10</param>
 					<param name="coords2">Viewtype539_coords11</param>
@@ -135,8 +243,26 @@
 				<animation effect="zoom" start="90" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
-					<param name="fallback">DefaultVideoDefaultVideo.png</param>
+					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">539</param>
 					<param name="coords">Viewtype539_coords10</param>
 					<param name="coords2">Viewtype539_coords11</param>
@@ -151,8 +277,26 @@
 				<animation effect="zoom" start="90" end="100" center="auto" time="300" tween="back" easing="out" reversible="false">Focus</animation>
 				<!-- Image - Videos -->
 				<include content="MediaViewImageFO">
-					<param name="fallback">DefaultVideoDefaultVideo.png</param>
+					<param name="fallback">DefaultVideo.png</param>
 					<param name="visible">Container.Content(videos)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Episodes -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultTVShows.png</param>
+					<param name="visible">Container.Content(episodes)</param>
+					<param name="id">539</param>
+					<param name="coords">Viewtype539_coords10</param>
+					<param name="coords2">Viewtype539_coords11</param>
+					<param name="coords3">Viewtype539_coords12</param>
+				</include>
+				<!-- Image - Movies -->
+				<include content="MediaViewImageFO">
+					<param name="fallback">DefaultMovies.png</param>
+					<param name="visible">Container.Content(movies)</param>
 					<param name="id">539</param>
 					<param name="coords">Viewtype539_coords10</param>
 					<param name="coords2">Viewtype539_coords11</param>

--- a/xml/Includes.xml
+++ b/xml/Includes.xml
@@ -199,16 +199,16 @@
 	
 	<!-- Default forced views -->
 	<include name="DefaultView">
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewList)">Container.SetViewMode(51)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewListinfo)">Container.SetViewMode(511)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWide)">Container.SetViewMode(523)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWidelow)">Container.SetViewMode(524)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWidelowinfo)">Container.SetViewMode(525)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWall)">Container.SetViewMode(535)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWallinfo)">Container.SetViewMode(536)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWallsmall)">Container.SetViewMode(537)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Container.SetViewMode(538)</onfocus>
-		<onfocus condition="Container.Content(videos) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWalllow)">Container.SetViewMode(539)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewList)">Container.SetViewMode(51)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewListinfo)">Container.SetViewMode(511)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWide)">Container.SetViewMode(523)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWidelow)">Container.SetViewMode(524)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWidelowinfo)">Container.SetViewMode(525)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWall)">Container.SetViewMode(535)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWallinfo)">Container.SetViewMode(536)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWallsmall)">Container.SetViewMode(537)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Container.SetViewMode(538)</onfocus>
+		<onfocus condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + Skin.HasSetting(DefaultVideosViewWalllow)">Container.SetViewMode(539)</onfocus>
 	</include>
 
 	<!-- Keyboard buttons -->

--- a/xml/Includes_SubMenu.xml
+++ b/xml/Includes_SubMenu.xml
@@ -1206,8 +1206,8 @@
 	<!-- My video nav sub menu -->
 	<include name="SubMenu_MyVideoNav">
 		<control type="grouplist" id="3001">
-			<include condition="Integer.IsGreater(Container.ViewCount,1) + ![Container.Content(videos) + Skin.HasSetting(FixedVideosView)]">SubMenu_coords3</include>
-			<include condition="!Integer.IsGreater(Container.ViewCount,1) | [Container.Content(videos) + Skin.HasSetting(FixedVideosView)]">SubMenu_coords4</include>
+			<include condition="Integer.IsGreater(Container.ViewCount,1)">SubMenu_coords3</include>
+			<include condition="!Integer.IsGreater(Container.ViewCount,1)">SubMenu_coords4</include>
 			<onleft>50</onleft>
 			<onright>50</onright>
 			<onback>50</onback>
@@ -1226,14 +1226,33 @@
 				<include>SubMenu_coords5</include>
 				<label>$LOCALIZE[31233] $INFO[Container.ViewMode]</label>
 				<onclick>Control.SetFocus(3002)</onclick>
-				<visible>Integer.IsGreater(Container.ViewCount,1) + ![Container.Content(videos) + Skin.HasSetting(FixedVideosView)]</visible>
+				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
+			</control>
+			
+			<!-- Set fixed video addon view -->
+			<control type="radiobutton" id="98">
+				<include>SubMenu_coords5</include>
+				<label>$LOCALIZE[31409]</label>
+				<onclick>Skin.ToggleSetting(FixedVideosView)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewList)">Container.SetViewMode(51)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewListinfo)">Container.SetViewMode(511)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWide)">Container.SetViewMode(523)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWidelow)">Container.SetViewMode(524)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWidelowinfo)">Container.SetViewMode(525)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWall)">Container.SetViewMode(535)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWallinfo)">Container.SetViewMode(536)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWallsmall)">Container.SetViewMode(537)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Container.SetViewMode(538)</onclick>
+				<onclick condition="Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Container.SetViewMode(539)</onclick>
+				<selected>Skin.HasSetting(FixedVideosView)</selected>
+				<visible>Integer.IsGreater(Container.ViewCount,1) + String.StartsWith(Container.FolderPath,plugin://plugin.video)</visible>
 			</control>
 
 			<!-- Seperator -->
 			<control type="image" id="80">
 				<include>SubMenu_coords7</include>
 				<texture>transparent.png</texture>
-				<visible>Integer.IsGreater(Container.ViewCount,1) + ![Container.Content(videos) + Skin.HasSetting(FixedVideosView)]</visible>
+				<visible>Integer.IsGreater(Container.ViewCount,1)</visible>
 			</control>
 
 			<!-- Sort by -->
@@ -1559,7 +1578,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[535]</altlabel>
 						<usealttexture>Control.IsVisible(51)</usealttexture>
 						<onclick>Container.SetViewMode(51)</onclick>
-						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(albums) | Container.Content(videos) | Container.Content(addons) | Container.Content(images) | Container.Content(games)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewList)">Skin.SetBool(DefaultVideosViewList)</onclick>
+						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(albums) | Container.Content(episodes) | Container.Content(videos) | Container.Content(addons) | Container.Content(images) | Container.Content(games)</visible>
 					</control>
 					
 					<!-- List info 511 -->
@@ -1569,6 +1590,8 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31117]</altlabel>
 						<usealttexture>Control.IsVisible(511)</usealttexture>
 						<onclick>Container.SetViewMode(511)</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewListinfo)">Skin.SetBool(DefaultVideosViewListinfo)</onclick>
 						<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) | Container.Content(videos)</visible>
 					</control>
 					
@@ -1609,7 +1632,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31241]</altlabel>
 						<usealttexture>Control.IsVisible(523)</usealttexture>
 						<onclick>Container.SetViewMode(523)</onclick>
-						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWide)">Skin.SetBool(DefaultVideosViewWide)</onclick>
+						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(episodes) | Container.Content(videos) | Container.Content(favourites)</visible>
 					</control>
 					
 					<!-- Wide low (videos) 524 -->
@@ -1619,7 +1644,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31112]</altlabel>
 						<usealttexture>Control.IsVisible(524)</usealttexture>
 						<onclick>Container.SetViewMode(524)</onclick>
-						<visible>Container.Content(videos)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWidelow)">Skin.SetBool(DefaultVideosViewWidelow)</onclick>
+						<visible>Container.Content(episodes) | Container.Content(videos)</visible>
 					</control>
 					
 					<!-- Wide low info (videos) 525 -->
@@ -1629,7 +1656,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31392]</altlabel>
 						<usealttexture>Control.IsVisible(525)</usealttexture>
 						<onclick>Container.SetViewMode(525)</onclick>
-						<visible>Container.Content(videos)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWidelowinfo)">Skin.SetBool(DefaultVideosViewWidelowinfo)</onclick>
+						<visible>Container.Content(episodes) | Container.Content(videos)</visible>
 					</control>
 					
 					<!-- Wall 53 -->
@@ -1689,7 +1718,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31078]</altlabel>
 						<usealttexture>Control.IsVisible(535)</usealttexture>
 						<onclick>Container.SetViewMode(535)</onclick>
-						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWall)">Skin.SetBool(DefaultVideosViewWall)</onclick>
+						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(episodes) | Container.Content(videos) | Container.Content(favourites)</visible>
 					</control>
 					
 					<!-- Wall info (videos) 536 -->
@@ -1699,7 +1730,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31133]</altlabel>
 						<usealttexture>Control.IsVisible(536)</usealttexture>
 						<onclick>Container.SetViewMode(536)</onclick>
-						<visible>Container.Content(videos)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWallinfo)">Skin.SetBool(DefaultVideosViewWallinfo)</onclick>
+						<visible>Container.Content(episodes) | Container.Content(videos)</visible>
 					</control>
 					
 					<!-- Wall small 537 -->
@@ -1709,7 +1742,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31114]</altlabel>
 						<usealttexture>Control.IsVisible(537)</usealttexture>
 						<onclick>Container.SetViewMode(537)</onclick>
-						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWallsmall)">Skin.SetBool(DefaultVideosViewWallsmall)</onclick>
+						<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(episodes) | Container.Content(videos) | Container.Content(favourites)</visible>
 					</control>
 					
 					<!-- Wall small info (videos) 538 -->
@@ -1719,7 +1754,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31116]</altlabel>
 						<usealttexture>Control.IsVisible(538)</usealttexture>
 						<onclick>Container.SetViewMode(538)</onclick>
-						<visible>Container.Content(videos)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Skin.SetBool(DefaultVideosViewWallsmallinfo)</onclick>
+						<visible>Container.Content(episodes) | Container.Content(videos)</visible>
 					</control>
 					
 					<!-- Wall low (videos) 539 -->
@@ -1729,7 +1766,9 @@
 						<altlabel>$LOCALIZE[143] $LOCALIZE[31113]</altlabel>
 						<usealttexture>Control.IsVisible(539)</usealttexture>
 						<onclick>Container.SetViewMode(539)</onclick>
-						<visible>Container.Content(videos)</visible>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView)">$VAR[DefaultViewSettings]</onclick>
+						<onclick condition="String.StartsWith(Container.FolderPath,plugin://plugin.video) + Skin.HasSetting(FixedVideosView) + !Skin.HasSetting(DefaultVideosViewWalllow)">Skin.SetBool(DefaultVideosViewWalllow)</onclick>
+						<visible>Container.Content(episodes) | Container.Content(videos)</visible>
 					</control>
 					
 				</control>

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -132,6 +132,20 @@
 		<value>$VAR[OverlayColorNF]</value>
 	</variable>
 	
+	<!-- Default forced views settings -->
+	<variable name="DefaultViewSettings">
+		<value condition="Skin.HasSetting(DefaultVideosViewList)">Skin.Reset(DefaultVideosViewList)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewListinfo)">Skin.Reset(DefaultVideosViewListinfo)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWide)">Skin.Reset(DefaultVideosViewWide)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWidelow)">Skin.Reset(DefaultVideosViewWidelow)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWidelowinfo)">Skin.Reset(DefaultVideosViewWidelowinfo)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWall)">Skin.Reset(DefaultVideosViewWall)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWallinfo)">Skin.Reset(DefaultVideosViewWallinfo)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWallsmall)">Skin.Reset(DefaultVideosViewWallsmall)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Skin.Reset(DefaultVideosViewWallsmallinfo)</value>
+		<value condition="Skin.HasSetting(DefaultVideosViewWallsmallinfo)">Skin.Reset(DefaultVideosViewWallsmallinfo)</value>
+	</variable>
+	
 	<!-- Busy spinner -->
 	<variable name="BusySpinner">
 		<value condition="Integer.IsLess(System.Memory(total),512)">busy-slow.gif</value>
@@ -208,7 +222,9 @@
 		<value condition="[Container.Content(movies) | [String.StartsWith(Container.FolderPath,videodb://movies/) + !String.EndsWith(Container.FolderPath,videodb://movies/)] | [String.StartsWith(Container.FolderPath,library://video/movies) + !String.EndsWith(Container.FolderPath,library://video/movies/)]] + !String.StartsWith(Container.FolderPath,videodb://movies/videoversions/)">$INFO[Container.FolderName]</value>
 		<value condition="Container.Content(movies) + String.StartsWith(Container.FolderPath,videodb://movies/videoversions/)">$INFO[Container.FolderName] ($LOCALIZE[24069])</value>
 		<value condition="[String.StartsWith(Container.FolderPath,library://video/tvshows/) + String.EndsWith(Container.FolderPath,library://video/tvshows/)] | [String.StartsWith(Container.FolderPath,videodb://tvshows/titles/) + String.EndsWith(Container.FolderPath,videodb://tvshows/titles/)]"></value>
-		<value condition="Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) | [String.StartsWith(Container.FolderPath,videodb://tvshows/) + !String.EndsWith(Container.FolderPath,videodb://tvshows/)] | [String.StartsWith(Container.FolderPath,library://video/tvshows/) + !String.EndsWith(Container.FolderPath,library://video/tvshows/)] | String.StartsWith(Container.FolderPath,videodb://recentlyaddedepisodes/)">$INFO[Container.FolderName]</value>
+		<value condition="Container.Content(episodes) + !String.IsEqual(Container.ShowTitle,Container.FolderName) + !String.IsEqual(Container.FolderName,$LOCALIZE[20366])">$INFO[Container.ShowTitle,, - ]$INFO[Container.FolderName]</value>
+		<value condition="Container.Content(episodes) + String.IsEqual(Container.FolderName,$LOCALIZE[20366])">$INFO[Container.ShowTitle]</value>
+		<value condition="Container.Content(tvshows) | Container.Content(episodes) | Container.Content(seasons) | [String.StartsWith(Container.FolderPath,videodb://tvshows/) + !String.EndsWith(Container.FolderPath,videodb://tvshows/)] | [String.StartsWith(Container.FolderPath,library://video/tvshows/) + !String.EndsWith(Container.FolderPath,library://video/tvshows/)] | String.StartsWith(Container.FolderPath,videodb://recentlyaddedepisodes/)">$INFO[Container.FolderName]</value>
 		<value condition="String.StartsWith(Container.FolderPath,library://video/musicvideos/) + String.EndsWith(Container.FolderPath,library://video/musicvideos/)"></value>
 		<value condition="Container.Content(musicvideos) | [String.StartsWith(Container.FolderPath,videodb://musicvideos/) + !String.EndsWith(Container.FolderPath,videodb://musicvideos/)] | [String.StartsWith(Container.FolderPath,library://video/musicvideos) + !String.EndsWith(Container.FolderPath,library://video/musicvideos/)]">$INFO[Container.FolderName]</value>
 		<value condition="Window.IsVisible(TVChannels)">$INFO[Control.GetLabel(29)]</value>
@@ -254,16 +270,16 @@
 	
 	<!-- Content type label -->
 	<variable name="ContentType">
-		<value condition="Container.Content(movies) + !String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20338]</value>
-		<value condition="Container.Content(movies) + !String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[342]</value>
-		<value condition="Container.Content(movies) + String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[40012]</value>
-		<value condition="Container.Content(movies) + String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[40013]</value>
+		<value condition="Container.Content(movies) + !String.StartsWith(Container.FolderPath,plugin://plugin.video) + !String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20338]</value>
+		<value condition="Container.Content(movies) + !String.StartsWith(Container.FolderPath,plugin://plugin.video) + !String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[342]</value>
+		<value condition="Container.Content(movies) + !String.StartsWith(Container.FolderPath,plugin://plugin.video) + String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[40012]</value>
+		<value condition="Container.Content(movies) + !String.StartsWith(Container.FolderPath,plugin://plugin.video) + String.StartsWith(Container.FolderPath,videodb://movies/videoversions/) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[40013]</value>
 		<value condition="Container.Content(tvshows) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20364]</value>
 		<value condition="Container.Content(tvshows) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20343]</value>
 		<value condition="Container.Content(seasons) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20373]</value>
 		<value condition="Container.Content(seasons) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[33054]</value>
-		<value condition="Container.Content(episodes) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20359]</value>
-		<value condition="Container.Content(episodes) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20360]</value>
+		<value condition="Container.Content(episodes) + !String.StartsWith(Container.FolderPath,plugin://plugin.video) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20359]</value>
+		<value condition="Container.Content(episodes) + !String.StartsWith(Container.FolderPath,plugin://plugin.video) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20360]</value>
 		<value condition="Container.Content(musicvideos) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20391]</value>
 		<value condition="Container.Content(musicvideos) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[20389]</value>
 		<value condition="Container.Content(genres) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[515]</value>
@@ -298,8 +314,8 @@
 		<value condition="[Window.IsVisible(RadioGuide) | Window.IsVisible(TVGuide) | Window.IsVisible(TVChannels) | Window.IsVisible(RadioRecordings)] + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[19019]</value>
 		<value condition="Container.Content(games) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[31238]</value>
 		<value condition="Container.Content(games) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[15016]</value>
-		<value condition="[Container.Content(videos) | Window.IsVisible(VideoPlaylist)] + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[157]</value>
-		<value condition="[Container.Content(videos) | Window.IsVisible(VideoPlaylist)] + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[10025]</value>
+		<value condition="[Container.Content(videos) | [Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Window.IsVisible(VideoPlaylist)] + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[157]</value>
+		<value condition="[Container.Content(videos) | [Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Window.IsVisible(VideoPlaylist)] + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[10025]</value>
 		<value condition="String.StartsWith(Container.FolderPath,addons://sources/game) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[31239]</value>
 		<value condition="String.StartsWith(Container.FolderPath,addons://sources/game) + !Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[35049]</value>
 		<value condition="Container.Content(favourites) + Integer.IsEqual(Container.NumItems,1)">$LOCALIZE[31015]</value>

--- a/xml/Viewtype51.xml
+++ b/xml/Viewtype51.xml
@@ -19,10 +19,10 @@
 				<param name="fallback">DefaultSets.png</param>
 				<param name="visible">Container.Content(sets)</param>
 			</include>
-			<!-- TV shows/Seasons -->
+			<!-- TV shows/seasons/episodes -->
 			<include content="image-51">
 				<param name="fallback">DefaultTVShows.png</param>
-				<param name="visible">Container.Content(tvshows) | Container.Content(seasons)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) + String.StartsWith(Container.FolderPath,plugin://plugin.video)</param>
 			</include>
 			<!-- Albums -->
 			<include content="image-51">
@@ -63,7 +63,7 @@
 			<orientation>vertical</orientation>
 			<viewtype label="$LOCALIZE[535]">list</viewtype>
 			<scrolltime tween="sine" easing="out">240</scrolltime>
-			<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(albums) | Container.Content(videos) | Container.Content(addons) | Container.Content(images) | Container.Content(games)</visible>
+			<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes) + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(albums) | Container.Content(videos) | Container.Content(addons) | Container.Content(images) | Container.Content(games)</visible>
 			<include>DefaultView</include>
 
 			<include>Viewtype51_coords2</include>

--- a/xml/Viewtype511.xml
+++ b/xml/Viewtype511.xml
@@ -14,15 +14,15 @@
 				<param name="fallback">DefaultMovies.png</param>
 				<param name="visible">Container.Content(movies) | Container.Content(sets)</param>
 			</include>
-			<!-- TV shows -->
+			<!-- TV shows/episdoes -->
 			<include content="image-511">
 				<param name="fallback">DefaultTVShows.png</param>
-				<param name="visible">Container.Content(tvshows)</param>
+				<param name="visible">Container.Content(tvshows) | Container.Content(episodes) + String.StartsWith(Container.FolderPath,plugin://plugin.video)</param>
 			</include>
 			<!-- TV show episodes -->
 			<include content="image-511-episodes">
 				<param name="fallback">DefaultTVShows.png</param>
-				<param name="visible">Container.Content(episodes)</param>
+				<param name="visible">Container.Content(episodes) + !String.StartsWith(Container.FolderPath,plugin://plugin.video)</param>
 			</include>
 			<!-- Videos -->
 			<include content="image-511">
@@ -33,7 +33,7 @@
 			<!-- Plot -->
 			<control type="group">
 				<include>Viewtype511_coords3</include>
-				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(videos)</visible>
+				<visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(episodes) + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				<control type="textbox">
 					<include>Viewtype511_coords4</include>
 					<align>left</align>
@@ -66,7 +66,7 @@
 			<!-- Episode Info -->
 			<control type="group">
 				<include>Viewtype511_coords7</include>
-				<visible>Container.Content(episodes)</visible>
+				<visible>Container.Content(episodes) + !String.StartsWith(Container.FolderPath,plugin://plugin.video)</visible>
 
 				<!-- Season & Episode Info -->
 				<control type="fadelabel">

--- a/xml/Viewtype523.xml
+++ b/xml/Viewtype523.xml
@@ -17,7 +17,7 @@
 				<orientation>horizontal</orientation>
 				<viewtype label="$LOCALIZE[31241]">wide</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+				<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | [Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos) | Container.Content(favourites)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype523_coords2</include>

--- a/xml/Viewtype524.xml
+++ b/xml/Viewtype524.xml
@@ -19,7 +19,7 @@
 				<orientation>horizontal</orientation>
 				<viewtype label="$LOCALIZE[31112]">wide</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype524_coords2</include>

--- a/xml/Viewtype525.xml
+++ b/xml/Viewtype525.xml
@@ -19,7 +19,7 @@
 				<orientation>horizontal</orientation>
 				<viewtype label="$LOCALIZE[31392]">biginfo</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype525_coords2</include>
@@ -31,7 +31,7 @@
 			<!-- Video info -->
 			<control type="group">
 				<include>Viewtype525_coords4</include>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				
 				<!-- Title -->
 				<control type="fadelabel">

--- a/xml/Viewtype535.xml
+++ b/xml/Viewtype535.xml
@@ -16,7 +16,7 @@
 				<pagecontrol>63</pagecontrol>
 				<viewtype label="$LOCALIZE[31078]">bigicon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+				<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | [Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos) | Container.Content(favourites)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype535_coords2</include>

--- a/xml/Viewtype536.xml
+++ b/xml/Viewtype536.xml
@@ -10,7 +10,7 @@
 			<!-- Video info -->
 			<control type="group">
 				<include>Viewtype536_coords1</include>
-				<visible>Container.Content(videos)</visible>
+				<visible>Container.Content(videos) | [Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video)</visible>
 				
 				<!-- Title -->
 				<control type="fadelabel">
@@ -131,7 +131,7 @@
 				<pagecontrol>60</pagecontrol>
 				<viewtype label="$LOCALIZE[31133]">bigicon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype536_coords15</include>

--- a/xml/Viewtype537.xml
+++ b/xml/Viewtype537.xml
@@ -16,7 +16,7 @@
 				<pagecontrol>63</pagecontrol>
 				<viewtype label="$LOCALIZE[31114]">icon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | Container.Content(videos) | Container.Content(favourites)</visible>
+				<visible>Container.Content(albums) | Container.Content(addons) | Container.Content(artists) | Container.Content(games) | [Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos) | Container.Content(favourites)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype537_coords2</include>

--- a/xml/Viewtype538.xml
+++ b/xml/Viewtype538.xml
@@ -10,7 +10,7 @@
 			<!-- Movie/TV show info -->
 			<control type="group">
 				<include>Viewtype538_coords1</include>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				
 				<!-- Title -->
 				<control type="fadelabel">
@@ -131,7 +131,7 @@
 				<pagecontrol>60</pagecontrol>
 				<viewtype label="$LOCALIZE[31116]">icon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype538_coords15</include>

--- a/xml/Viewtype539.xml
+++ b/xml/Viewtype539.xml
@@ -17,7 +17,7 @@
 				<preloaditems>4</preloaditems>
 				<viewtype label="$LOCALIZE[31113]">icon</viewtype>
 				<scrolltime tween="sine" easing="out">240</scrolltime>
-				<visible>Container.Content(videos)</visible>
+				<visible>[Container.Content(episodes) | Container.Content(movies)] + String.StartsWith(Container.FolderPath,plugin://plugin.video) | Container.Content(videos)</visible>
 				<include>DefaultView</include>
 
 				<include>Viewtype539_coords2</include>


### PR DESCRIPTION
Coordinates_Viewtype523.xml:
- add new content type image includes

Coordinates_Viewtype524.xml:
- add new content type image includes

Coordinates_Viewtype525.xml:
- add new content type image includes

Coordinates_Viewtype535.xml:
- add new content type image includes

Coordinates_Viewtype536.xml:
- add new content type image includes

Coordinates_Viewtype537.xml:
- add new content type image includes

Coordinates_Viewtype538.xml:
- add new content type image includes

Coordinates_Viewtype539.xml:
- add new content type image includes
- fix videos fallback icon

Includes.xml:
- adjust DefaultView include to work with multiple content types and specifically with video addons

Includes_SubMenu.xml:
- add fixed video addon views setting to side menu
- adjust views menu to work together with fixed video addon views setting

Variables.xml:
- add new DefaultViewSettings variable for reworked views menu buttons
- adjust HeadingLabelSecondary variable to show proper information on episodes level (TV show title and season, if useful)
- adjust ContentType variable to show videos content type when a list of video addon items are shown

Viewtype51.xml:
- adjust visibility conditions of images and list container to work with multiple with multiple video addons content type

Viewtype511.xml:
- adjust visibility conditions of images and list container to work with multiple with multiple video addons content type

Viewtype523.xml:
- adjust visibility conditions of list container to work with multiple with multiple video addons content type

Viewtype524xml:
- adjust visibility conditions of list container to work with multiple with multiple video addons content type

Viewtype525.xml:
- adjust visibility conditions of list container and info controls to work with multiple with multiple video addons content type

Viewtype535.xml:
- adjust visibility conditions of panel container to work with multiple with multiple video addons content type

Viewtype536.xml:
- adjust visibility conditions of panel container and info controls to work with multiple with multiple video addons content type

Viewtype537.xml:
- adjust visibility conditions of panel container to work with multiple with multiple video addons content type

Viewtype538.xml:
- adjust visibility conditions of panel container and info controls to work with multiple with multiple video addons content type

Viewtype539.xml:
- adjust visibility conditions of panel container to work with multiple with multiple video addons content type

addon.xml:
- bump version to 21.2.0
- update changelog

Changelog.md:
- update changelog
