### PR TITLE
Fix DV profiles implementation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -599,6 +599,7 @@ DialogVideoInfo.xml:
 
 Variables.xml:
 - rework VideoResolution to general Video variable for edge cases e.g. with video add-ons
+- use new DV profile info label in HDRType variable
 
 Variables_Skinshortcuts.xml:
 - turn case sensitive sort order properties to lower case

--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -888,7 +888,8 @@
 	
 	<!-- HDR type labels -->
 	<variable name="HDRType">
-		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">DV$INFO[ListItem.DVProfile, (P,)]</value>
+		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision) + !String.IsEmpty(ListItem.DVProfile)">DV$INFO[ListItem.DVProfile, (P,)]</value>
+		<value condition="String.IsEqual(ListItem.HdrType,dolbyvision) + String.IsEmpty(ListItem.DVProfile)">DV</value>
 		<value condition="!String.IsEmpty(ListItem.HdrType)">$INFO[ListItem.HdrType,[UPPERCASE],[/UPPERCASE]]</value>
 	</variable>
 


### PR DESCRIPTION
Variables.xml:
- rework use of new DV profile info label in HDRType variable to only show P prefix, if the info label is populated

Changelog.md:
- update changelog
