### PR TITLE
Fix text width of slider and spin settings controls

### DIFF
--- a/xml/Coordinates_DialogAddonSettings.xml
+++ b/xml/Coordinates_DialogAddonSettings.xml
@@ -269,18 +269,22 @@
 	<include name="DialogAddonSettings_coords10_16:9">
 		<width>1170</width>
 		<height>66</height>
+		<textwidth>1105</textwidth>
 	</include>
 	<include name="DialogAddonSettings_coords10_21:9">
 		<width>1810</width>
 		<height>66</height>
+		<textwidth>1745</textwidth>
 	</include>
 	<include name="DialogAddonSettings_coords10_21:9_masked">
 		<width>1810</width>
 		<height>66</height>
+		<textwidth>1745</textwidth>
 	</include>
 	<include name="DialogAddonSettings_coords10_4:3">
 		<width>690</width>
 		<height>66</height>
+		<textwidth>625</textwidth>
 	</include>
 	
 	<include name="DialogAddonSettings_coords11">
@@ -290,24 +294,74 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords11_4:3</include>
 	</include>
 	<include name="DialogAddonSettings_coords11_16:9">
+		<width>1170</width>
+		<height>66</height>
+		<textwidth>890</textwidth>
+	</include>
+	<include name="DialogAddonSettings_coords11_21:9">
+		<width>1810</width>
+		<height>66</height>
+		<textwidth>1530</textwidth>
+	</include>
+	<include name="DialogAddonSettings_coords11_21:9_masked">
+		<width>1810</width>
+		<height>66</height>
+		<textwidth>1530</textwidth>
+	</include>
+	<include name="DialogAddonSettings_coords11_4:3">
+		<width>690</width>
+		<height>66</height>
+		<textwidth>410</textwidth>
+	</include>
+	
+	<include name="DialogAddonSettings_coords12">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogAddonSettings_coords12_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogAddonSettings_coords12_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogAddonSettings_coords12_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords12_4:3</include>
+	</include>
+	<include name="DialogAddonSettings_coords12_16:9">
+		<width>1170</width>
+		<height>66</height>
+	</include>
+	<include name="DialogAddonSettings_coords12_21:9">
+		<width>1810</width>
+		<height>66</height>
+	</include>
+	<include name="DialogAddonSettings_coords12_21:9_masked">
+		<width>1810</width>
+		<height>66</height>
+	</include>
+	<include name="DialogAddonSettings_coords12_4:3">
+		<width>690</width>
+		<height>66</height>
+	</include>
+	
+	<include name="DialogAddonSettings_coords13">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogAddonSettings_coords13_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogAddonSettings_coords13_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogAddonSettings_coords13_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogAddonSettings_coords13_4:3</include>
+	</include>
+	<include name="DialogAddonSettings_coords13_16:9">
 		<left>600</left>
 		<bottom>180</bottom>
 		<width>1170</width>
 		<height>36</height>
 	</include>
-	<include name="DialogAddonSettings_coords11_21:9">
+	<include name="DialogAddonSettings_coords13_21:9">
 		<left>600</left>
 		<bottom>180</bottom>
 		<width>1810</width>
 		<height>36</height>
 	</include>
-	<include name="DialogAddonSettings_coords11_21:9_masked">
+	<include name="DialogAddonSettings_coords13_21:9_masked">
 		<left>600</left>
 		<bottom>360</bottom>
 		<width>1810</width>
 		<height>36</height>
 	</include>
-	<include name="DialogAddonSettings_coords11_4:3">
+	<include name="DialogAddonSettings_coords13_4:3">
 		<left>600</left>
 		<bottom>180</bottom>
 		<width>690</width>

--- a/xml/Coordinates_DialogSettings.xml
+++ b/xml/Coordinates_DialogSettings.xml
@@ -113,19 +113,23 @@
 	</include>
 	<include name="DialogSettings_coords5_16:9">
 		<width>1170</width>
-		<height>20</height>
+		<height>50</height>
+		<textwidth>1105</textwidth>
 	</include>
 	<include name="DialogSettings_coords5_21:9">
 		<width>1810</width>
-		<height>20</height>
+		<height>50</height>
+		<textwidth>1745</textwidth>
 	</include>
 	<include name="DialogSettings_coords5_21:9_masked">
 		<width>1810</width>
-		<height>20</height>
+		<height>50</height>
+		<textwidth>1745</textwidth>
 	</include>
 	<include name="DialogSettings_coords5_4:3">
 		<width>690</width>
-		<height>20</height>
+		<height>50</height>
+		<textwidth>625</textwidth>
 	</include>
 	
 	<include name="DialogSettings_coords6">
@@ -135,28 +139,24 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords6_4:3</include>
 	</include>
 	<include name="DialogSettings_coords6_16:9">
-		<centerleft>50%</centerleft>
-		<centertop>50%</centertop>
-		<width>920</width>
-		<height>940</height>
+		<width>1170</width>
+		<height>50</height>
+		<textwidth>890</textwidth>
 	</include>
 	<include name="DialogSettings_coords6_21:9">
-		<centerleft>50%</centerleft>
-		<centertop>50%</centertop>
-		<width>920</width>
-		<height>940</height>
+		<width>1810</width>
+		<height>50</height>
+		<textwidth>1530</textwidth>
 	</include>
 	<include name="DialogSettings_coords6_21:9_masked">
-		<centerleft>50%</centerleft>
-		<centertop>50%</centertop>
-		<width>920</width>
-		<height>940</height>
+		<width>1810</width>
+		<height>50</height>
+		<textwidth>1530</textwidth>
 	</include>
 	<include name="DialogSettings_coords6_4:3">
-		<centerleft>50%</centerleft>
-		<centertop>50%</centertop>
-		<width>920</width>
-		<height>940</height>
+		<width>690</width>
+		<height>50</height>
+		<textwidth>410</textwidth>
 	</include>
 	
 	<include name="DialogSettings_coords7">
@@ -166,20 +166,20 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords7_4:3</include>
 	</include>
 	<include name="DialogSettings_coords7_16:9">
-		<width>920</width>
-		<height>940</height>
+		<width>1170</width>
+		<height>20</height>
 	</include>
 	<include name="DialogSettings_coords7_21:9">
-		<width>920</width>
-		<height>940</height>
+		<width>1810</width>
+		<height>20</height>
 	</include>
 	<include name="DialogSettings_coords7_21:9_masked">
-		<width>920</width>
-		<height>940</height>
+		<width>1810</width>
+		<height>20</height>
 	</include>
 	<include name="DialogSettings_coords7_4:3">
-		<width>920</width>
-		<height>940</height>
+		<width>690</width>
+		<height>20</height>
 	</include>
 	
 	<include name="DialogSettings_coords8">
@@ -189,28 +189,28 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords8_4:3</include>
 	</include>
 	<include name="DialogSettings_coords8_16:9">
-		<left>50</left>
-		<top>30</top>
-		<width>820</width>
-		<height>33</height>
+		<centerleft>50%</centerleft>
+		<centertop>50%</centertop>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	<include name="DialogSettings_coords8_21:9">
-		<left>50</left>
-		<top>30</top>
-		<width>820</width>
-		<height>33</height>
+		<centerleft>50%</centerleft>
+		<centertop>50%</centertop>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	<include name="DialogSettings_coords8_21:9_masked">
-		<left>50</left>
-		<top>30</top>
-		<width>820</width>
-		<height>33</height>
+		<centerleft>50%</centerleft>
+		<centertop>50%</centertop>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	<include name="DialogSettings_coords8_4:3">
-		<left>50</left>
-		<top>30</top>
-		<width>820</width>
-		<height>33</height>
+		<centerleft>50%</centerleft>
+		<centertop>50%</centertop>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	
 	<include name="DialogSettings_coords9">
@@ -220,28 +220,20 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords9_4:3</include>
 	</include>
 	<include name="DialogSettings_coords9_16:9">
-		<left>50</left>
-		<top>90</top>
-		<width>820</width>
-		<height>780</height>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	<include name="DialogSettings_coords9_21:9">
-		<left>50</left>
-		<top>90</top>
-		<width>820</width>
-		<height>780</height>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	<include name="DialogSettings_coords9_21:9_masked">
-		<left>50</left>
-		<top>90</top>
-		<width>820</width>
-		<height>780</height>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	<include name="DialogSettings_coords9_4:3">
-		<left>50</left>
-		<top>90</top>
-		<width>820</width>
-		<height>780</height>
+		<width>920</width>
+		<height>940</height>
 	</include>
 	
 	<include name="DialogSettings_coords10">
@@ -252,23 +244,27 @@
 	</include>
 	<include name="DialogSettings_coords10_16:9">
 		<left>50</left>
+		<top>30</top>
 		<width>820</width>
-		<height>42</height>
+		<height>33</height>
 	</include>
 	<include name="DialogSettings_coords10_21:9">
 		<left>50</left>
+		<top>30</top>
 		<width>820</width>
-		<height>42</height>
+		<height>33</height>
 	</include>
 	<include name="DialogSettings_coords10_21:9_masked">
 		<left>50</left>
+		<top>30</top>
 		<width>820</width>
-		<height>42</height>
+		<height>33</height>
 	</include>
 	<include name="DialogSettings_coords10_4:3">
 		<left>50</left>
+		<top>30</top>
 		<width>820</width>
-		<height>42</height>
+		<height>33</height>
 	</include>
 	
 	<include name="DialogSettings_coords11">
@@ -279,23 +275,27 @@
 	</include>
 	<include name="DialogSettings_coords11_16:9">
 		<left>50</left>
+		<top>90</top>
 		<width>820</width>
-		<height>50</height>
+		<height>780</height>
 	</include>
 	<include name="DialogSettings_coords11_21:9">
 		<left>50</left>
+		<top>90</top>
 		<width>820</width>
-		<height>50</height>
+		<height>780</height>
 	</include>
 	<include name="DialogSettings_coords11_21:9_masked">
 		<left>50</left>
+		<top>90</top>
 		<width>820</width>
-		<height>50</height>
+		<height>780</height>
 	</include>
 	<include name="DialogSettings_coords11_4:3">
 		<left>50</left>
+		<top>90</top>
 		<width>820</width>
-		<height>50</height>
+		<height>780</height>
 	</include>
 	
 	<include name="DialogSettings_coords12">
@@ -307,26 +307,22 @@
 	<include name="DialogSettings_coords12_16:9">
 		<left>50</left>
 		<width>820</width>
-		<height>50</height>
-		<textwidth>782</textwidth>
+		<height>42</height>
 	</include>
 	<include name="DialogSettings_coords12_21:9">
 		<left>50</left>
 		<width>820</width>
-		<height>50</height>
-		<textwidth>782</textwidth>
+		<height>42</height>
 	</include>
 	<include name="DialogSettings_coords12_21:9_masked">
 		<left>50</left>
 		<width>820</width>
-		<height>50</height>
-		<textwidth>782</textwidth>
+		<height>42</height>
 	</include>
 	<include name="DialogSettings_coords12_4:3">
 		<left>50</left>
 		<width>820</width>
-		<height>50</height>
-		<textwidth>782</textwidth>
+		<height>42</height>
 	</include>
 	
 	<include name="DialogSettings_coords13">
@@ -338,22 +334,22 @@
 	<include name="DialogSettings_coords13_16:9">
 		<left>50</left>
 		<width>820</width>
-		<height>20</height>
+		<height>50</height>
 	</include>
 	<include name="DialogSettings_coords13_21:9">
 		<left>50</left>
 		<width>820</width>
-		<height>20</height>
+		<height>50</height>
 	</include>
 	<include name="DialogSettings_coords13_21:9_masked">
 		<left>50</left>
 		<width>820</width>
-		<height>20</height>
+		<height>50</height>
 	</include>
 	<include name="DialogSettings_coords13_4:3">
 		<left>50</left>
 		<width>820</width>
-		<height>20</height>
+		<height>50</height>
 	</include>
 	
 	<include name="DialogSettings_coords14">
@@ -365,19 +361,139 @@
 	<include name="DialogSettings_coords14_16:9">
 		<left>50</left>
 		<width>820</width>
-		<top>865</top>
+		<height>50</height>
+		<textwidth>782</textwidth>
 	</include>
 	<include name="DialogSettings_coords14_21:9">
 		<left>50</left>
 		<width>820</width>
-		<top>865</top>
+		<height>50</height>
+		<textwidth>782</textwidth>
 	</include>
 	<include name="DialogSettings_coords14_21:9_masked">
 		<left>50</left>
 		<width>820</width>
-		<top>865</top>
+		<height>50</height>
+		<textwidth>782</textwidth>
 	</include>
 	<include name="DialogSettings_coords14_4:3">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>782</textwidth>
+	</include>
+	
+	<include name="DialogSettings_coords15">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogSettings_coords15_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSettings_coords15_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogSettings_coords15_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords15_4:3</include>
+	</include>
+	<include name="DialogSettings_coords15_16:9">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>755</textwidth>
+	</include>
+	<include name="DialogSettings_coords15_21:9">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>755</textwidth>
+	</include>
+	<include name="DialogSettings_coords15_21:9_masked">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>755</textwidth>
+	</include>
+	<include name="DialogSettings_coords15_4:3">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>755</textwidth>
+	</include>
+	
+	<include name="DialogSettings_coords16">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogSettings_coords16_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSettings_coords16_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogSettings_coords16_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords16_4:3</include>
+	</include>
+	<include name="DialogSettings_coords16_16:9">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>540</textwidth>
+	</include>
+	<include name="DialogSettings_coords16_21:9">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>540</textwidth>
+	</include>
+	<include name="DialogSettings_coords16_21:9_masked">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>540</textwidth>
+	</include>
+	<include name="DialogSettings_coords16_4:3">
+		<left>50</left>
+		<width>820</width>
+		<height>50</height>
+		<textwidth>540</textwidth>
+	</include>
+	
+	<include name="DialogSettings_coords17">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogSettings_coords17_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSettings_coords17_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogSettings_coords17_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords17_4:3</include>
+	</include>
+	<include name="DialogSettings_coords17_16:9">
+		<left>50</left>
+		<width>820</width>
+		<height>20</height>
+	</include>
+	<include name="DialogSettings_coords17_21:9">
+		<left>50</left>
+		<width>820</width>
+		<height>20</height>
+	</include>
+	<include name="DialogSettings_coords17_21:9_masked">
+		<left>50</left>
+		<width>820</width>
+		<height>20</height>
+	</include>
+	<include name="DialogSettings_coords17_4:3">
+		<left>50</left>
+		<width>820</width>
+		<height>20</height>
+	</include>
+	
+	<include name="DialogSettings_coords18">
+		<include condition="$EXP[NonMaskedCoordinates]">DialogSettings_coords18_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">DialogSettings_coords18_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">DialogSettings_coords18_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">DialogSettings_coords18_4:3</include>
+	</include>
+	<include name="DialogSettings_coords18_16:9">
+		<left>50</left>
+		<width>820</width>
+		<top>865</top>
+	</include>
+	<include name="DialogSettings_coords18_21:9">
+		<left>50</left>
+		<width>820</width>
+		<top>865</top>
+	</include>
+	<include name="DialogSettings_coords18_21:9_masked">
+		<left>50</left>
+		<width>820</width>
+		<top>865</top>
+	</include>
+	<include name="DialogSettings_coords18_4:3">
 		<left>50</left>
 		<width>820</width>
 		<top>865</top>

--- a/xml/Coordinates_SettingsCategory.xml
+++ b/xml/Coordinates_SettingsCategory.xml
@@ -360,5 +360,59 @@
 		<height>66</height>
 		<textwidth>732</textwidth>
 	</include>
+	
+	<include name="SettingsCategory_coords13">
+		<include condition="$EXP[NonMaskedCoordinates]">SettingsCategory_coords13_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SettingsCategory_coords13_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">SettingsCategory_coords13_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SettingsCategory_coords13_4:3</include>
+	</include>
+	<include name="SettingsCategory_coords13_16:9">
+		<width>1250</width>
+		<height>66</height>
+		<textwidth>1185</textwidth>
+	</include>
+	<include name="SettingsCategory_coords13_21:9">
+		<width>1890</width>
+		<height>66</height>
+		<textwidth>1825</textwidth>
+	</include>
+	<include name="SettingsCategory_coords13_21:9_masked">
+		<width>1890</width>
+		<height>66</height>
+		<textwidth>1825</textwidth>
+	</include>
+	<include name="SettingsCategory_coords13_4:3">
+		<width>770</width>
+		<height>66</height>
+		<textwidth>705</textwidth>
+	</include>
+	
+	<include name="SettingsCategory_coords14">
+		<include condition="$EXP[NonMaskedCoordinates]">SettingsCategory_coords14_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">SettingsCategory_coords14_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">SettingsCategory_coords14_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">SettingsCategory_coords14_4:3</include>
+	</include>
+	<include name="SettingsCategory_coords14_16:9">
+		<width>1250</width>
+		<height>66</height>
+		<textwidth>970</textwidth>
+	</include>
+	<include name="SettingsCategory_coords14_21:9">
+		<width>1890</width>
+		<height>66</height>
+		<textwidth>1610</textwidth>
+	</include>
+	<include name="SettingsCategory_coords14_21:9_masked">
+		<width>1890</width>
+		<height>66</height>
+		<textwidth>1610</textwidth>
+	</include>
+	<include name="SettingsCategory_coords14_4:3">
+		<width>770</width>
+		<height>66</height>
+		<textwidth>490</textwidth>
+	</include>
 
 </includes>

--- a/xml/Defaults.xml
+++ b/xml/Defaults.xml
@@ -48,16 +48,16 @@
 		<height>66</height>
 		<align>left</align>
 		<aligny>center</aligny>
+		<font>Font33</font>
 		<label></label>
 		<textoffsetx>0</textoffsetx>
-		<font>Font33</font>
 		<textcolor>$VAR[TextColorNF]</textcolor>
 		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-		<texturenofocus></texturenofocus>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
-		<alttexturenofocus></alttexturenofocus>
+		<texturenofocus></texturenofocus>
 		<alttexturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</alttexturefocus>
+		<alttexturenofocus></alttexturenofocus>
 		<pulseonselect>False</pulseonselect>
 		<include>WindowDepth</include>
 	</default>
@@ -69,19 +69,19 @@
 		<aligny>center</aligny>
 		<font>Font33</font>
 		<label></label>
+		<textoffsetx>0</textoffsetx>
 		<textcolor>$VAR[TextColorNF]</textcolor>
 		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
 		<textwidth>362</textwidth>
 		<radiowidth>16</radiowidth>
 		<radioheight>16</radioheight>
-		<texturenofocus></texturenofocus>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<texturenofocus></texturenofocus>
 		<textureradioonfocus colordiffuse="$VAR[OverlayColorFO]">common/RadioOn.png</textureradioonfocus>
 		<textureradioonnofocus colordiffuse="$VAR[OverlayColorFO]">common/RadioOn.png</textureradioonnofocus>
 		<textureradioofffocus colordiffuse="$VAR[OverlayColorFO]">common/RadioOff.png</textureradioofffocus>
 		<textureradiooffnofocus colordiffuse="$VAR[OverlayColorFO]">common/RadioOff.png</textureradiooffnofocus>
-		<textoffsetx>0</textoffsetx>
 		<pulseonselect>False</pulseonselect>
 		<include>WindowDepth</include>
 	</default>
@@ -91,21 +91,24 @@
 		<height>66</height>
 		<align>left</align>
 		<aligny>center</aligny>
-		<label></label>
 		<font>Font33</font>
-		<spinwidth>35</spinwidth>
-		<spinheight>66</spinheight>
+		<label></label>
+		<textoffsetx>0</textoffsetx>
+		<textwidth>335</textwidth>
+		<spinwidth>43</spinwidth>
+		<spinheight>60</spinheight>
+		<textcolor>$VAR[TextColorNF]</textcolor>
+		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
+		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
+		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<alttexturenofocus></alttexturenofocus>
 		<textureup colordiffuse="$VAR[OverlayColorNF]">common/ArrowUpFO.png</textureup>
 		<texturedown colordiffuse="$VAR[OverlayColorNF]">common/ArrowDownFO.png</texturedown>
 		<textureupfocus colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpFO.png</textureupfocus>
 		<texturedownfocus colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownFO.png</texturedownfocus>
-		<textcolor>$VAR[TextColorNF]</textcolor>
-		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
-		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
 		<textoffsetx>0</textoffsetx>
 		<reverse>yes</reverse>
 		<pulseonselect>False</pulseonselect>
-		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
 		<include>WindowDepth</include>
 	</default>
 
@@ -114,43 +117,46 @@
 		<width>66</width>
 		<align>left</align>
 		<aligny>center</aligny>
+		<font>Font33</font>
+		<textoffsetx>0</textoffsetx>
+		<textcolor>$VAR[TextColorNF]</textcolor>
+		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
+		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
 		<spinwidth>43</spinwidth>
 		<spinheight>60</spinheight>
+		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<alttexturenofocus></alttexturenofocus>
 		<textureup colordiffuse="$VAR[OverlayColorNF]">common/ArrowUpFO.png</textureup>
 		<texturedown colordiffuse="$VAR[OverlayColorNF]">common/ArrowDownFO.png</texturedown>
 		<textureupfocus colordiffuse="$VAR[OverlayColorFO]">common/ArrowUpFO.png</textureupfocus>
 		<texturedownfocus colordiffuse="$VAR[OverlayColorFO]">common/ArrowDownFO.png</texturedownfocus>
-		<font>Font33</font>
-		<textcolor>$VAR[TextColorNF]</textcolor>
-		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
-		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-		<textoffsetx>0</textoffsetx>
 		<reverse>yes</reverse>
 		<pulseonselect>False</pulseonselect>
-		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
 		<include>WindowDepth</include>
 	</default>
 
 	<default type="sliderex">
+		<width>400</width>
 		<height>66</height>
-		<width>183</width>
 		<align>left</align>
 		<aligny>center</aligny>
+		<font>Font33</font>
+		<textoffsetx>0</textoffsetx>
+		<textcolor>$VAR[TextColorNF]</textcolor>
+		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
+		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
 		<colordiffuse>$VAR[OverlayColorNF]</colordiffuse>
+		<textwidth>120</textwidth>
+		<sliderwidth>230</sliderwidth>
+		<sliderheight>20</sliderheight>
+		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<alttexturenofocus></alttexturenofocus>
 		<texturesliderbar>osd/OSDSliderBack.png</texturesliderbar>
 		<texturesliderbardisabled colordiffuse="$VAR[DisabledColor]">osd/OSDSliderBack.png</texturesliderbardisabled>
 		<textureslidernib border="10,0,10,0" colordiffuse="$VAR[OverlayColorNF]">osd/OSDSliderNibNF.png</textureslidernib>
 		<textureslidernibfocus border="10,0,10,0" colordiffuse="$VAR[OverlayColorFO]">osd/OSDSliderNibFO.png</textureslidernibfocus>
 		<textureslidernibdisabled border="10,0,10,0" colordiffuse="$VAR[DisabledColor]">osd/OSDSliderNibFO.png</textureslidernibdisabled>
-		<sliderwidth>230</sliderwidth>
-		<sliderheight>20</sliderheight>
-		<font>Font33</font>
-		<textcolor>$VAR[TextColorNF]</textcolor>
-		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
-		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-		<textoffsetx>0</textoffsetx>
 		<orientation>horizontal</orientation>
-		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
 		<include>WindowDepth</include>
 	</default>
 	
@@ -159,17 +165,18 @@
 		<width>183</width>
 		<align>left</align>
 		<aligny>center</aligny>
-		<colorwidth>43</colorwidth>
-		<colorheight>43</colorheight>
-		<texturecolormask>common/white.png</texturecolormask>
-		<texturecolordisabledmask colordiffuse="$VAR[DisabledColor]">common/white.png</texturecolordisabledmask>
 		<font>Font33</font>
+		<textoffsetx>0</textoffsetx>
 		<textcolor>$VAR[TextColorNF]</textcolor>
 		<focusedcolor>$VAR[TextColorFO]</focusedcolor>
 		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
-		<textoffsetx>0</textoffsetx>
-		<pulseonselect>False</pulseonselect>
+		<colorwidth>43</colorwidth>
+		<colorheight>43</colorheight>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
+		<texturenofocus></texturenofocus>
+		<texturecolormask>common/white.png</texturecolormask>
+		<texturecolordisabledmask colordiffuse="$VAR[DisabledColor]">common/white.png</texturecolordisabledmask>
+		<pulseonselect>False</pulseonselect>
 		<include>WindowDepth</include>
 	</default>
 
@@ -214,7 +221,8 @@
 		<disabledcolor>$VAR[DisabledColor]</disabledcolor>
 		<invalidcolor>$VAR[InvalidColor]</invalidcolor>
 		<texturefocus colordiffuse="$VAR[buttonfocus]">common/focus.png</texturefocus>
-		<pulseonselect>no</pulseonselect>
+		<texturenofocus></texturenofocus>
+		<pulseonselect>False</pulseonselect>
 		<include>WindowDepth</include>
 	</default>
 

--- a/xml/DialogAddonSettings.xml
+++ b/xml/DialogAddonSettings.xml
@@ -143,7 +143,7 @@
 
 			<!-- Default spincontrolex -->
 			<control type="spincontrolex" id="9">
-				<include>DialogAddonSettings_coords8</include>
+				<include>DialogAddonSettings_coords10</include>
 				<font>Font33</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<focusedcolor>$VAR[TextColorFO]</focusedcolor>
@@ -152,7 +152,7 @@
 
 			<!-- Default seperator -->
 			<control type="image" id="11">
-				<include>DialogAddonSettings_coords10</include>
+				<include>DialogAddonSettings_coords12</include>
 				<texture border="2" colordiffuse="$VAR[OverlayColorNF]">common/Divider.png</texture>
 			</control>
 			
@@ -163,7 +163,7 @@
 
 			<!-- Default slider -->
 			<control type="sliderex" id="13">
-				<include>DialogAddonSettings_coords8</include>
+				<include>DialogAddonSettings_coords11</include>
 				<font>Font33</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
 				<focusedcolor>$VAR[TextColorFO]</focusedcolor>
@@ -181,7 +181,7 @@
 			
 			<!-- Settings description -->
 			<control type="fadelabel" id="6">
-				<include>DialogAddonSettings_coords11</include>
+				<include>DialogAddonSettings_coords13</include>
 				<font>Font27</font>
 			</control>
 

--- a/xml/Includes_DialogSettings.xml
+++ b/xml/Includes_DialogSettings.xml
@@ -53,7 +53,7 @@
 
 				<!-- Default spincontrolex -->
 				<control type="spincontrolex" id="9">
-					<include>DialogSettings_coords3</include>
+					<include>DialogSettings_coords5</include>
 				</control>
 
 				<!-- Default edit -->
@@ -63,12 +63,12 @@
 
 				<!-- Default slider -->
 				<control type="sliderex" id="13"> 
-					<include>DialogSettings_coords3</include>
+					<include>DialogSettings_coords6</include>
 				</control>
 
 				<!-- Default image -->
 				<control type="image" id="11">
-					<include>DialogSettings_coords5</include>
+					<include>DialogSettings_coords7</include>
 					<texture border="5,0,5,0" colordiffuse="$VAR[OverlayColorNF]">common/ScrollBackgroundHorizontal.png</texture>
 				</control>
 
@@ -126,7 +126,7 @@
 
 			<control type="group">
 				<include>DialogDepth</include>
-				<include>DialogSettings_coords6</include>
+				<include>DialogSettings_coords8</include>
 				<visible>!Window.IsVisible(10153) + !Window.IsVisible(DialogSelect.xml) + !Window.IsVisible(playerprocessinfo) + !Window.IsVisible(SliderDialog) + !Window.IsVisible(FileBrowser) + !Window.IsVisible(shutdownmenu) + String.IsEmpty(Window(home).Property(service.upnext.dialog))</visible>
 				
 				<!-- Animation -->
@@ -135,13 +135,13 @@
 
 				<!-- Window Background -->
 				<control type="image">
-					<include>DialogSettings_coords7</include>
+					<include>DialogSettings_coords9</include>
 					<texture colordiffuse="$VAR[MenuOSDColor]">$VAR[MenuOSDBackground]</texture>
 				</control>
 
 				<!-- Heading -->
 				<control type="label" id="2">
-					<include>DialogSettings_coords8</include>
+					<include>DialogSettings_coords10</include>
 					<align>center</align>
 					<aligny>top</aligny>
 					<font>Font33</font>
@@ -149,7 +149,7 @@
 
 				<!-- Grouplist -->
 				<control type="grouplist" id="5">
-					<include>DialogSettings_coords9</include>
+					<include>DialogSettings_coords11</include>
 					<itemgap>0</itemgap>
 					<onleft>noop</onleft>
 					<onright>noop</onright>
@@ -161,7 +161,7 @@
 
 				<!-- Default label -->
 				<control type="label" id="14">
-					<include>DialogSettings_coords10</include>
+					<include>DialogSettings_coords12</include>
 					<font>Font33</font>
 					<align>center</align>
 					<label></label>
@@ -170,38 +170,38 @@
 
 				<!-- Default button -->
 				<control type="button" id="7">
-					<include>DialogSettings_coords11</include>
+					<include>DialogSettings_coords13</include>
 				</control>
 
 				<!-- Default radiobutton -->
 				<control type="radiobutton" id="8">
-					<include>DialogSettings_coords12</include>
+					<include>DialogSettings_coords14</include>
 				</control>
 
 				<!-- Default spincontrolex -->
 				<control type="spincontrolex" id="9">
-					<include>DialogSettings_coords12</include>
+					<include>DialogSettings_coords15</include>
 				</control>
 
 				<!-- Default edit -->
 				<control type="edit" id="12">
-					<include>DialogSettings_coords11</include>
+					<include>DialogSettings_coords13</include>
 				</control>
 
 				<!-- Default slider -->
 				<control type="sliderex" id="13"> 
-					<include>DialogSettings_coords11</include>
+					<include>DialogSettings_coords16</include>
 				</control>
 
 				<!-- Default image -->
 				<control type="image" id="11">
-					<include>DialogSettings_coords13</include>
+					<include>DialogSettings_coords17</include>
 					<texture border="5,0,5,0" colordiffuse="$VAR[OverlayColorNF]">common/ScrollBackgroundHorizontal.png</texture>
 				</control>
 
 				<!-- Button grouplist -->
 				<control type="grouplist" id="9001">
-					<include>DialogSettings_coords14</include>
+					<include>DialogSettings_coords18</include>
 					<itemgap>30</itemgap>
 					<onleft>noop</onleft>
 					<onright>noop</onright>

--- a/xml/SettingsCategory.xml
+++ b/xml/SettingsCategory.xml
@@ -168,7 +168,7 @@
 
 				<!-- Default spincontrolex -->
 				<control type="spincontrolex" id="9">
-					<include>SettingsCategory_coords10</include>
+					<include>SettingsCategory_coords13</include>
 					<font>Font33</font>
 					<textcolor>$VAR[TextColorNF]</textcolor>
 					<focusedcolor>$VAR[TextColorFO]</focusedcolor>
@@ -177,7 +177,7 @@
 
 				<!-- Default sliderex -->
 				<control type="sliderex" id="13">
-					<include>SettingsCategory_coords10</include>
+					<include>SettingsCategory_coords14</include>
 					<font>Font33</font>
 					<textcolor>$VAR[TextColorNF]</textcolor>
 					<focusedcolor>$VAR[TextColorFO]</focusedcolor>


### PR DESCRIPTION
Coordinates_DialogAddonSettings.xml:
- add new coordinates includes for slider and spin controls

Coordinates_DialogSettings.xml:
- add new coordinates includes for slider and spin controls

Coordinates_SettingsCategory.xml:
- add new coordinates includes for slider and spin controls

Defaults.xml:
- fix general formatting
- adjust coordinates of slider and spin controls

DialogAddonSettings.xml:
- add new coordinates includes to slider and spin controls

Includes_DialogSettings.xml:
- add new coordinates includes to slider and spin controls

SettingsCategory.xml:
- add new coordinates includes to slider and spin controls
