### PR TITLE
Improve main menu widget sorting and item limit

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,17 @@
 
 ---
 
-**_v21.2.1_**
+**_v21.2.2_**
+
+_Improved_
+- add new item limits to main menu widgets
+
+_Fixed_
+- fix the date added sort order of main menu widgets
+
+---
+
+**_v21.2.1 - August 2025_**
 
 _Improved_
 - change masking bars to allow fully transparent colour values
@@ -552,36 +562,20 @@ Release
 
 ---
 
-**Changelog v21.2.1**
+**Changelog v21.2.2**
 
-_add back OSDMaskAutoNF file for auto masking feature_
+overrides.xml:
+- turn case sensitive sort order properties to lower case
+- add new lower widget item limit
 
-Texture.xbt:
-- update textures file with added back auto masking Icon
+script-skinshortcuts-static.xml:
+- turn case sensitive sort order properties to lower case
 
-Coordinates_DialogVideoManager.xml:
-- replace texture variable to show proper list icons
-
-Custom_Debug_Info.xml:
-- add missing dialog label for video manager dialog
-
-DialogVideoManager.xml:
-- add missing buttons and fix visibility conditions of existing ones
-
-Includes.xml:
-- adjust colour diffuse of masking bars to allow fully transparent colours
-
-SkinSettings.xml:
-- fix custom masking colour setting to adjust the correct colour
-
-Variables.xml:
-- add new VideoManagerImage variable for fixes video manager dialog list
-
-VideoFullScreen.xml:
-- adjust colour diffuse of masking bars to allow fully transparent colours
+Variables_Skinshortcuts.xml:
+- turn case sensitive sort order properties to lower case
 
 addon.xml:
-- bump version to 21.2.1
+- bump version to 21.2.2
 - update changelog
 
 Changelog.md:

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.osmc" version="21.2.1" name="OSMC Skin" provider-name="OSMC">
+<addon id="skin.osmc" version="21.2.2" name="OSMC Skin" provider-name="OSMC">
 	<requires>
 		<import addon="xbmc.gui" version="5.17.0"/>
 		<import addon="script.skinshortcuts" version="2.0.3" optional="true"/>
@@ -18,6 +18,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]Improved[/B][CR]- change masking bars to allow fully transparent colour values[CR][CR][B]Fixed[/B][CR]- fix missing OSD icon for auto masking feaure[CR]- fix custom masking colour setting[CR]- fix versions/extras management dialog</news>
+		<news>[B]Improved[/B][CR]- add new item limits to main menu widgets[CR][CR][B]Fixed[/B][CR]- fix the date added sort order of main menu widgets</news>
 	</extension>
 </addon>

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -118,7 +118,7 @@
 	
 	<widgetdefaultnode labelID="31179" group="movies.1" label="$LOCALIZE[31179]" type="movies" path="special://skin/extras/playlists/movies_recentlyadded.xsp" target="videos">library</widgetdefaultnode>
 	<propertydefault labelID="31179" group="movies.1" property="widgetArt">Art(poster)</propertydefault>
-	<propertydefault labelID="31179" group="movies.1" property="widgetSortBy">dateAdded</propertydefault>
+	<propertydefault labelID="31179" group="movies.1" property="widgetSortBy">dateadded</propertydefault>
 	<propertydefault labelID="31179" group="movies.1" property="widgetSortDirection">descending</propertydefault>
 	
 	<widgetdefaultnode labelID="31118" group="tvshows.1" label="$LOCALIZE[31118]" type="tvshows" path="special://skin/extras/playlists/tvshows_random.xsp" target="videos">library</widgetdefaultnode>
@@ -134,7 +134,7 @@
 	
 	<widgetdefaultnode labelID="31207" group="music.1" label="$LOCALIZE[31207]" type="albums" path="musicdb://recentlyaddedalbums/" target="music">music</widgetdefaultnode>
 	<propertydefault labelID="31207" group="music.1" property="layout">square-small</propertydefault>
-	<propertydefault labelID="31207" group="music.1" property="widgetSortBy">dateAdded</propertydefault>
+	<propertydefault labelID="31207" group="music.1" property="widgetSortBy">dateadded</propertydefault>
 	<propertydefault labelID="31207" group="music.1" property="widgetSortDirection">descending</propertydefault>
 	
 	<widgetdefault labelID="35049" group="15016.1">GameWidget</widgetdefault>
@@ -380,7 +380,7 @@
 	<property property="widgetSortBy" label="$LOCALIZE[554]" condition="String.IsEqual(Container(211).ListItem.Property(widgetType),songs)">tracknumber</property>
 	<property property="widgetSortBy" label="$LOCALIZE[19029]" condition="String.IsEqual(Container(211).ListItem.Property(widgetType),pvr)">channelnumber</property>
 	<property property="widgetSortBy" label="$LOCALIZE[345]" condition="String.IsEqual(Container(211).ListItem.Property(widgetType),movies) | String.IsEqual(Container(211).ListItem.Property(widgetType),tvshows) | String.IsEqual(Container(211).ListItem.Property(widgetType),musicvideos) | String.IsEqual(Container(211).ListItem.Property(widgetType),albums)">year</property>
-	<property property="widgetSortBy" label="$LOCALIZE[570]" condition="!String.IsEqual(Container(211).ListItem.Property(widgetType),pvr)">dateAdded</property>
+	<property property="widgetSortBy" label="$LOCALIZE[570]" condition="!String.IsEqual(Container(211).ListItem.Property(widgetType),pvr)">dateadded</property>
 	<property property="widgetSortBy" label="$LOCALIZE[590]">random</property>
 	<property property="widgetSortBy" label="$LOCALIZE[515]" condition="String.IsEqual(Container(211).ListItem.Property(widgetType),movies) | String.IsEqual(Container(211).ListItem.Property(widgetType),tvshows) | String.IsEqual(Container(211).ListItem.Property(widgetType),musicvideos) | String.IsEqual(Container(211).ListItem.Property(widgetType),albums) | String.IsEqual(Container(211).ListItem.Property(widgetType),songs)">genre</property>
 	<property property="widgetSortBy" label="$LOCALIZE[567]" condition="String.IsEqual(Container(211).ListItem.Property(widgetType),movies) | String.IsEqual(Container(211).ListItem.Property(widgetType),tvshows) | String.IsEqual(Container(211).ListItem.Property(widgetType),musicvideos) | String.IsEqual(Container(211).ListItem.Property(widgetType),episodes)">playcount</property>
@@ -389,18 +389,27 @@
 	<property property="widgetSortBy" label="$LOCALIZE[563]" condition="String.IsEqual(Container(211).ListItem.Property(widgetType),movies) | String.IsEqual(Container(211).ListItem.Property(widgetType),tvshows) | String.IsEqual(Container(211).ListItem.Property(widgetType),episodes)">rating</property>
 	<property property="widgetSortBy" label="$LOCALIZE[33067]" condition="String.IsEqual(Container(211).ListItem.Property(widgetTarget),video) | String.IsEqual(Container(211).ListItem.Property(widgetTarget),music)">userrating</property>
 
-    <!-- Widget Sort Direction -->
-    <propertySettings property="widgetSortDirection" title="$LOCALIZE[31176]" showNone="True" />
-    <property property="widgetSortDirection" label="$LOCALIZE[584]">ascending</property>
-    <property property="widgetSortDirection" label="$LOCALIZE[585]">descending</property>
+	<!-- Widget Sort Direction -->
+	<propertySettings property="widgetSortDirection" title="$LOCALIZE[31176]" showNone="True" />
+	<property property="widgetSortDirection" label="$LOCALIZE[584]">ascending</property>
+	<property property="widgetSortDirection" label="$LOCALIZE[585]">descending</property>
 	
 	<!-- Widget Limit -->
-    <propertySettings property="widgetLimit" title="Item limit" showNone="True" />
-    <property property="widgetLimit" label="10 ">$NUMBER[10]</property>
+	<propertySettings property="widgetLimit" title="Item limit" showNone="True" />
+	<property property="widgetLimit" label="1 ">$NUMBER[1]</property>
+	<property property="widgetLimit" label="2 ">$NUMBER[2]</property>
+	<property property="widgetLimit" label="3 ">$NUMBER[3]</property>
+	<property property="widgetLimit" label="4 ">$NUMBER[4]</property>
+	<property property="widgetLimit" label="5 ">$NUMBER[5]</property>
+	<property property="widgetLimit" label="6 ">$NUMBER[6]</property>
+	<property property="widgetLimit" label="7 ">$NUMBER[7]</property>
+	<property property="widgetLimit" label="8 ">$NUMBER[8]</property>
+	<property property="widgetLimit" label="9 ">$NUMBER[9]</property>
+	<property property="widgetLimit" label="10 ">$NUMBER[10]</property>
 	<property property="widgetLimit" label="15 ">$NUMBER[15]</property>
-    <property property="widgetLimit" label="20 ">$NUMBER[20]</property>
-    <property property="widgetLimit" label="25 ">$NUMBER[25]</property>
-    <property property="widgetLimit" label="30 ">$NUMBER[30]</property>
+	<property property="widgetLimit" label="20 ">$NUMBER[20]</property>
+	<property property="widgetLimit" label="25 ">$NUMBER[25]</property>
+	<property property="widgetLimit" label="30 ">$NUMBER[30]</property>
 	<property property="widgetLimit" label="50 ">$NUMBER[50]</property>
 	<property property="widgetLimit" label="100 ">$NUMBER[100]</property>
 

--- a/xml/Variables_Skinshortcuts.xml
+++ b/xml/Variables_Skinshortcuts.xml
@@ -86,7 +86,7 @@
 		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),tracknumber)">$LOCALIZE[554]</value>
 		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),channelnumber)">$LOCALIZE[19029]</value>
 		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),year)">$LOCALIZE[345]</value>
-		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),dateAdded)">$LOCALIZE[570]</value>
+		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),dateadded)">$LOCALIZE[570]</value>
 		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),random)">$LOCALIZE[590]</value>
 		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),genre)">$LOCALIZE[515]</value>
 		<value condition="String.IsEqual(Container(211).ListItem.Property(widgetSortBy),playcount)">$LOCALIZE[567]</value>

--- a/xml/script-skinshortcuts-static.xml
+++ b/xml/script-skinshortcuts-static.xml
@@ -729,7 +729,7 @@
 			<property name="widgetType">movies</property>
 			<property name="widgetPath">special://skin/extras/playlists/movies_recentlyadded.xsp</property>
 			<property name="widgetTarget">videos</property>
-			<property name="widgetSortBy">dateAdded</property>
+			<property name="widgetSortBy">dateadded</property>
 			<property name="widgetSortDirection">descending</property>
 			<property name="path">noop</property>
 			<property name="list">noop</property>
@@ -813,7 +813,7 @@
 			<property name="widgetType">albums</property>
 			<property name="widgetPath">musicdb://recentlyaddedalbums/</property>
 			<property name="widgetTarget">music</property>
-			<property name="widgetSortBy">dateAdded</property>
+			<property name="widgetSortBy">dateadded</property>
 			<property name="widgetSortDirection">descending</property>
 			<property name="path">noop</property>
 			<property name="list">noop</property>
@@ -2229,7 +2229,7 @@
 				</control>
 				
 			</focusedlayout>
-			<content sortby="dateAdded" sortorder="descending" target="videos" browse="never">special://skin/extras/playlists/movies_recentlyadded.xsp</content>
+			<content sortby="dateadded" sortorder="descending" target="videos" browse="never">special://skin/extras/playlists/movies_recentlyadded.xsp</content>
 		</control>
 		<control id="10201" type="list">
 			<viewtype label="$LOCALIZE[535]">list</viewtype>
@@ -3649,7 +3649,7 @@
 					</control>
 				</control>
 			</focusedlayout>
-			<content sortby="dateAdded" sortorder="descending" target="music" browse="never">musicdb://recentlyaddedalbums/</content>
+			<content sortby="dateadded" sortorder="descending" target="music" browse="never">musicdb://recentlyaddedalbums/</content>
 		</control>
 		<control id="10601" type="list">
 			<viewtype label="$LOCALIZE[535]">list</viewtype>


### PR DESCRIPTION
overrides.xml:
- turn case sensitive sort order properties to lower case
- add new lower widget item limit

script-skinshortcuts-static.xml:
- turn case sensitive sort order properties to lower case

Variables_Skinshortcuts.xml:
- turn case sensitive sort order properties to lower case

addon.xml:
- bump version to 21.2.2
- update changelog

Changelog.md:
- update changelog
