### PR TITLE
Media flags and debug overlay improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 
 _Improved_
 - add new item limits to main menu widgets
+- improve rendering of video media flags all over the skin for edge cases
+- improve debug overlay
 
 _Fixed_
 - fix the date added sort order of main menu widgets
@@ -564,12 +566,36 @@ Release
 
 **Changelog v21.2.2**
 
+strings.po:
+- adjust widget limit description text for new widget item limit options (31375)
+
 overrides.xml:
 - turn case sensitive sort order properties to lower case
 - add new lower widget item limit
 
 script-skinshortcuts-static.xml:
 - turn case sensitive sort order properties to lower case
+
+Coordinates_Custom_Debug_Info.xml:
+- add new coordinates includes for reworked debug overlay
+
+Coordinates_DialogSelect.xml:
+- adjust video version secondary label to use new Video variable
+
+Coordinates_DialogVideoManager.xml:
+- adjust video version secondary label to use new Video variable
+
+Custom_Debug_Info.xml:
+- rework debug overlay to show information more clearly
+
+DialogVideoInfo.xml:
+- use new Video variable for video related information
+
+DialogVideoInfo.xml:
+- use new Video variable for video related information
+
+Variables.xml:
+- rework VideoResolution to general Video variable for edge cases e.g. with video add-ons
 
 Variables_Skinshortcuts.xml:
 - turn case sensitive sort order properties to lower case

--- a/addon.xml
+++ b/addon.xml
@@ -18,6 +18,6 @@
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>
 		</assets>
-		<news>[B]Improved[/B][CR]- add new item limits to main menu widgets[CR][CR][B]Fixed[/B][CR]- fix the date added sort order of main menu widgets</news>
+		<news>[B]Improved[/B][CR]- add new item limits to main menu widgets[CR]- improve rendering of video media flags all over the skin for edge cases[CR]- improve debug overlay[CR][CR][B]Fixed[/B][CR]- fix the date added sort order of main menu widgets</news>
 	</extension>
 </addon>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1851,7 +1851,7 @@ msgstr ""
 
 #: /SkinSettings.xml
 msgctxt "#31375"
-msgid "Changes the maximum number of items shown by the widget. Options available: 10, 15, 20, 25, 30, 50, 100, None (all items available)"
+msgid "Changes the maximum number of items shown by the widget. Options available: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 50, 100, None (all items available)"
 msgstr ""
 
 #: /SkinSettings.xml

--- a/xml/Coordinates_Custom_Debug_Info.xml
+++ b/xml/Coordinates_Custom_Debug_Info.xml
@@ -11,25 +11,25 @@
 		<left>15</left>
 		<top>15</top>
 		<width>930</width>
-		<height>450</height>
+		<height>136</height>
 	</include>
 	<include name="Custom_Debug_Info_coords1_21:9">
 		<left>15</left>
 		<top>15</top>
 		<width>1250</width>
-		<height>450</height>
+		<height>136</height>
 	</include>
 	<include name="Custom_Debug_Info_coords1_21:9_masked">
 		<left>15</left>
 		<top>195</top>
 		<width>1250</width>
-		<height>450</height>
+		<height>136</height>
 	</include>
 	<include name="Custom_Debug_Info_coords1_4:3">
 		<left>15</left>
 		<top>15</top>
 		<width>690</width>
-		<height>450</height>
+		<height>136</height>
 	</include>
 	
 	<include name="Custom_Debug_Info_coords2">
@@ -40,19 +40,19 @@
 	</include>
 	<include name="Custom_Debug_Info_coords2_16:9">
 		<width>930</width>
-		<height>21</height>
+		<height>25</height>
 	</include>
 	<include name="Custom_Debug_Info_coords2_21:9">
 		<width>1250</width>
-		<height>21</height>
+		<height>25</height>
 	</include>
 	<include name="Custom_Debug_Info_coords2_21:9_masked">
 		<width>1250</width>
-		<height>21</height>
+		<height>25</height>
 	</include>
 	<include name="Custom_Debug_Info_coords2_4:3">
 		<width>690</width>
-		<height>21</height>
+		<height>25</height>
 	</include>
 	
 	<include name="Custom_Debug_Info_coords3">
@@ -62,24 +62,93 @@
 		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Debug_Info_coords3_4:3</include>
 	</include>
 	<include name="Custom_Debug_Info_coords3_16:9">
+		<width>180</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords3_21:9">
+		<width>180</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords3_21:9_masked">
+		<width>180</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords3_4:3">
+		<width>180</width>
+		<height>25</height>
+	</include>
+	
+	<include name="Custom_Debug_Info_coords4">
+		<include condition="$EXP[NonMaskedCoordinates]">Custom_Debug_Info_coords4_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Custom_Debug_Info_coords4_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">Custom_Debug_Info_coords4_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Debug_Info_coords4_4:3</include>
+	</include>
+	<include name="Custom_Debug_Info_coords4_16:9">
+		<width>745</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords4_21:9">
+		<width>1065</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords4_21:9_masked">
+		<width>1065</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords4_4:3">
+		<width>505</width>
+		<height>25</height>
+	</include>
+	
+	<include name="Custom_Debug_Info_coords5">
+		<include condition="$EXP[NonMaskedCoordinates]">Custom_Debug_Info_coords5_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Custom_Debug_Info_coords5_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">Custom_Debug_Info_coords5_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Debug_Info_coords5_4:3</include>
+	</include>
+	<include name="Custom_Debug_Info_coords5_16:9">
+		<width>930</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords5_21:9">
+		<width>1250</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords5_21:9_masked">
+		<width>1250</width>
+		<height>25</height>
+	</include>
+	<include name="Custom_Debug_Info_coords5_4:3">
+		<width>690</width>
+		<height>25</height>
+	</include>
+	
+	<include name="Custom_Debug_Info_coords6">
+		<include condition="$EXP[NonMaskedCoordinates]">Custom_Debug_Info_coords6_16:9</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,21:9)">Custom_Debug_Info_coords6_21:9</include>
+		<include condition="$EXP[MaskedCoordinates]">Custom_Debug_Info_coords6_21:9_masked</include>
+		<include condition="String.IsEqual(Skin.AspectRatio,4:3)">Custom_Debug_Info_coords6_4:3</include>
+	</include>
+	<include name="Custom_Debug_Info_coords6_16:9">
 		<right>15</right>
 		<top>15</top>
 		<width>930</width>
 		<height>450</height>
 	</include>
-	<include name="Custom_Debug_Info_coords3_21:9">
+	<include name="Custom_Debug_Info_coords6_21:9">
 		<right>15</right>
 		<top>15</top>
 		<width>1250</width>
 		<height>450</height>
 	</include>
-	<include name="Custom_Debug_Info_coords3_21:9_masked">
+	<include name="Custom_Debug_Info_coords6_21:9_masked">
 		<right>15</right>
 		<top>195</top>
 		<width>1250</width>
 		<height>450</height>
 	</include>
-	<include name="Custom_Debug_Info_coords3_4:3">
+	<include name="Custom_Debug_Info_coords6_4:3">
 		<right>15</right>
 		<top>15</top>
 		<width>690</width>

--- a/xml/Coordinates_DialogSelect.xml
+++ b/xml/Coordinates_DialogSelect.xml
@@ -308,7 +308,7 @@
 					<height>27</height>
 					<font>Font27-light</font>
 					<textcolor>$VAR[TextColorNF]</textcolor>
-					<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<visible>Window.IsActive(selectvideoversion)</visible>
 				</control>
 			</control>
@@ -372,7 +372,7 @@
 					<height>27</height>
 					<font>Font27-light</font>
 					<textcolor>$VAR[TextColorNF]</textcolor>
-					<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<visible>Window.IsActive(selectvideoversion)</visible>
 				</control>
 			</control>
@@ -436,7 +436,7 @@
 					<height>27</height>
 					<font>Font27-light</font>
 					<textcolor>$VAR[TextColorNF]</textcolor>
-					<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<visible>Window.IsActive(selectvideoversion)</visible>
 				</control>
 			</control>
@@ -500,7 +500,7 @@
 					<height>27</height>
 					<font>Font27-light</font>
 					<textcolor>$VAR[TextColorNF]</textcolor>
-					<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<visible>Window.IsActive(selectvideoversion)</visible>
 				</control>
 			</control>
@@ -596,7 +596,7 @@
 						<height>27</height>
 						<font>Font27-bold</font>
 						<textcolor>$VAR[TextColorFO]</textcolor>
-						<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+						<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 						<scroll>True</scroll>
 						<visible>Window.IsActive(selectvideoversion)</visible>
 					</control>
@@ -687,7 +687,7 @@
 						<height>27</height>
 						<font>Font27-bold</font>
 						<textcolor>$VAR[TextColorFO]</textcolor>
-						<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+						<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 						<scroll>True</scroll>
 						<visible>Window.IsActive(selectvideoversion)</visible>
 					</control>
@@ -778,7 +778,7 @@
 						<height>27</height>
 						<font>Font27-bold</font>
 						<textcolor>$VAR[TextColorFO]</textcolor>
-						<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+						<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 						<scroll>True</scroll>
 						<visible>Window.IsActive(selectvideoversion)</visible>
 					</control>
@@ -869,7 +869,7 @@
 						<height>27</height>
 						<font>Font27-bold</font>
 						<textcolor>$VAR[TextColorFO]</textcolor>
-						<label>$VAR[Duration,, &#8226; ]$VAR[VideoCodec]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1] &#8226; $VAR[Audio]</label>
+						<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 						<scroll>True</scroll>
 						<visible>Window.IsActive(selectvideoversion)</visible>
 					</control>

--- a/xml/Coordinates_DialogVideoManager.xml
+++ b/xml/Coordinates_DialogVideoManager.xml
@@ -136,7 +136,7 @@
 				<height>27</height>
 				<font>Font27-light</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
-				<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+				<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 			</control>
 		</itemlayout>
 	</include>
@@ -176,7 +176,7 @@
 				<height>27</height>
 				<font>Font27-light</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
-				<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+				<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 			</control>
 		</itemlayout>
 	</include>
@@ -216,7 +216,7 @@
 				<height>27</height>
 				<font>Font27-light</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
-				<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+				<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 			</control>
 		</itemlayout>
 	</include>
@@ -246,7 +246,7 @@
 				<height>27</height>
 				<font>Font27-light</font>
 				<textcolor>$VAR[TextColorNF]</textcolor>
-				<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+				<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 			</control>
 		</itemlayout>
 	</include>
@@ -295,7 +295,7 @@
 					<height>27</height>
 					<font>Font27-bold</font>
 					<textcolor>$VAR[TextColorFO]</textcolor>
-					<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<scroll>True</scroll>
 				</control>
 			</control>
@@ -339,7 +339,7 @@
 					<height>27</height>
 					<font>Font27-bold</font>
 					<textcolor>$VAR[TextColorFO]</textcolor>
-					<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<scroll>True</scroll>
 				</control>
 			</control>
@@ -383,7 +383,7 @@
 					<height>27</height>
 					<font>Font27-bold</font>
 					<textcolor>$VAR[TextColorFO]</textcolor>
-					<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<scroll>True</scroll>
 				</control>
 			</control>
@@ -427,7 +427,7 @@
 					<height>27</height>
 					<font>Font27-bold</font>
 					<textcolor>$VAR[TextColorFO]</textcolor>
-					<label>$VAR[Duration]$VAR[VideoCodec, &#8226; ,]$VAR[VideoResolution, &#8226; ,]$INFO[ListItem.VideoAspect, &#8226; ,:1]$VAR[Audio, &#8226; ,]</label>
+					<label>$VAR[Duration]$VAR[Video, &#8226; ,]$VAR[Audio, &#8226; ,]</label>
 					<scroll>True</scroll>
 				</control>
 			</control>

--- a/xml/Custom_Debug_Info.xml
+++ b/xml/Custom_Debug_Info.xml
@@ -10,924 +10,1016 @@
 		<control type="grouplist">
 			<include>Custom_Debug_Info_coords1</include>
 			<itemgap>12</itemgap>
+			
+			<control type="grouplist">
+				<include>Custom_Debug_Info_coords2</include>
+				<orientation>horizontal</orientation>
+				
+				<!-- Control label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords3</include>
+					<textcolor>FF00FF00</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<label>Current control: </label>
+					<visible>![String.IsEmpty(System.CurrentControl) + String.IsEmpty(System.CurrentControlID) + String.IsEmpty(Container.CurrentItem) + String.IsEmpty(ListItem.DBID)]</visible>
+				</control>
+				
+				<!-- Control label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords4</include>
+					<textcolor>FFFF0000</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<scroll>true</scroll>
+					<label>$INFO[System.CurrentControl]$INFO[System.CurrentControlID, (ID: ,)]$INFO[Container.CurrentItem, &#8226; Item: ,]$INFO[ListItem.DBID, &#8226; DBID: ,]</label>
+					<visible>![String.IsEmpty(System.CurrentControl) + String.IsEmpty(System.CurrentControlID) + String.IsEmpty(Container.CurrentItem) + String.IsEmpty(ListItem.DBID)]</visible>
+				</control>
+			</control>
+			
+			<control type="grouplist">
+				<include>Custom_Debug_Info_coords2</include>
+				<orientation>horizontal</orientation>
+				
+				<!-- Control label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords3</include>
+					<textcolor>FF00FF00</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<label>Folder: </label>
+					<visible>!String.IsEmpty(Container.FolderName)</visible>
+				</control>
+
+				<!-- Folder label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords4</include>
+					<textcolor>FFFF0000</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<scroll>true</scroll>
+					<label>$INFO[Container.FolderName]</label>
+					<visible>!String.IsEmpty(Container.FolderName)</visible>
+				</control>
+			
+			</control>
+			
+			<control type="grouplist">
+				<include>Custom_Debug_Info_coords2</include>
+				<orientation>horizontal</orientation>
+				
+				<!-- Control label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords3</include>
+					<textcolor>FF00FF00</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<label>Path: </label>
+					<visible>!String.IsEmpty(Container.FolderPath)</visible>
+				</control>
+			
+				<!-- Path label -->
+				<control type="fadelabel">
+					<include>Custom_Debug_Info_coords4</include>
+					<textcolor>FFFF0000</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<label>$INFO[Container.FolderPath]</label>
+					<visible>!String.IsEmpty(Container.FolderPath)</visible>
+				</control>
+			
+			</control>
+			
+			<control type="grouplist">
+				<include>Custom_Debug_Info_coords2</include>
+				<orientation>horizontal</orientation>
+				
+				<!-- Control label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords3</include>
+					<textcolor>FF00FF00</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<label>Content: </label>
+					<visible>!String.IsEmpty(Container.Content)</visible>
+				</control>
+			
+				<!-- Content label -->
+				<control type="label">
+					<include>Custom_Debug_Info_coords4</include>
+					<textcolor>FFFF0000</textcolor>
+					<shadowcolor>FF000000</shadowcolor>
+					<font>font13</font>
+					<align>left</align>
+					<scroll>true</scroll>
+					<label>$INFO[Container.Content]</label>
+					<visible>!String.IsEmpty(Container.Content)</visible>
+				</control>
+			
+			</control>
+
+		</control>
+		
+		<control type="grouplist">
+			<include>Custom_Debug_Info_coords6</include>
+			<itemgap>12</itemgap>
 
 			<!-- Window labels -->
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>$INFO[System.CurrentWindow]</label>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>AddonBrowser.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(AddonBrowser.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>EventLog.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(EventLog.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>FileManager.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(FileManager.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Home.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(Home.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>LoginScreen.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(LoginScreen.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF00FF00</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MusicVisualisation.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MusicVisualisation.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyFavourites.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyFavourites.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyGames.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyGames.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyMusicNav.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyMusicNav.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyMusicPlaylist.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyMusicPlaylist.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyMusicPlaylistEditor.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyMusicPlaylistEditor.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPics.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPics.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPlaylist.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPlaylist.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPrograms.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPrograms.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPVRChannels.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPVRChannels.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPVRGuide.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPVRGuide.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPVRRecordings.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPVRRecordings.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPVRSearch.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPVRSearch.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyPVRTimers.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyPVRTimers.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyVideoNav.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyVideoNav.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MyWeather.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(MyWeather.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Settings.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(Settings.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SettingsCategory.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(SettingsCategory.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SettingsProfile.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(SettingsProfile.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SettingsScreenCalibration.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(SettingsScreenCalibration.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SettingsSystemInfo.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(SettingsSystemInfo.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SkinSettings.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(SkinSettings.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FFE8E8FF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>VideoFullScreen.xml $INFO[Container.Viewmode,(,]$INFO[Container.SortMethod, &#8226; ,]$INFO[Container.SortOrder, &#8226; ,)]</label>
 				<visible>Window.IsVisible(VideoFullScreen.xml)</visible>
 			</control>
 
 			<!-- Dialog labels -->
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_AutoMusicVis.xml</label>
 				<visible>Window.IsVisible(1115)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Backup.xml</label>
 				<visible>Window.IsVisible(1104)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Cache_Progress.xml</label>
 				<visible>Window.IsVisible(1100)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Confirm_Reset_Skin_Settings.xml</label>
 				<visible>Window.IsVisible(1107)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Customization.xml</label>
 				<visible>Window.IsVisible(1103)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_DialogMasking.xml</label>
 				<visible>Window.IsVisible(1105)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Disabled_Add-on.xml</label>
 				<visible>Window.IsVisible(1102)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Skin_Shortcuts_Help.xml</label>
 				<visible>Window.IsVisible(1106)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Custom_Welcome.xml</label>
 				<visible>Window.IsVisible(1101)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogAddonInfo.xml</label>
 				<visible>Window.IsVisible(DialogAddonInfo.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogAddonSettings.xml</label>
 				<visible>Window.IsVisible(DialogAddonSettings.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogBusy.xml</label>
 				<visible>Window.IsVisible(DialogBusy.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogButtonMenu.xml</label>
 				<visible>Window.IsVisible(DialogButtonMenu.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogColorPicker.xml</label>
 				<visible>Window.IsVisible(DialogColorPicker.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogConfirm.xml</label>
 				<visible>Window.IsVisible(DialogConfirm.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogContextMenu.xml</label>
 				<visible>Window.IsVisible(DialogContextMenu.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogExtendedProgressBar.xml</label>
 				<visible>Window.IsVisible(DialogExtendedProgressBar.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogFavourites.xml</label>
 				<visible>Window.IsVisible(DialogFavourites.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogFullScreenInfo.xml</label>
 				<visible>Window.IsVisible(DialogFullScreenInfo.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogGameControllers.xml</label>
 				<visible>Window.IsVisible(DialogGameControllers.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogKeyboard.xml</label>
 				<visible>Window.IsVisible(DialogKeyboard.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogMediaSource.xml</label>
 				<visible>Window.IsVisible(DialogMediaSource.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogMusicInfo.xml</label>
 				<visible>Window.IsVisible(DialogMusicInfo.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogNotification.xml</label>
 				<visible>Window.IsVisible(DialogNotification.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogNumeric.xml</label>
 				<visible>Window.IsVisible(DialogNumeric.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPictureInfo.xml</label>
 				<visible>Window.IsVisible(DialogPictureInfo.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPlayerProcessInfo.xml</label>
 				<visible>Window.IsVisible(DialogPlayerProcessInfo.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRChannelGuide.xml</label>
 				<visible>Window.IsVisible(DialogPVRChannelGuide.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRChannelManager.xml</label>
 				<visible>Window.IsVisible(DialogPVRChannelManager.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRChannelsOSD.xml</label>
 				<visible>Window.IsVisible(DialogPVRChannelsOSD.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRGroupManager.xml</label>
 				<visible>Window.IsVisible(DialogPVRGroupManager.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRGuideControls.xml</label>
 				<visible>Window.IsVisible(DialogPVRGuideControls.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRGuideSearch.xml</label>
 				<visible>Window.IsVisible(DialogPVRGuideSearch.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogPVRInfo.xml</label>
 				<visible>Window.IsVisible(DialogPVRInfo.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogSeekbar.xml</label>
 				<visible>Window.IsVisible(DialogSeekbar.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogSelect.xml</label>
 				<visible>Window.IsVisible(DialogSelect.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogSettings.xml</label>
 				<visible>Window.IsVisible(DialogSettings.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogSlider.xml</label>
 				<visible>Window.IsVisible(DialogSlider.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogSubtitles.xml</label>
 				<visible>Window.IsVisible(DialogSubtitles.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogTextViewer.xml</label>
 				<visible>Window.IsVisible(DialogTextViewer.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogVideoInfo.xml</label>
 				<visible>Window.IsVisible(DialogVideoInfo.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogVideoManager.xml</label>
 				<visible>Window.IsVisible(DialogVideoManager.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>DialogVolumeBar.xml</label>
 				<visible>Window.IsVisible(DialogVolumeBar.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>FileBrowser.xml</label>
 				<visible>Window.IsVisible(FileBrowser.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>GameOSD.xml</label>
 				<visible>Window.IsVisible(GameOSD.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>MusicOSD.xml</label>
 				<visible>Window.IsVisible(MusicOSD.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>PlayerControls.xml</label>
 				<visible>Window.IsVisible(PlayerControls.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>Pointer.xml</label>
 				<visible>Window.IsVisible(Pointer.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>script-skinshortcuts.xml</label>
 				<visible>String.IsEqual(Window(10000).Property(scriptdialog),script-skinshortcuts.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>script-upnext-stillwatching.xml</label>
 				<visible>String.IsEqual(Window(10000).Property(scriptdialog),script-upnext-stillwatching.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>script-upnext-stillwatching-simple.xml</label>
 				<visible>String.IsEqual(Window(10000).Property(scriptdialog),script-upnext-stillwatching-simple.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>script-upnext-upnext.xml</label>
 				<visible>String.IsEqual(Window(10000).Property(scriptdialog),script-upnext-upnext.xml)</visible>
 			</control>
 			
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>script-upnext-upnext-simple.xml</label>
 				<visible>String.IsEqual(Window(10000).Property(scriptdialog),script-upnext-upnext-simple.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SlideShow.xml</label>
 				<visible>Window.IsVisible(SlideShow.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SmartPlaylistEditor.xml</label>
 				<visible>Window.IsVisible(SmartPlaylistEditor.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>SmartPlaylistRule.xml</label>
 				<visible>Window.IsVisible(SmartPlaylistRule.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>VideoOSD.xml</label>
 				<visible>Window.IsVisible(VideoOSD.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>VideoOSDBookmarks.xml</label>
 				<visible>Window.IsVisible(VideoOSDBookmarks.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>VideoOSDSettings.xml</label>
 				<visible>Window.IsVisible(VideoOSDSettings.xml)</visible>
 			</control>
 
 			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
+				<include>Custom_Debug_Info_coords5</include>
+				<textcolor>FF8F8FFF</textcolor>
 				<shadowcolor>FF000000</shadowcolor>
 				<font>font13</font>
-				<align>left</align>
+				<align>right</align>
 				<label>VisualisationPresetList.xml</label>
 				<visible>Window.IsVisible(VisualisationPresetList.xml)</visible>
-			</control>
-
-		</control>
-		
-		<control type="grouplist">
-			<include>Custom_Debug_Info_coords3</include>
-			<itemgap>12</itemgap>
-
-			<!-- Control label -->
-			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FF0000FF</textcolor>
-				<shadowcolor>FF000000</shadowcolor>
-				<font>font13</font>
-				<align>right</align>
-				<label>$INFO[System.CurrentControl]$INFO[System.CurrentControlID, (,)]$INFO[Container.Content, ,]$INFO[Container.CurrentItem, (,)]$INFO[ListItem.DBID, DBID: ,]</label>
-				<visible>![String.IsEmpty(System.CurrentControl) + String.IsEmpty(System.CurrentControlID) + String.IsEmpty(Container.Content) + String.IsEmpty(Container.CurrentItem) + String.IsEmpty(ListItem.DBID)]</visible>
-			</control>
-
-			<!-- Folder & Path label -->
-			<control type="fadelabel">
-				<include>Custom_Debug_Info_coords2</include>
-				<textcolor>FFFF0000</textcolor>
-				<shadowcolor>FF000000</shadowcolor>
-				<font>font13</font>
-				<align>right</align>
-				<label>[COLOR=FF00FF00]$INFO[Container.FolderName,, &#8226; ][/COLOR]$INFO[Container.FolderPath]</label>
-				<visible>!String.IsEmpty(Container.FolderName)</visible>
 			</control>
 			
 		</control>

--- a/xml/DialogVideoInfo.xml
+++ b/xml/DialogVideoInfo.xml
@@ -414,7 +414,7 @@
 						<control type="fadelabel">
 							<include>DialogVideoInfo_coords7</include>
 							<font>Font36</font>
-							<label>$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]$INFO[ListItem.VideoWidth]$INFO[ListItem.VideoHeight,x,]$INFO[ListItem.VideoAspect, &#8226; ,:1]</label>
+							<label>$VAR[Video]</label>
 							<textcolor>$VAR[TextColorFO]</textcolor>
 						</control>
 					</control>
@@ -581,7 +581,7 @@
 						<control type="fadelabel">
 							<include>DialogVideoInfo_coords7</include>
 							<font>Font36</font>
-							<label>$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]$INFO[ListItem.VideoWidth]$INFO[ListItem.VideoHeight,x,]$INFO[ListItem.VideoAspect, &#8226; ,:1]</label>
+							<label>$VAR[Video]</label>
 							<textcolor>$VAR[TextColorFO]</textcolor>
 						</control>
 					</control>

--- a/xml/Includes_MediaFlags.xml
+++ b/xml/Includes_MediaFlags.xml
@@ -61,7 +61,7 @@
 					</control>
 					<control type="fadelabel" id="9990">
 						<include>MediaFlags_coords5</include>
-						<label>$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]$INFO[ListItem.VideoWidth]$INFO[ListItem.VideoHeight,x,]$INFO[ListItem.VideoAspect, &#8226; ,:1]</label>
+						<label>$VAR[Video]</label>
 						<font>Font30</font>
 						<textcolor>$VAR[TextColorNF]</textcolor>
 					</control>

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -857,15 +857,16 @@
 		<value condition="!String.IsEmpty(ListItem.Property(SubtitleLanguage.5))">$INFO[ListItem.Property(SubtitleLanguage.1),[CAPITALIZE],[/CAPITALIZE]]$INFO[ListItem.Property(SubtitleLanguage.2),$COMMA [CAPITALIZE],[/CAPITALIZE]]$INFO[ListItem.Property(SubtitleLanguage.3),$COMMA [CAPITALIZE],[/CAPITALIZE]]$INFO[ListItem.Property(SubtitleLanguage.4),$COMMA [CAPITALIZE],[/CAPITALIZE] ...]</value>
 	</variable>
 	
-	<!-- Video Resolution labels -->
-	<variable name="VideoResolution">
-		<value condition="![String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)]">$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]$INFO[ListItem.VideoWidth]x$INFO[ListItem.VideoHeight]</value>
+	<!-- Video info label -->
+	<variable name="Video">
+		<value condition="![String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)]">$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]$INFO[ListItem.VideoWidth]$INFO[ListItem.VideoHeight,x,]$INFO[ListItem.VideoAspect, &#8226; ,:1]</value>
 		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,480) | String.IsEqual(ListItem.VideoResolution,576) | String.IsEqual(ListItem.VideoResolution,540)">$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]SD</value>
-		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,720)">$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]HD</value>
-		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,1080)">$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]Full HD</value>
-		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,4K)">$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]4K UHD</value>
-		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,8K)">$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]8K UHD</value>
-		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEmpty(ListItem.VideoResolution)">$VAR[HDRType,, &#8226; ]$VAR[3DMode]</value>
+		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,720)">$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]HD</value>
+		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,1080)">$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]Full HD</value>
+		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,4K)">$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]4K UHD</value>
+		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEqual(ListItem.VideoResolution,8K)">$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode,, &#8226; ]8K UHD</value>
+		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEmpty(ListItem.VideoResolution) + !String.IsEmpty(ListItem.HdrType)">$VAR[VideoCodec,, &#8226; ]$VAR[HDRType,, &#8226; ]$VAR[3DMode]</value>
+		<value condition="[String.IsEmpty(ListItem.VideoWidth) | String.IsEmpty(ListItem.VideoHeight)] + String.IsEmpty(ListItem.VideoResolution) + String.IsEmpty(ListItem.HdrType) + !String.IsEmpty(ListItem.VideoCodec)">$VAR[VideoCodec]$VAR[3DMode, &#8226; ,]</value>
 	</variable>
 	
 	<!-- Video Codec labels -->
@@ -884,6 +885,12 @@
 		<value condition="String.IsEqual(ListItem.VideoCodec,xvid)">XviD</value>
 		<value>$INFO[ListItem.VideoCodec,[UPPERCASE],[/UPPERCASE]]</value>
 	</variable>
+	
+	<!-- HDR type labels -->
+	<variable name="HDRType">
+		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">DV</value>
+		<value condition="!String.IsEmpty(ListItem.HdrType)">$INFO[ListItem.HdrType,[UPPERCASE],[/UPPERCASE]]</value>
+	</variable>
 
 	<!-- 3D Video label -->
 	<variable name="3DMode">
@@ -892,12 +899,6 @@
 		<value condition="String.Contains(ListItem.FileName,_ou-) | String.Contains(ListItem.FileName,_ou.) | String.Contains(ListItem.FileName,_ou_) | String.Contains(ListItem.FileName,_tab-) | String.Contains(ListItem.FileName,_tab.) | String.Contains(ListItem.FileName,_tab_) | String.Contains(ListItem.FileName,-ou-) | String.Contains(ListItem.FileName,-ou.) | String.Contains(ListItem.FileName,-ou_) | String.Contains(ListItem.FileName,-tab-) | String.Contains(ListItem.FileName,-tab.) | String.Contains(ListItem.FileName,-tab_) | String.Contains(ListItem.FileName,.ou-) | String.Contains(ListItem.FileName,.ou.) | String.Contains(ListItem.FileName,.ou_) | String.Contains(ListItem.FileName,.tab-) | String.Contains(ListItem.FileName,.tab.) | String.Contains(ListItem.FileName,.tab_)">3D (TAB)</value>
 		<value condition="String.Contains(ListItem.FileName,_sbs-) | String.Contains(ListItem.FileName,_sbs.) | String.Contains(ListItem.FileName,_sbs_) | String.Contains(ListItem.FileName,-sbs-) | String.Contains(ListItem.FileName,-sbs.) | String.Contains(ListItem.FileName,-sbs_) | String.Contains(ListItem.FileName,.sbs-) | String.Contains(ListItem.FileName,.sbs.) | String.Contains(ListItem.FileName,.sbs_)">3D (SBS)</value>
 		<value condition="ListItem.IsStereoscopic | String.Contains(ListItem.FileName,.3d-) | String.Contains(ListItem.FileName,.3d.) | String.Contains(ListItem.FileName,.3d_) | String.Contains(ListItem.FileName,-3d-) | String.Contains(ListItem.FileName,-3d.) | String.Contains(ListItem.FileName,-3d_) | String.Contains(ListItem.FileName,_3d-) | String.Contains(ListItem.FileName,_3d.) | String.Contains(ListItem.FileName,_3d_)">3D</value>
-	</variable>
-	
-	<!-- HDR type labels -->
-	<variable name="HDRType">
-		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">DV</value>
-		<value condition="!String.IsEmpty(ListItem.HdrType)">$INFO[ListItem.HdrType,[UPPERCASE],[/UPPERCASE]]</value>
 	</variable>
 	
 	<!-- Season/Episode label -->


### PR DESCRIPTION
strings.po:
- adjust widget limit description text for new widget item limit options (31375)

Coordinates_Custom_Debug_Info.xml:
- add new coordinates includes for reworked debug overlay

Coordinates_DialogSelect.xml:
- adjust video version secondary label to use new Video variable

Coordinates_DialogVideoManager.xml:
- adjust video version secondary label to use new Video variable

Custom_Debug_Info.xml:
- rework debug overlay to show information more clearly

DialogVideoInfo.xml:
- use new Video variable for video related information

DialogVideoInfo.xml:
- use new Video variable for video related information

Variables.xml:
- rework VideoResolution to general Video variable for edge cases e.g. with video add-ons

addon.xml:
- update changelog

Changelog.md:
- update changelog
